### PR TITLE
fix: preserve whitespace after sentence boundaries for TTS

### DIFF
--- a/api/assistant-api/internal/aggregator/text/internal/default/default_llm_text_aggregator.go
+++ b/api/assistant-api/internal/aggregator/text/internal/default/default_llm_text_aggregator.go
@@ -112,14 +112,16 @@ func NewDefaultLLMTextAggregator(_ context.Context, logger commons.Logger, onPac
 }
 
 // compileBoundaryRegex builds a regex that matches any sentence boundary
-// character followed by optional whitespace.
+// character. Whitespace after the boundary is intentionally NOT consumed
+// so that it is preserved as a leading space in the next emitted chunk,
+// preventing TTS engines from merging words across sentence boundaries.
 func compileBoundaryRegex() (*regexp.Regexp, error) {
 	parts := make([]string, len(sentenceBoundaries))
 	for i, b := range sentenceBoundaries {
 		parts[i] = regexp.QuoteMeta(b)
 	}
 
-	pattern := fmt.Sprintf(`(%s)\s*`, strings.Join(parts, "|"))
+	pattern := fmt.Sprintf(`(%s)`, strings.Join(parts, "|"))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile sentence boundary regex: %w", err)

--- a/api/assistant-api/internal/aggregator/text/internal/default/default_sentence_aggregator_test.go
+++ b/api/assistant-api/internal/aggregator/text/internal/default/default_sentence_aggregator_test.go
@@ -405,12 +405,19 @@ func TestWhitespaceHandling(t *testing.T) {
 	aggregator.Aggregate(ctx, internal_type.LLMResponseDeltaPacket{ContextID: "speaker1", Text: "World."})
 
 	results := collect()
-	if len(results) < 1 {
-		t.Fatalf("expected at least 1 result, got %d", len(results))
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
 	}
 
-	if ts, ok := results[0].(internal_type.SpeakTextPacket); ok && ts.Text != "Hello.   \n  " {
-		t.Errorf("expected 'Hello.', got %q", ts.Text)
+	// Whitespace after the boundary stays in the buffer, not consumed by the regex.
+	// First chunk: just the sentence up to and including the boundary punctuation.
+	if ts, ok := results[0].(internal_type.SpeakTextPacket); ok && ts.Text != "Hello." {
+		t.Errorf("expected %q, got %q", "Hello.", ts.Text)
+	}
+
+	// Second chunk: the preserved whitespace followed by the next sentence.
+	if ts, ok := results[1].(internal_type.SpeakTextPacket); ok && ts.Text != "   \n  World." {
+		t.Errorf("expected %q, got %q", "   \n  World.", ts.Text)
 	}
 }
 


### PR DESCRIPTION
Stop consuming whitespace in the boundary regex so it remains as a leading space in the next chunk, preventing TTS engines from merging words across sentence boundaries.
