### PR TITLE
feat: add MiniMax as LLM provider for text generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Rapida is written in **Go**, using the highly optimized [gRPC](https://github.co
 - **Real-time Voice Orchestration**  
   Stream and process audio with low latency using GRPC.
 
-- **LLM-Agnostic Architecture**  
-  Bring your own model—OpenAI, Anthropic, open-source models, or custom inference.
+- **LLM-Agnostic Architecture**
+  Bring your own model—OpenAI, Anthropic, MiniMax, open-source models, or custom inference.
 
 - **Production-grade Reliability**  
   Built-in retries, error handling, call lifecycle management, and health checks.
@@ -151,7 +151,7 @@ Edit environment files before starting:
 - `docker/integration-api/.integration.env` - Integration API (port 9004)
 - `docker/document-api/config.yaml` - Document API (port 9010)
 
-Add your API keys (OpenAI, Anthropic, Deepgram, Twilio, etc.) in these files.
+Add your API keys (OpenAI, Anthropic, MiniMax, Deepgram, Twilio, etc.) in these files.
 
 ---
 

--- a/api/integration-api/internal/caller/caller.go
+++ b/api/integration-api/internal/caller/caller.go
@@ -11,6 +11,7 @@ import (
 	internal_cohere_callers "github.com/rapidaai/api/integration-api/internal/caller/cohere"
 	internal_gemini_callers "github.com/rapidaai/api/integration-api/internal/caller/gemini"
 	internal_huggingface_callers "github.com/rapidaai/api/integration-api/internal/caller/huggingface"
+	internal_minimax_callers "github.com/rapidaai/api/integration-api/internal/caller/minimax"
 	internal_mistral_callers "github.com/rapidaai/api/integration-api/internal/caller/mistral"
 	internal_openai_callers "github.com/rapidaai/api/integration-api/internal/caller/openai"
 	internal_replicate_callers "github.com/rapidaai/api/integration-api/internal/caller/replicate"
@@ -31,6 +32,7 @@ const (
 	AZURE       IntegrationProvider = "azure-foundry"
 	COHERE      IntegrationProvider = "cohere"
 	MISTRAL     IntegrationProvider = "mistral"
+	MINIMAX     IntegrationProvider = "minimax"
 	REPLICATE   IntegrationProvider = "replicate"
 	HUGGINGFACE IntegrationProvider = "huggingface"
 	VOYAGEAI    IntegrationProvider = "voyageai"
@@ -52,6 +54,8 @@ func GetLargeLanguageCaller(logger commons.Logger, provider string, credential *
 		return internal_cohere_callers.NewLargeLanguageCaller(logger, credential), nil
 	case MISTRAL:
 		return internal_mistral_callers.NewLargeLanguageCaller(logger, credential), nil
+	case MINIMAX:
+		return internal_minimax_callers.NewLargeLanguageCaller(logger, credential), nil
 	case REPLICATE:
 		return internal_replicate_callers.NewLargeLanguageCaller(logger, credential), nil
 	case HUGGINGFACE:
@@ -111,6 +115,8 @@ func GetVerifier(logger commons.Logger, provider string, credential *protos.Cred
 		return internal_cohere_callers.NewVerifyCredentialCaller(logger, credential), nil
 	case MISTRAL:
 		return internal_mistral_callers.NewVerifyCredentialCaller(logger, credential), nil
+	case MINIMAX:
+		return internal_minimax_callers.NewVerifyCredentialCaller(logger, credential), nil
 	case REPLICATE:
 		return internal_replicate_callers.NewVerifyCredentialCaller(logger, credential), nil
 	case HUGGINGFACE:

--- a/api/integration-api/internal/caller/minimax/integration_test.go
+++ b/api/integration-api/internal/caller/minimax/integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+// Rapida -- Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+
+package internal_minimax_callers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	testutil "github.com/rapidaai/api/integration-api/internal/caller/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const providerName = "minimax"
+
+// TestIntegration_ChatCompletion verifies non-streaming chat completion: send a
+// simple prompt and assert the assistant responds with content and metrics.
+func TestIntegration_ChatCompletion(t *testing.T) {
+	cfg := testutil.LoadConfig(t)
+	pcfg := cfg.ChatProvider(t, providerName)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cred := testutil.BuildCredential(pcfg.Credential)
+	caller := NewLargeLanguageCaller(testutil.NewTestLogger(), cred)
+	opts := testutil.BuildChatOptions(pcfg)
+
+	msg, metrics, err := caller.GetChatCompletion(ctx, testutil.SimpleMessages(), opts)
+	require.NoError(t, err, "GetChatCompletion should succeed")
+	require.NotNil(t, msg, "response message should not be nil")
+
+	contents := msg.GetAssistant().GetContents()
+	assert.NotEmpty(t, contents, "assistant should return content")
+	assert.NotEmpty(t, metrics, "metrics should be returned")
+	testutil.AssertHasMetric(t, metrics, "TIME_TAKEN")
+	t.Logf("provider=%s response=%q", providerName, contents)
+}
+
+// TestIntegration_StreamChatCompletion verifies streaming chat completion: send a
+// simple prompt and assert tokens are streamed, metrics are returned.
+func TestIntegration_StreamChatCompletion(t *testing.T) {
+	cfg := testutil.LoadConfig(t)
+	pcfg := cfg.ChatProvider(t, providerName)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cred := testutil.BuildCredential(pcfg.Credential)
+	caller := NewLargeLanguageCaller(testutil.NewTestLogger(), cred)
+	opts := testutil.BuildChatOptions(pcfg)
+
+	collector := &testutil.StreamCollector{}
+	err := caller.StreamChatCompletion(ctx, testutil.SimpleMessages(), opts,
+		collector.OnStream, collector.OnMetrics, collector.OnError)
+	require.NoError(t, err, "StreamChatCompletion should succeed")
+	collector.AssertStream(t)
+	t.Logf("provider=%s stream_count=%d", providerName, collector.StreamCount)
+}
+
+// TestIntegration_VerifyCredential verifies that valid credentials pass
+// the provider's credential verification endpoint without error.
+func TestIntegration_VerifyCredential(t *testing.T) {
+	cfg := testutil.LoadConfig(t)
+	pcfg := cfg.VerifyProvider(t, providerName)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cred := testutil.BuildCredential(pcfg.Credential)
+	verifier := NewVerifyCredentialCaller(testutil.NewTestLogger(), cred)
+	_, err := verifier.CredentialVerifier(ctx, testutil.BuildVerifyOptions(pcfg))
+	require.NoError(t, err, "CredentialVerifier should succeed with valid credentials")
+	t.Logf("provider=%s credential_verification=ok", providerName)
+}

--- a/api/integration-api/internal/caller/minimax/llm.go
+++ b/api/integration-api/internal/caller/minimax/llm.go
@@ -1,0 +1,453 @@
+// Rapida -- Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_minimax_callers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	internal_caller_metrics "github.com/rapidaai/api/integration-api/internal/caller/metrics"
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/utils"
+	protos "github.com/rapidaai/protos"
+)
+
+type largeLanguageCaller struct {
+	MiniMax
+}
+
+func NewLargeLanguageCaller(logger commons.Logger, credential *protos.Credential) internal_callers.LargeLanguageCaller {
+	return &largeLanguageCaller{
+		MiniMax: minimax(logger, credential),
+	}
+}
+
+// clampTemperature ensures the temperature is within MiniMax's valid range (0, 1].
+// MiniMax does not accept temperature=0; the minimum is just above 0.
+func clampTemperature(temp float64) float64 {
+	if temp <= 0 {
+		return 0.01
+	}
+	if temp > 1 {
+		return 1.0
+	}
+	return temp
+}
+
+func (llc *largeLanguageCaller) buildRequestBody(
+	allMessages []*protos.Message,
+	options *internal_callers.ChatCompletionOptions,
+) map[string]interface{} {
+	requestBody := map[string]interface{}{}
+
+	for key, value := range options.ModelParameter {
+		switch key {
+		case "model.name":
+			if modelName, err := utils.AnyToString(value); err == nil {
+				requestBody["model"] = modelName
+			}
+		case "model.temperature":
+			if temp, err := utils.AnyToFloat64(value); err == nil {
+				requestBody["temperature"] = clampTemperature(temp)
+			}
+		case "model.top_p":
+			if topP, err := utils.AnyToFloat64(value); err == nil {
+				requestBody["top_p"] = topP
+			}
+		case "model.max_completion_tokens":
+			if maxTokens, err := utils.AnyToInt64(value); err == nil {
+				requestBody["max_tokens"] = maxTokens
+			}
+		case "model.stop":
+			if stopStr, err := utils.AnyToString(value); err == nil {
+				stops := []string{}
+				for _, s := range strings.Split(stopStr, ",") {
+					if trimmed := strings.TrimSpace(s); trimmed != "" {
+						stops = append(stops, trimmed)
+					}
+				}
+				if len(stops) > 0 {
+					requestBody["stop"] = stops
+				}
+			}
+		case "model.tool_choice":
+			if choice, err := utils.AnyToString(value); err == nil {
+				requestBody["tool_choice"] = choice
+			}
+		}
+	}
+
+	// Build tool definitions
+	if len(options.ToolDefinitions) > 0 {
+		tools := make([]map[string]interface{}, 0, len(options.ToolDefinitions))
+		for _, tl := range options.ToolDefinitions {
+			if tl.Type != "function" && tl.Type != "tool" {
+				continue
+			}
+			if tl.Function == nil {
+				continue
+			}
+			fn := tl.Function
+			funcDef := map[string]interface{}{
+				"name": fn.Name,
+			}
+			if fn.Description != "" {
+				funcDef["description"] = fn.Description
+			}
+			if fn.Parameters != nil {
+				funcDef["parameters"] = fn.Parameters.ToMap()
+			} else {
+				funcDef["parameters"] = map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				}
+			}
+			tools = append(tools, map[string]interface{}{
+				"type":     "function",
+				"function": funcDef,
+			})
+		}
+		if len(tools) > 0 {
+			requestBody["tools"] = tools
+		}
+	}
+
+	// Build messages
+	requestBody["messages"] = buildMessages(allMessages)
+
+	return requestBody
+}
+
+func (llc *largeLanguageCaller) GetChatCompletion(
+	ctx context.Context,
+	allMessages []*protos.Message,
+	options *internal_callers.ChatCompletionOptions,
+) (*protos.Message, []*protos.Metric, error) {
+	llc.logger.Debugf("getting chat completion from minimax")
+	metrics := internal_caller_metrics.NewMetricBuilder(options.RequestId)
+	metrics.OnStart()
+
+	requestBody := llc.buildRequestBody(allMessages, options)
+	options.PreHook(requestBody)
+
+	res, err := llc.CallJSON(ctx, "chat/completions", "POST", map[string]string{}, requestBody)
+	if err != nil {
+		llc.logger.Errorf("getting error for minimax chat completion %v", err)
+		options.PostHook(map[string]interface{}{
+			"result": res,
+			"error":  err,
+		}, metrics.OnFailure().Build())
+		return nil, metrics.Build(), err
+	}
+	metrics.OnSuccess()
+
+	var resp MiniMaxMessageResponse
+	if err := json.Unmarshal([]byte(*res), &resp); err != nil {
+		llc.logger.Errorf("error while parsing minimax chat completion response %v", err)
+		options.PostHook(map[string]interface{}{
+			"result": res,
+			"error":  err,
+		}, metrics.Build())
+		return nil, metrics.Build(), err
+	}
+
+	metrics.OnAddMetrics(llc.UsageMetrics(resp.Usage)...)
+
+	assistantMsg := &protos.AssistantMessage{
+		Contents:  make([]string, 0),
+		ToolCalls: make([]*protos.ToolCall, 0),
+	}
+
+	for _, choice := range resp.Choices {
+		switch choice.FinishReason {
+		case "stop":
+			content := stripThinkingTags(choice.Message.Content)
+			assistantMsg.Contents = append(assistantMsg.Contents, content)
+		case "tool_calls":
+			for _, tc := range choice.Message.ToolCalls {
+				if tc.Type == "function" {
+					assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, &protos.ToolCall{
+						Id:   tc.ID,
+						Type: tc.Type,
+						Function: &protos.FunctionCall{
+							Name:      tc.Function.Name,
+							Arguments: tc.Function.Arguments,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	message := &protos.Message{
+		Role: "assistant",
+		Message: &protos.Message_Assistant{
+			Assistant: assistantMsg,
+		},
+	}
+	options.PostHook(map[string]interface{}{
+		"result": res,
+	}, metrics.Build())
+	return message, metrics.Build(), nil
+}
+
+func (llc *largeLanguageCaller) StreamChatCompletion(
+	ctx context.Context,
+	allMessages []*protos.Message,
+	options *internal_callers.ChatCompletionOptions,
+	onStream func(string, *protos.Message) error,
+	onMetrics func(string, *protos.Message, []*protos.Metric) error,
+	onError func(string, error),
+) error {
+	start := time.Now()
+	metrics := internal_caller_metrics.NewMetricBuilder(options.RequestId)
+	metrics.OnStart()
+	var firstTokenTime *time.Time
+
+	requestBody := llc.buildRequestBody(allMessages, options)
+	requestBody["stream"] = true
+	options.PreHook(requestBody)
+
+	resp, err := llc.Call(ctx, "chat/completions", "POST", map[string]string{}, requestBody)
+	if err != nil {
+		llc.logger.Errorf("minimax stream chat completion request failed: %v", err)
+		onError(options.Request.GetRequestId(), err)
+		options.PostHook(map[string]interface{}{
+			"error": err,
+		}, metrics.OnFailure().Build())
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errMsg := fmt.Errorf("minimax stream returned status %d", resp.StatusCode)
+		onError(options.Request.GetRequestId(), errMsg)
+		options.PostHook(map[string]interface{}{
+			"error": errMsg,
+		}, metrics.OnFailure().Build())
+		return errMsg
+	}
+
+	assistantMsg := &protos.AssistantMessage{
+		Contents:  make([]string, 0),
+		ToolCalls: make([]*protos.ToolCall, 0),
+	}
+	contentBuffer := make([]string, 0)
+	hasToolCalls := false
+
+	// Track tool call accumulation by index
+	toolCallMap := map[int]*protos.ToolCall{}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk MiniMaxStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			llc.logger.Warnf("failed to parse minimax stream chunk: %v", err)
+			continue
+		}
+
+		// Capture final usage from the last chunk
+		if chunk.Usage != nil {
+			metrics.OnAddMetrics(llc.UsageMetrics(chunk.Usage)...)
+		}
+
+		for i, choice := range chunk.Choices {
+			// Accumulate tool calls
+			for _, tc := range choice.Delta.ToolCalls {
+				hasToolCalls = true
+				existing, ok := toolCallMap[tc.Index]
+				if !ok {
+					existing = &protos.ToolCall{
+						Id:   tc.ID,
+						Type: tc.Type,
+						Function: &protos.FunctionCall{
+							Name:      tc.Function.Name,
+							Arguments: tc.Function.Arguments,
+						},
+					}
+					toolCallMap[tc.Index] = existing
+				} else {
+					if tc.ID != "" {
+						existing.Id = tc.ID
+					}
+					if tc.Function.Name != "" {
+						existing.Function.Name += tc.Function.Name
+					}
+					existing.Function.Arguments += tc.Function.Arguments
+				}
+			}
+
+			content := choice.Delta.Content
+			if content != "" {
+				if len(contentBuffer) <= i {
+					contentBuffer = append(contentBuffer, content)
+				} else {
+					contentBuffer[i] += content
+				}
+
+				if !hasToolCalls {
+					if firstTokenTime == nil {
+						now := time.Now()
+						firstTokenTime = &now
+					}
+					tokenMsg := &protos.Message{
+						Role: "assistant",
+						Message: &protos.Message_Assistant{
+							Assistant: &protos.AssistantMessage{
+								Contents: []string{content},
+							},
+						},
+					}
+					if err := onStream(options.Request.GetRequestId(), tokenMsg); err != nil {
+						llc.logger.Warnf("error streaming token: %v", err)
+					}
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		llc.logger.Errorf("error reading minimax stream: %v", err)
+		onError(options.Request.GetRequestId(), err)
+		options.PostHook(map[string]interface{}{
+			"error": err,
+		}, metrics.OnFailure().Build())
+		return err
+	}
+
+	// Strip thinking tags from accumulated content
+	for i, c := range contentBuffer {
+		contentBuffer[i] = stripThinkingTags(c)
+	}
+	assistantMsg.Contents = contentBuffer
+
+	// Collect accumulated tool calls
+	for _, tc := range toolCallMap {
+		assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, tc)
+	}
+
+	protoMsg := &protos.Message{
+		Role: "assistant",
+		Message: &protos.Message_Assistant{
+			Assistant: assistantMsg,
+		},
+	}
+
+	if firstTokenTime != nil {
+		metrics.OnAddMetrics(&protos.Metric{
+			Name:        "FIRST_TOKEN_RECIEVED_TIME",
+			Value:       fmt.Sprintf("%d", firstTokenTime.Sub(start)),
+			Description: "Time to receive first token from LLM",
+		})
+	}
+	metrics.OnSuccess()
+
+	onMetrics(options.Request.GetRequestId(), protoMsg, metrics.Build())
+	options.PostHook(map[string]interface{}{
+		"result": contentBuffer,
+	}, metrics.Build())
+
+	return nil
+}
+
+func (llc *largeLanguageCaller) GetCompletion(
+	ctx context.Context,
+	providerModel string,
+	prompts []string,
+	options *internal_callers.CompletionOptions,
+) ([]string, []*protos.Metric, error) {
+	llc.logger.Debugf("getting completion for minimax")
+	metrics := internal_caller_metrics.NewMetricBuilder(options.RequestId)
+	metrics.OnStart()
+	return nil, metrics.OnFailure().Build(), errors.New("text completion not supported by MiniMax; use chat completion instead")
+}
+
+// buildMessages converts proto messages to the OpenAI-compatible format used by MiniMax.
+func buildMessages(allMessages []*protos.Message) []map[string]interface{} {
+	msg := make([]map[string]interface{}, 0)
+	for _, cntn := range allMessages {
+		switch cntn.GetRole() {
+		case "user":
+			if user := cntn.GetUser(); user != nil {
+				msg = append(msg, map[string]interface{}{
+					"role":    "user",
+					"content": user.GetContent(),
+				})
+			}
+		case "assistant":
+			if assistant := cntn.GetAssistant(); assistant != nil {
+				entry := map[string]interface{}{
+					"role":    "assistant",
+					"content": strings.Join(assistant.GetContents(), ""),
+				}
+				if toolCalls := assistant.GetToolCalls(); len(toolCalls) > 0 {
+					tcs := make([]map[string]interface{}, 0, len(toolCalls))
+					for _, tc := range toolCalls {
+						tcs = append(tcs, map[string]interface{}{
+							"id":   tc.GetId(),
+							"type": "function",
+							"function": map[string]string{
+								"name":      tc.GetFunction().GetName(),
+								"arguments": tc.GetFunction().GetArguments(),
+							},
+						})
+					}
+					entry["tool_calls"] = tcs
+				}
+				msg = append(msg, entry)
+			}
+		case "system":
+			if system := cntn.GetSystem(); system != nil {
+				msg = append(msg, map[string]interface{}{
+					"role":    "system",
+					"content": system.GetContent(),
+				})
+			}
+		case "tool":
+			if tool := cntn.GetTool(); tool != nil {
+				for _, t := range tool.GetTools() {
+					msg = append(msg, map[string]interface{}{
+						"role":            "tool",
+						"content":         t.GetContent(),
+						"tool_call_id":    t.GetId(),
+					})
+				}
+			}
+		}
+	}
+	return msg
+}
+
+// stripThinkingTags removes <think>...</think> blocks from MiniMax model responses.
+func stripThinkingTags(content string) string {
+	for {
+		start := strings.Index(content, "<think>")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(content, "</think>")
+		if end == -1 {
+			// Incomplete think tag — remove from <think> to end
+			content = content[:start]
+			break
+		}
+		content = content[:start] + content[end+len("</think>"):]
+	}
+	return strings.TrimSpace(content)
+}

--- a/api/integration-api/internal/caller/minimax/llm_test.go
+++ b/api/integration-api/internal/caller/minimax/llm_test.go
@@ -1,0 +1,241 @@
+// Rapida -- Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_minimax_callers
+
+import (
+	"testing"
+
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/protos"
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger() commons.Logger {
+	lgr, _ := commons.NewApplicationLogger()
+	return lgr
+}
+
+func TestMessageBuilding_UserAndAssistant(t *testing.T) {
+	msgs := []*protos.Message{
+		{Role: "user", Message: &protos.Message_User{User: &protos.UserMessage{Content: "Hello"}}},
+		{Role: "assistant", Message: &protos.Message_Assistant{Assistant: &protos.AssistantMessage{Contents: []string{"Hi there"}}}},
+		{Role: "user", Message: &protos.Message_User{User: &protos.UserMessage{Content: "How are you?"}}},
+	}
+
+	result := buildMessages(msgs)
+	require.Len(t, result, 3)
+	assert.Equal(t, "user", result[0]["role"])
+	assert.Equal(t, "Hello", result[0]["content"])
+	assert.Equal(t, "assistant", result[1]["role"])
+	assert.Equal(t, "Hi there", result[1]["content"])
+	assert.Equal(t, "user", result[2]["role"])
+	assert.Equal(t, "How are you?", result[2]["content"])
+}
+
+func TestMessageBuilding_SystemMessage(t *testing.T) {
+	msgs := []*protos.Message{
+		{Role: "system", Message: &protos.Message_System{System: &protos.SystemMessage{Content: "You are helpful"}}},
+		{Role: "user", Message: &protos.Message_User{User: &protos.UserMessage{Content: "Hi"}}},
+	}
+
+	result := buildMessages(msgs)
+	require.Len(t, result, 2)
+	assert.Equal(t, "system", result[0]["role"])
+	assert.Equal(t, "You are helpful", result[0]["content"])
+	assert.Equal(t, "user", result[1]["role"])
+}
+
+func TestMessageBuilding_ToolMessages(t *testing.T) {
+	msgs := []*protos.Message{
+		{
+			Role: "assistant",
+			Message: &protos.Message_Assistant{
+				Assistant: &protos.AssistantMessage{
+					Contents: []string{""},
+					ToolCalls: []*protos.ToolCall{
+						{
+							Id:   "call_123",
+							Type: "function",
+							Function: &protos.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"location":"NYC"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Role: "tool",
+			Message: &protos.Message_Tool{
+				Tool: &protos.ToolMessage{
+					Tools: []*protos.ToolContent{
+						{Id: "call_123", Content: `{"temp": 72}`},
+					},
+				},
+			},
+		},
+	}
+
+	result := buildMessages(msgs)
+	require.Len(t, result, 2)
+
+	// Check assistant message with tool calls
+	assert.Equal(t, "assistant", result[0]["role"])
+	toolCalls, ok := result[0]["tool_calls"]
+	require.True(t, ok, "assistant message should have tool_calls")
+	tcSlice, ok := toolCalls.([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, tcSlice, 1)
+	assert.Equal(t, "call_123", tcSlice[0]["id"])
+
+	// Check tool message
+	assert.Equal(t, "tool", result[1]["role"])
+	assert.Equal(t, `{"temp": 72}`, result[1]["content"])
+	assert.Equal(t, "call_123", result[1]["tool_call_id"])
+}
+
+func TestMessageBuilding_Empty(t *testing.T) {
+	result := buildMessages([]*protos.Message{})
+	assert.Empty(t, result)
+}
+
+func TestStripThinkingTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no thinking tags",
+			input:    "Hello, world!",
+			expected: "Hello, world!",
+		},
+		{
+			name:     "simple thinking tag",
+			input:    "<think>reasoning here</think>The answer is 42.",
+			expected: "The answer is 42.",
+		},
+		{
+			name:     "multiple thinking tags",
+			input:    "<think>first</think>Hello <think>second</think>world",
+			expected: "Hello world",
+		},
+		{
+			name:     "incomplete thinking tag",
+			input:    "<think>never closed",
+			expected: "",
+		},
+		{
+			name:     "empty content after stripping",
+			input:    "<think>only thinking</think>",
+			expected: "",
+		},
+		{
+			name:     "thinking with whitespace",
+			input:    "  <think>reasoning</think>  Result  ",
+			expected: "Result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripThinkingTags(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClampTemperature(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{"zero", 0, 0.01},
+		{"negative", -0.5, 0.01},
+		{"normal", 0.7, 0.7},
+		{"max", 1.0, 1.0},
+		{"over max", 1.5, 1.0},
+		{"min valid", 0.01, 0.01},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := clampTemperature(tt.input)
+			assert.InDelta(t, tt.expected, result, 0.001)
+		})
+	}
+}
+
+func TestUsageMetrics(t *testing.T) {
+	mm := &MiniMax{logger: newTestLogger()}
+
+	t.Run("nil usage", func(t *testing.T) {
+		metrics := mm.UsageMetrics(nil)
+		assert.Empty(t, metrics)
+	})
+
+	t.Run("valid usage", func(t *testing.T) {
+		usage := &MiniMaxUsage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		}
+		metrics := mm.UsageMetrics(usage)
+		require.Len(t, metrics, 3)
+
+		metricMap := map[string]string{}
+		for _, m := range metrics {
+			metricMap[m.Name] = m.Value
+		}
+		assert.Equal(t, "50", metricMap["OUTPUT_TOKEN"])
+		assert.Equal(t, "100", metricMap["INPUT_TOKEN"])
+		assert.Equal(t, "150", metricMap["TOTAL_TOKEN"])
+	})
+}
+
+func TestEndpoint(t *testing.T) {
+	mm := &MiniMax{logger: newTestLogger()}
+
+	result := mm.Endpoint("chat/completions")
+	assert.Equal(t, "https://api.minimax.io/v1/chat/completions", result)
+}
+
+func TestGetCompletion_ReturnsError(t *testing.T) {
+	caller := &largeLanguageCaller{
+		MiniMax: MiniMax{logger: newTestLogger()},
+	}
+
+	_, metrics, err := caller.GetCompletion(nil, "model", []string{"prompt"}, &internal_callers.CompletionOptions{})
+	assert.Error(t, err, "GetCompletion should return error for unsupported operation")
+	assert.Contains(t, err.Error(), "not supported")
+	assert.NotNil(t, metrics)
+}
+
+func TestMiniMaxErrorString(t *testing.T) {
+	t.Run("with error detail", func(t *testing.T) {
+		mmErr := MiniMaxError{
+			Error: &struct {
+				Message string `json:"message,omitempty"`
+				Type    string `json:"type,omitempty"`
+				Code    string `json:"code,omitempty"`
+			}{
+				Message: "invalid api key",
+				Type:    "authentication_error",
+				Code:    "invalid_api_key",
+			},
+			StatusCode: 401,
+		}
+		assert.Contains(t, mmErr.ErrorString(), "invalid api key")
+		assert.Contains(t, mmErr.ErrorString(), "authentication_error")
+	})
+
+	t.Run("without error detail", func(t *testing.T) {
+		mmErr := MiniMaxError{StatusCode: 500}
+		assert.Contains(t, mmErr.ErrorString(), "500")
+	})
+}

--- a/api/integration-api/internal/caller/minimax/minimax.go
+++ b/api/integration-api/internal/caller/minimax/minimax.go
@@ -1,0 +1,214 @@
+// Rapida -- Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_minimax_callers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+	"github.com/rapidaai/protos"
+	integration_api "github.com/rapidaai/protos"
+)
+
+type MiniMax struct {
+	logger     commons.Logger
+	credential internal_callers.CredentialResolver
+}
+
+type MiniMaxError struct {
+	Error *struct {
+		Message string `json:"message,omitempty"`
+		Type    string `json:"type,omitempty"`
+		Code    string `json:"code,omitempty"`
+	} `json:"error,omitempty"`
+	StatusCode int `json:"status_code,omitempty"`
+}
+
+type MiniMaxUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type MiniMaxMessageResponse struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Model   string        `json:"model"`
+	Created int64         `json:"created"`
+	Usage   *MiniMaxUsage `json:"usage"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Content   string `json:"content"`
+			Role      string `json:"role"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+type MiniMaxStreamChunk struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Model   string        `json:"model"`
+	Created int64         `json:"created"`
+	Usage   *MiniMaxUsage `json:"usage"`
+	Choices []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Content   string `json:"content"`
+			Role      string `json:"role"`
+			ToolCalls []struct {
+				Index    int    `json:"index"`
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+func (e MiniMaxError) ErrorString() string {
+	if e.Error != nil {
+		return fmt.Sprintf("minimax api error: %s (type=%s, code=%s)", e.Error.Message, e.Error.Type, e.Error.Code)
+	}
+	return fmt.Sprintf("minimax api error: status_code=%d", e.StatusCode)
+}
+
+var (
+	API_KEY            = "key"
+	API_KEY_HEADER_KEY = "Authorization"
+	API_URL            = "https://api.minimax.io/v1/"
+	TIMEOUT            = 5 * time.Minute
+)
+
+func minimax(logger commons.Logger, credential *integration_api.Credential) MiniMax {
+	return MiniMax{
+		logger: logger,
+		credential: func() map[string]interface{} {
+			return credential.GetValue().AsMap()
+		},
+	}
+}
+
+func (mm *MiniMax) Do(req *http.Request) (*http.Response, error) {
+	client := &http.Client{
+		Timeout: TIMEOUT,
+	}
+	mm.logger.Debugf("making request to minimax with %+v", req)
+	return client.Do(req)
+}
+
+func (mm *MiniMax) Call(ctx context.Context, endpoint, method string, headers map[string]string, payload map[string]interface{}) (*http.Response, error) {
+	credentials := mm.credential()
+	cx, ok := credentials[API_KEY]
+	if !ok {
+		mm.logger.Errorf("Unable to get API key for MiniMax")
+		return nil, errors.New("unable to resolve the credential")
+	}
+
+	var in io.Reader
+	if payload != nil {
+		encodedPayload, err := json.Marshal(payload)
+		if err != nil {
+			mm.logger.Errorf("Unable to encode the payload for minimax err = %v", err)
+			return nil, err
+		}
+		in = bytes.NewBuffer(encodedPayload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, mm.Endpoint(endpoint), in)
+	if err != nil {
+		mm.logger.Errorf("Unable to build the request for minimax err = %v", err)
+		return nil, err
+	}
+
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add(API_KEY_HEADER_KEY, fmt.Sprintf("Bearer %s", cx.(string)))
+
+	return mm.Do(req)
+}
+
+func (mm *MiniMax) CallJSON(ctx context.Context, endpoint, method string, headers map[string]string, payload map[string]interface{}) (*string, error) {
+	resp, err := mm.Call(ctx, endpoint, method, headers, payload)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			mm.logger.Errorf("unable to read response body for minimax with error %v", err)
+			return nil, err
+		}
+		bodyString := string(bodyBytes)
+		return &bodyString, nil
+	}
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var apiErr MiniMaxError
+	if jsonErr := json.Unmarshal(bodyBytes, &apiErr); jsonErr == nil && apiErr.Error != nil {
+		apiErr.StatusCode = resp.StatusCode
+		return nil, fmt.Errorf("%s", apiErr.ErrorString())
+	}
+	return nil, fmt.Errorf("minimax api error: status=%d body=%s", resp.StatusCode, string(bodyBytes))
+}
+
+func (mm *MiniMax) Endpoint(urlPath string) string {
+	baseURL, _ := url.Parse(API_URL)
+	joinedPath := path.Join(baseURL.Path, urlPath)
+	baseURL.Path = joinedPath
+	return baseURL.String()
+}
+
+func (mm *MiniMax) UsageMetrics(usages *MiniMaxUsage) []*protos.Metric {
+	metrics := make([]*protos.Metric, 0)
+	if usages != nil {
+		metrics = append(metrics, &protos.Metric{
+			Name:        type_enums.OUTPUT_TOKEN.String(),
+			Value:       fmt.Sprintf("%d", usages.CompletionTokens),
+			Description: "Output Token",
+		})
+
+		metrics = append(metrics, &protos.Metric{
+			Name:        type_enums.INPUT_TOKEN.String(),
+			Value:       fmt.Sprintf("%d", usages.PromptTokens),
+			Description: "Input Token",
+		})
+
+		metrics = append(metrics, &protos.Metric{
+			Name:        type_enums.TOTAL_TOKEN.String(),
+			Value:       fmt.Sprintf("%d", usages.TotalTokens),
+			Description: "Total Token",
+		})
+	}
+	return metrics
+}

--- a/api/integration-api/internal/caller/minimax/verify-credential.go
+++ b/api/integration-api/internal/caller/minimax/verify-credential.go
@@ -1,0 +1,52 @@
+// Rapida -- Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_minimax_callers
+
+import (
+	"context"
+	"net/http"
+
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/utils"
+	integration_api "github.com/rapidaai/protos"
+)
+
+type verifyCredentialCaller struct {
+	MiniMax
+}
+
+func NewVerifyCredentialCaller(logger commons.Logger, credential *integration_api.Credential) internal_callers.Verifier {
+	return &verifyCredentialCaller{
+		MiniMax: minimax(logger, credential),
+	}
+}
+
+func (vc *verifyCredentialCaller) CredentialVerifier(
+	ctx context.Context,
+	options *internal_callers.CredentialVerifierOptions) (*string, error) {
+	// MiniMax does not have a /v1/models endpoint.
+	// Verify credentials by making a minimal chat completion request.
+	payload := map[string]interface{}{
+		"model": "MiniMax-M2.7",
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hi"},
+		},
+		"max_tokens":  1,
+		"temperature": 0.01,
+	}
+	_, err := vc.CallJSON(ctx, "chat/completions", "POST", map[string]string{}, payload)
+	if err != nil {
+		vc.logger.Debugf("minimax credential verification with error %v", err)
+		// Check if the error indicates auth failure specifically
+		if resp, callErr := vc.Call(ctx, "chat/completions", "POST", map[string]string{}, payload); callErr == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+				return utils.Ptr("valid"), nil
+			}
+		}
+		return nil, err
+	}
+	return utils.Ptr("valid"), nil
+}

--- a/api/integration-api/internal/caller/testdata/integration_config.yaml.example
+++ b/api/integration-api/internal/caller/testdata/integration_config.yaml.example
@@ -73,6 +73,13 @@ chat:
     options:
       model.name: "meta-llama/Meta-Llama-3-8B-Instruct"
 
+  minimax:
+    enabled: false
+    credential:
+      key: "..."
+    options:
+      model.name: "MiniMax-M2.7"
+
 # ─── Embeddings ────────────────────────────────────────────────────────────────
 embedding:
   openai:
@@ -201,6 +208,11 @@ verify:
       key: "hf_..."
 
   voyageai:
+    enabled: false
+    credential:
+      key: "..."
+
+  minimax:
     enabled: false
     credential:
       key: "..."

--- a/ui/src/providers/minimax/text-models.json
+++ b/ui/src/providers/minimax/text-models.json
@@ -1,0 +1,132 @@
+[
+    {
+        "id": "minimax/MiniMax-M2.7",
+        "name": "MiniMax-M2.7",
+        "config": {
+            "parameters": [
+                {
+                    "key": "model.temperature",
+                    "label": "Temperature",
+                    "type": "slider",
+                    "advanced": true,
+                    "required": true,
+                    "default": "0.7",
+                    "min": 0.01,
+                    "max": 1,
+                    "step": 0.01,
+                    "errorMessage": "MiniMax requires temperature between 0.01 and 1.0",
+                    "helpText": "Controls randomness. MiniMax requires values in (0, 1]."
+                },
+                {
+                    "key": "model.top_p",
+                    "label": "Top P",
+                    "type": "slider",
+                    "advanced": true,
+                    "required": true,
+                    "default": "1",
+                    "min": 0,
+                    "max": 1,
+                    "step": 0.05,
+                    "errorMessage": "Please provide a value between 0 and 1"
+                },
+                {
+                    "key": "model.max_completion_tokens",
+                    "label": "Max Completion Tokens",
+                    "type": "number",
+                    "advanced": true,
+                    "required": true,
+                    "default": "2048",
+                    "min": 1,
+                    "errorMessage": "Must be at least 1"
+                },
+                {
+                    "key": "model.tool_choice",
+                    "label": "Tool Choices",
+                    "type": "select",
+                    "advanced": true,
+                    "required": false,
+                    "choices": [
+                        { "label": "None", "value": "none" },
+                        { "label": "Auto", "value": "auto" },
+                        { "label": "Required", "value": "required" }
+                    ],
+                    "helpText": "How the model should select which tool to use."
+                },
+                {
+                    "key": "model.stop",
+                    "label": "Stop Sequences",
+                    "type": "input",
+                    "advanced": true,
+                    "required": false,
+                    "placeholder": "Comma-separated sequences",
+                    "helpText": "Sequences where the API will stop generating tokens."
+                }
+            ]
+        }
+    },
+    {
+        "id": "minimax/MiniMax-M2.7-highspeed",
+        "name": "MiniMax-M2.7-highspeed",
+        "config": {
+            "parameters": [
+                {
+                    "key": "model.temperature",
+                    "label": "Temperature",
+                    "type": "slider",
+                    "advanced": true,
+                    "required": true,
+                    "default": "0.7",
+                    "min": 0.01,
+                    "max": 1,
+                    "step": 0.01,
+                    "errorMessage": "MiniMax requires temperature between 0.01 and 1.0",
+                    "helpText": "Controls randomness. MiniMax requires values in (0, 1]."
+                },
+                {
+                    "key": "model.top_p",
+                    "label": "Top P",
+                    "type": "slider",
+                    "advanced": true,
+                    "required": true,
+                    "default": "1",
+                    "min": 0,
+                    "max": 1,
+                    "step": 0.05,
+                    "errorMessage": "Please provide a value between 0 and 1"
+                },
+                {
+                    "key": "model.max_completion_tokens",
+                    "label": "Max Completion Tokens",
+                    "type": "number",
+                    "advanced": true,
+                    "required": true,
+                    "default": "2048",
+                    "min": 1,
+                    "errorMessage": "Must be at least 1"
+                },
+                {
+                    "key": "model.tool_choice",
+                    "label": "Tool Choices",
+                    "type": "select",
+                    "advanced": true,
+                    "required": false,
+                    "choices": [
+                        { "label": "None", "value": "none" },
+                        { "label": "Auto", "value": "auto" },
+                        { "label": "Required", "value": "required" }
+                    ],
+                    "helpText": "How the model should select which tool to use."
+                },
+                {
+                    "key": "model.stop",
+                    "label": "Stop Sequences",
+                    "type": "input",
+                    "advanced": true,
+                    "required": false,
+                    "placeholder": "Comma-separated sequences",
+                    "helpText": "Sequences where the API will stop generating tokens."
+                }
+            ]
+        }
+    }
+]

--- a/ui/src/providers/provider.development.json
+++ b/ui/src/providers/provider.development.json
@@ -581,9 +581,10 @@
     {
         "code": "minimax",
         "name": "MiniMax",
-        "description": "MiniMax provides advanced text-to-speech synthesis with streaming SSE support and multiple voice options.",
+        "description": "MiniMax provides advanced AI models for text generation and text-to-speech synthesis with streaming SSE support.",
         "image": "https://rapida-assets-01.s3.ap-south-1.amazonaws.com/providers/minimax.png",
         "featureList": [
+            "text",
             "tts",
             "external"
         ],

--- a/ui/src/providers/provider.production.json
+++ b/ui/src/providers/provider.production.json
@@ -582,8 +582,9 @@
         "code": "minimax",
         "name": "MiniMax",
         "image": "https://rapida-assets-01.s3.ap-south-1.amazonaws.com/providers/minimax.png",
-        "description": "MiniMax provides advanced text-to-speech synthesis with streaming SSE support and multiple voice options.",
+        "description": "MiniMax provides advanced AI models for text generation and text-to-speech synthesis with streaming SSE support.",
         "featureList": [
+            "text",
             "tts",
             "external"
         ],


### PR DESCRIPTION
## Summary

Add **MiniMax** as a first-class LLM provider in the integration-api service, extending the existing TTS-only integration to include chat completion with both streaming (SSE) and non-streaming modes.

### MiniMax Models
- **MiniMax-M2.7** — Latest flagship model with 204K context window
- **MiniMax-M2.7-highspeed** — Optimized for low-latency voice AI workloads

### Changes

**Backend** (`api/integration-api/internal/caller/minimax/`):
- `minimax.go` — Base HTTP client with credential resolver and usage metrics
- `llm.go` — `LargeLanguageCaller` implementation with:
  - Non-streaming `GetChatCompletion` via OpenAI-compatible `/v1/chat/completions`
  - Streaming `StreamChatCompletion` with SSE parsing and first-token-time tracking
  - Temperature clamping to MiniMax's required (0, 1] range
  - `<think>` tag stripping for reasoning model output
  - Full tool/function calling support
- `verify-credential.go` — Credential verification via minimal chat completion
- Registered `MINIMAX` constant and factory cases in `caller.go`

**Frontend** (`ui/src/providers/minimax/`):
- `text-models.json` — Model catalog with per-model parameter configs (temperature, top_p, max_tokens, tool_choice, stop sequences)
- Added `"text"` to `featureList` in both dev and prod provider registries

**Tests**:
- 10 unit tests covering message building, think-tag stripping, temperature clamping, usage metrics, endpoint resolution, and error handling
- 3 integration tests (chat completion, streaming, credential verification) with `//go:build integration` tag

**Docs**:
- Updated integration test config example with MiniMax sections
- Added MiniMax to README provider list

## Test plan

- [ ] Unit tests pass: `go test ./api/integration-api/internal/caller/minimax/...`
- [ ] Integration tests pass with `MINIMAX_API_KEY` configured in `integration_config.yaml`
- [ ] MiniMax appears in the text provider dropdown in the UI
- [ ] Non-streaming chat completion returns valid responses
- [ ] Streaming chat completion streams tokens and reports metrics
- [ ] Credential verification succeeds with valid API key
- [ ] Temperature values at boundaries (0, 1) are correctly clamped
- [ ] Existing providers unaffected (no regressions)