### PR TITLE
fix: added DID (callerID) so it can be used anywhere in session

### DIFF
--- a/api/assistant-api/internal/channel/telephony/internal/asterisk/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/asterisk/telephony.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
@@ -87,7 +88,7 @@ func (apt *asteriskTelephony) OutboundCall(
 	auth types.SimplePrinciple,
 	toPhone string,
 	fromPhone string,
-	assistantId, assistantConversationId uint64,
+	assistant *internal_assistant_entity.Assistant, assistantConversationId uint64,
 	vaultCredential *protos.VaultCredential,
 	opts utils.Option,
 ) (*internal_type.CallInfo, error) {
@@ -151,7 +152,7 @@ func (apt *asteriskTelephony) OutboundCall(
 
 	if !hasDialplan {
 		params.Set("app", appName)
-		params.Set("appArgs", fmt.Sprintf("incoming,assistant_id=%d,conversation_id=%d", assistantId, assistantConversationId))
+		params.Set("appArgs", fmt.Sprintf("incoming,assistant_id=%d,conversation_id=%d", assistant.Id, assistantConversationId))
 	}
 
 	channelVars := map[string]string{}

--- a/api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
 	internal_exotel "github.com/rapidaai/api/assistant-api/internal/channel/telephony/internal/exotel/internal"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 
 	"github.com/rapidaai/pkg/commons"
@@ -113,7 +114,7 @@ func (exo *exotelTelephony) OutboundCall(
 	auth types.SimplePrinciple,
 	toPhone string,
 	fromPhone string,
-	assistantId, assistantConversationId uint64,
+	assistant *internal_assistant_entity.Assistant, assistantConversationId uint64,
 	vaultCredential *protos.VaultCredential,
 	opts utils.Option) (*internal_type.CallInfo, error) {
 	info := &internal_type.CallInfo{Provider: exotelProvider}

--- a/api/assistant-api/internal/channel/telephony/internal/sip/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/sip/telephony.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	"github.com/rapidaai/pkg/commons"
@@ -103,7 +104,8 @@ func (t *sipTelephony) OutboundCall(
 	auth types.SimplePrinciple,
 	toPhone string,
 	fromPhone string,
-	assistantId, assistantConversationId uint64,
+	assistant *internal_assistant_entity.Assistant,
+	assistantConversationId uint64,
 	vaultCredential *protos.VaultCredential,
 	opts utils.Option,
 ) (*internal_type.CallInfo, error) {
@@ -129,7 +131,7 @@ func (t *sipTelephony) OutboundCall(
 
 	session, err := t.sharedServer.MakeCall(context.Background(), cfg, toPhone, fromPhone, sip_infra.MakeCallOptions{
 		Auth:            auth,
-		AssistantID:     assistantId,
+		Assistant:       assistant,
 		ConversationID:  assistantConversationId,
 		VaultCredential: vaultCredential,
 	})
@@ -143,7 +145,7 @@ func (t *sipTelephony) OutboundCall(
 		"to", toPhone,
 		"from", fromPhone,
 		"call_id", session.GetCallID(),
-		"assistant_id", assistantId,
+		"assistant_id", assistant.Id,
 		"conversation_id", assistantConversationId)
 
 	info.ChannelUUID = session.GetCallID()
@@ -154,7 +156,7 @@ func (t *sipTelephony) OutboundCall(
 			"to":              toPhone,
 			"from":            fromPhone,
 			"call_id":         session.GetCallID(),
-			"assistant_id":    assistantId,
+			"assistant_id":    assistant.Id,
 			"conversation_id": assistantConversationId,
 		},
 	}

--- a/api/assistant-api/internal/channel/telephony/internal/sip/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/sip/telephony.go
@@ -127,16 +127,12 @@ func (t *sipTelephony) OutboundCall(
 		return info, fmt.Errorf("shared SIP server is not running")
 	}
 
-	// Metadata must be set before MakeCall — on fast LANs the 200 OK arrives
-	// before the caller gets a chance to set it, causing a race.
-	callMetadata := map[string]interface{}{
-		"assistant_id":    assistantId,
-		"conversation_id": assistantConversationId,
-		"to_phone":        toPhone,
-		"auth":            auth,
-		"sip_config":      cfg,
-	}
-	session, err := t.sharedServer.MakeCall(context.Background(), cfg, toPhone, fromPhone, callMetadata)
+	session, err := t.sharedServer.MakeCall(context.Background(), cfg, toPhone, fromPhone, sip_infra.MakeCallOptions{
+		Auth:            auth,
+		AssistantID:     assistantId,
+		ConversationID:  assistantConversationId,
+		VaultCredential: vaultCredential,
+	})
 	if err != nil {
 		info.Status = "FAILED"
 		info.ErrorMessage = fmt.Sprintf("call error: %s", err.Error())

--- a/api/assistant-api/internal/channel/telephony/internal/twilio/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/twilio/telephony.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
@@ -102,7 +103,7 @@ func (tpc *twilioTelephony) StatusCallback(c *gin.Context, auth types.SimplePrin
 	return &internal_type.StatusInfo{Event: event, Payload: eventDetails}, nil
 }
 
-func (tpc *twilioTelephony) OutboundCall(auth types.SimplePrinciple, toPhone string, fromPhone string, assistantId, assistantConversationId uint64, vaultCredential *protos.VaultCredential, opts utils.Option) (*internal_type.CallInfo, error) {
+func (tpc *twilioTelephony) OutboundCall(auth types.SimplePrinciple, toPhone string, fromPhone string, assistant *internal_assistant_entity.Assistant, assistantConversationId uint64, vaultCredential *protos.VaultCredential, opts utils.Option) (*internal_type.CallInfo, error) {
 	info := &internal_type.CallInfo{Provider: twilioProvider}
 
 	contextID, _ := opts.GetString("rapida.context_id")
@@ -126,10 +127,10 @@ func (tpc *twilioTelephony) OutboundCall(auth types.SimplePrinciple, toPhone str
 	callParams.SetTwiml(
 		tpc.CreateTwinML(
 			tpc.appCfg.PublicAssistantHost,
-			fmt.Sprintf("%d__%d", assistantId, assistantConversationId),
+			fmt.Sprintf("%d__%d", assistant.Id, assistantConversationId),
 			internal_type.GetContextAnswerPath(twilioProvider, contextID),
 			fmt.Sprintf("https://%s/%s", tpc.appCfg.PublicAssistantHost, internal_type.GetContextEventPath(twilioProvider, contextID)),
-			assistantId,
+			assistant.Id,
 			toPhone),
 	)
 	resp, err := client.Api.CreateCall(callParams)

--- a/api/assistant-api/internal/channel/telephony/internal/vonage/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/vonage/telephony.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
@@ -93,7 +94,7 @@ func (vng *vonageTelephony) OutboundCall(
 	auth types.SimplePrinciple,
 	toPhone string,
 	fromPhone string,
-	assistantId, assistantConversationId uint64,
+	assistant *internal_assistant_entity.Assistant, assistantConversationId uint64,
 	vaultCredential *protos.VaultCredential,
 	opts utils.Option,
 ) (*internal_type.CallInfo, error) {

--- a/api/assistant-api/internal/channel/telephony/outbound.go
+++ b/api/assistant-api/internal/channel/telephony/outbound.go
@@ -135,7 +135,7 @@ func (d *OutboundDispatcher) performOutbound(ctx context.Context, cc *callcontex
 	opts := assistant.AssistantPhoneDeployment.GetOptions()
 	opts["rapida.context_id"] = cc.ContextID
 
-	callInfo, callErr := telephony.OutboundCall(auth, cc.CallerNumber, cc.FromNumber, cc.AssistantID, cc.ConversationID, vltC, opts)
+	callInfo, callErr := telephony.OutboundCall(auth, cc.CallerNumber, cc.FromNumber, assistant, cc.ConversationID, vltC, opts)
 	if callErr != nil {
 		d.logger.Errorf("outbound dispatcher[%s]: telephony call failed for contextId=%s: %v", cc.Provider, cc.ContextID, callErr)
 	}

--- a/api/assistant-api/internal/type/telephony.go
+++ b/api/assistant-api/internal/type/telephony.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	"github.com/rapidaai/pkg/types"
 	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/protos"
@@ -78,7 +79,7 @@ type Telephony interface {
 	// ReceiveCall processes an incoming call webhook and returns structured call info.
 	ReceiveCall(c *gin.Context) (*CallInfo, error)
 	// OutboundCall places an outbound call and returns structured call info.
-	OutboundCall(auth types.SimplePrinciple, toPhone string, fromPhone string, assistantId, assistantConversationId uint64, vaultCredential *protos.VaultCredential, opts utils.Option) (*CallInfo, error)
+	OutboundCall(auth types.SimplePrinciple, toPhone string, fromPhone string, assistant *internal_assistant_entity.Assistant, assistantConversationId uint64, vaultCredential *protos.VaultCredential, opts utils.Option) (*CallInfo, error)
 	// InboundCall instructs the provider to answer/connect the inbound call.
 	InboundCall(c *gin.Context, auth types.SimplePrinciple, assistantId uint64, clientNumber string, assistantConversationId uint64) error
 }

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -1435,8 +1435,7 @@ func (s *Server) sendBye(session *Session) {
 // MakeCallOptions holds the typed context for an outbound call.
 type MakeCallOptions struct {
 	Auth            types.SimplePrinciple
-	Assistant       *internal_assistant_entity.Assistant // Full entity if available
-	AssistantID     uint64                               // Fallback when entity is not available
+	Assistant       *internal_assistant_entity.Assistant
 	ConversationID  uint64
 	VaultCredential *protos.VaultCredential
 }
@@ -1462,6 +1461,7 @@ func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI strin
 		Logger:          s.logger,
 		Auth:            opts.Auth,
 		Assistant:       opts.Assistant,
+		ConversationID:  opts.ConversationID,
 		VaultCredential: opts.VaultCredential,
 	})
 	if err != nil {
@@ -1472,14 +1472,6 @@ func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI strin
 	session.SetLocalRTP(invite.externalIP, invite.localPort)
 	session.SetRTPHandler(invite.rtpHandler)
 	session.SetDialogClientSession(invite.dialogSession)
-
-	// Set metadata for onInvite backward compatibility
-	if opts.Assistant != nil {
-		session.SetMetadata("assistant_id", opts.Assistant.Id)
-	} else if opts.AssistantID > 0 {
-		session.SetMetadata("assistant_id", opts.AssistantID)
-	}
-	session.SetMetadata("conversation_id", opts.ConversationID)
 
 	s.registerSession(session, invite.callID)
 

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/types"
 	"github.com/rapidaai/protos"
 	"github.com/redis/go-redis/v9"
 )
@@ -638,8 +640,8 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 		CallID:          callID,
 		Codec:           negotiatedCodec,
 		Logger:          s.logger,
-		Auth:            resolvedExtra["auth"],
-		Assistant:       resolvedExtra["assistant"],
+		Auth:            resolvedExtra["auth"].(types.SimplePrinciple),
+		Assistant:       resolvedExtra["assistant"].(*internal_assistant_entity.Assistant),
 		VaultCredential: vaultCredential,
 	})
 	if err != nil {
@@ -1430,10 +1432,19 @@ func (s *Server) sendBye(session *Session) {
 	}
 }
 
+// MakeCallOptions holds the typed context for an outbound call.
+type MakeCallOptions struct {
+	Auth            types.SimplePrinciple
+	Assistant       *internal_assistant_entity.Assistant // Full entity if available
+	AssistantID     uint64                               // Fallback when entity is not available
+	ConversationID  uint64
+	VaultCredential *protos.VaultCredential
+}
+
 // MakeCall initiates an outbound SIP call using the DialogClientCache.
 // The cache stores the dialog so incoming BYE/re-INVITE are properly routed
 // to the correct DialogClientSession via handleBye → dialogClientCache.ReadBye.
-func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI string, metadata map[string]interface{}) (*Session, error) {
+func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI string, opts MakeCallOptions) (*Session, error) {
 	if s.state.Load() != int32(ServerStateRunning) {
 		return nil, fmt.Errorf("SIP server is not running")
 	}
@@ -1443,35 +1454,15 @@ func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI strin
 		return nil, err
 	}
 
-	// Extract auth, assistant, and vault credential from metadata for direct session access
-	var sessionAuth interface{}
-	var sessionAssistant interface{}
-	var sessionVaultCred *protos.VaultCredential
-
-	if metadata != nil {
-		if val, ok := metadata["auth"]; ok {
-			sessionAuth = val
-		}
-		if val, ok := metadata["assistant"]; ok {
-			sessionAssistant = val
-		}
-		if vaultCredVal, ok := metadata["vault_credential"]; ok {
-			if vaultCred, ok := vaultCredVal.(*protos.VaultCredential); ok {
-				sessionVaultCred = vaultCred
-			}
-		}
-	}
-
-	// Create our internal session with auth and assistant context
 	session, err := NewSession(ctx, &SessionConfig{
 		Config:          cfg,
 		Direction:       CallDirectionOutbound,
 		CallID:          invite.callID,
 		Codec:           &CodecPCMU,
 		Logger:          s.logger,
-		Auth:            sessionAuth,
-		Assistant:       sessionAssistant,
-		VaultCredential: sessionVaultCred,
+		Auth:            opts.Auth,
+		Assistant:       opts.Assistant,
+		VaultCredential: opts.VaultCredential,
 	})
 	if err != nil {
 		invite.cleanup()
@@ -1482,14 +1473,13 @@ func (s *Server) MakeCall(ctx context.Context, cfg *Config, toURI, fromURI strin
 	session.SetRTPHandler(invite.rtpHandler)
 	session.SetDialogClientSession(invite.dialogSession)
 
-	// Set metadata on the session BEFORE launching the goroutine.
-	// handleOutboundDialog runs asynchronously and calls onInvite → handleOutboundAnswered
-	// which reads this metadata. On fast LANs the 200 OK can arrive before the caller
-	// of MakeCall gets a chance to set metadata, causing a race condition where
-	// handleOutboundAnswered fails with "outbound session missing assistant_id metadata".
-	for k, v := range metadata {
-		session.SetMetadata(k, v)
+	// Set metadata for onInvite backward compatibility
+	if opts.Assistant != nil {
+		session.SetMetadata("assistant_id", opts.Assistant.Id)
+	} else if opts.AssistantID > 0 {
+		session.SetMetadata("assistant_id", opts.AssistantID)
 	}
+	session.SetMetadata("conversation_id", opts.ConversationID)
 
 	s.registerSession(session, invite.callID)
 
@@ -1843,13 +1833,16 @@ func (s *Server) prepareOutboundInvite(ctx context.Context, cfg *Config, toURI, 
 		fromDomain = cfg.Server
 	}
 	fromUser := strings.TrimSpace(fromURI)
+	if cfg.CallerID != "" {
+		fromUser = cfg.CallerID
+	}
 	if fromUser == "" {
 		fromUser = cfg.Username
 	}
 	if fromUser == "" {
 		rtpHandler.Stop()
 		s.rtpAllocator.Release(rtpPort)
-		return nil, fmt.Errorf("SIP From user is empty: fromPhone or sip_username must be set")
+		return nil, fmt.Errorf("SIP From user is empty: fromPhone, caller_id, or sip_username must be set")
 	}
 
 	fromHDR := &sip.FromHeader{

--- a/api/assistant-api/sip/infra/session.go
+++ b/api/assistant-api/sip/infra/session.go
@@ -37,9 +37,9 @@ type SessionConfig struct {
 	CallID          string // Optional: if empty, a new UUID will be generated
 	Codec           *Codec
 	Logger          commons.Logger
-	Auth            types.SimplePrinciple                  // Authentication principal
-	Assistant       *internal_assistant_entity.Assistant    // Assistant entity
-	VaultCredential *protos.VaultCredential                 // Vault-resolved SIP provider credential
+	Auth            types.SimplePrinciple                // Authentication principal
+	Assistant       *internal_assistant_entity.Assistant // Assistant entity
+	VaultCredential *protos.VaultCredential              // Vault-resolved SIP provider credential
 }
 
 // Session manages a single SIP call session
@@ -69,9 +69,9 @@ type Session struct {
 	metadata map[string]interface{}
 
 	// Authentication and authorization context - available in all session methods
-	auth            types.SimplePrinciple                  // Authentication principal
-	assistant       *internal_assistant_entity.Assistant    // Assistant entity
-	vaultCredential *protos.VaultCredential                 // Vault-resolved SIP provider credential
+	auth            types.SimplePrinciple                // Authentication principal
+	assistant       *internal_assistant_entity.Assistant // Assistant entity
+	vaultCredential *protos.VaultCredential              // Vault-resolved SIP provider credential
 
 	// byeReceived is closed when a SIP BYE is received for this session.
 	// Used to notify startCall about early BYE without fully ending the session.

--- a/api/assistant-api/sip/infra/session.go
+++ b/api/assistant-api/sip/infra/session.go
@@ -39,6 +39,7 @@ type SessionConfig struct {
 	Logger          commons.Logger
 	Auth            types.SimplePrinciple                // Authentication principal
 	Assistant       *internal_assistant_entity.Assistant // Assistant entity
+	ConversationID  uint64                               // Conversation ID (outbound: set by channel pipeline)
 	VaultCredential *protos.VaultCredential              // Vault-resolved SIP provider credential
 }
 
@@ -71,6 +72,7 @@ type Session struct {
 	// Authentication and authorization context - available in all session methods
 	auth            types.SimplePrinciple                // Authentication principal
 	assistant       *internal_assistant_entity.Assistant // Assistant entity
+	conversationID  uint64                               // Conversation ID
 	vaultCredential *protos.VaultCredential              // Vault-resolved SIP provider credential
 
 	// byeReceived is closed when a SIP BYE is received for this session.
@@ -144,6 +146,7 @@ func NewSession(ctx context.Context, cfg *SessionConfig) (*Session, error) {
 		negotiatedCodec: codec,
 		auth:            cfg.Auth,
 		assistant:       cfg.Assistant,
+		conversationID:  cfg.ConversationID,
 		vaultCredential: cfg.VaultCredential,
 		byeReceived:     make(chan struct{}),
 	}
@@ -483,6 +486,13 @@ func (s *Session) GetAuth() types.SimplePrinciple {
 	return s.auth
 }
 
+// SetAuth sets the authentication principal for this session.
+func (s *Session) SetAuth(auth types.SimplePrinciple) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.auth = auth
+}
+
 // GetAssistant returns the assistant entity for this session.
 func (s *Session) GetAssistant() *internal_assistant_entity.Assistant {
 	s.mu.RLock()
@@ -490,8 +500,28 @@ func (s *Session) GetAssistant() *internal_assistant_entity.Assistant {
 	return s.assistant
 }
 
+// SetAssistant sets the assistant entity for this session.
+func (s *Session) SetAssistant(assistant *internal_assistant_entity.Assistant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.assistant = assistant
+}
+
+// GetConversationID returns the conversation ID for this session.
+func (s *Session) GetConversationID() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.conversationID
+}
+
+// SetConversationID sets the conversation ID for this session.
+func (s *Session) SetConversationID(id uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conversationID = id
+}
+
 // GetVaultCredential returns the vault-resolved SIP provider credential for this session.
-// Available in all session methods after session creation.
 func (s *Session) GetVaultCredential() *protos.VaultCredential {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/api/assistant-api/sip/infra/session.go
+++ b/api/assistant-api/sip/infra/session.go
@@ -18,7 +18,9 @@ import (
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
 	"github.com/google/uuid"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/types"
 	"github.com/rapidaai/protos"
 )
 
@@ -35,9 +37,9 @@ type SessionConfig struct {
 	CallID          string // Optional: if empty, a new UUID will be generated
 	Codec           *Codec
 	Logger          commons.Logger
-	Auth            interface{}             // Authentication principal (types.SimplePrinciple)
-	Assistant       interface{}             // Assistant entity (*internal_assistant_entity.Assistant)
-	VaultCredential *protos.VaultCredential // Vault-resolved SIP provider credential
+	Auth            types.SimplePrinciple                  // Authentication principal
+	Assistant       *internal_assistant_entity.Assistant    // Assistant entity
+	VaultCredential *protos.VaultCredential                 // Vault-resolved SIP provider credential
 }
 
 // Session manages a single SIP call session
@@ -67,9 +69,9 @@ type Session struct {
 	metadata map[string]interface{}
 
 	// Authentication and authorization context - available in all session methods
-	auth            interface{}             // Authentication principal (types.SimplePrinciple)
-	assistant       interface{}             // Assistant entity (*internal_assistant_entity.Assistant)
-	vaultCredential *protos.VaultCredential // Vault-resolved SIP provider credential
+	auth            types.SimplePrinciple                  // Authentication principal
+	assistant       *internal_assistant_entity.Assistant    // Assistant entity
+	vaultCredential *protos.VaultCredential                 // Vault-resolved SIP provider credential
 
 	// byeReceived is closed when a SIP BYE is received for this session.
 	// Used to notify startCall about early BYE without fully ending the session.
@@ -474,17 +476,15 @@ func (s *Session) Disconnect() {
 	}
 }
 
-// GetAuth returns the authentication principal (types.SimplePrinciple) for this session.
-// Available in all session methods after session creation.
-func (s *Session) GetAuth() interface{} {
+// GetAuth returns the authentication principal for this session.
+func (s *Session) GetAuth() types.SimplePrinciple {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.auth
 }
 
 // GetAssistant returns the assistant entity for this session.
-// Available in all session methods after session creation.
-func (s *Session) GetAssistant() interface{} {
+func (s *Session) GetAssistant() *internal_assistant_entity.Assistant {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.assistant

--- a/api/assistant-api/sip/pipeline/media.go
+++ b/api/assistant-api/sip/pipeline/media.go
@@ -45,6 +45,7 @@ func (d *Dispatcher) handleSessionEstablished(ctx context.Context, v sip_infra.S
 			v.Session.End()
 			return
 		}
+		v.Session.SetConversationID(conversationID)
 	}
 
 	setup, err := d.onCallSetup(ctx, v.Session, v.Auth, v.AssistantID, conversationID)

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -271,32 +271,14 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) 
 		return fmt.Errorf("missing auth on session %s", callID)
 	}
 
-	var assistantID uint64
 	assistant := session.GetAssistant()
-	if assistant != nil {
-		assistantID = assistant.Id
-	} else if idVal, ok := session.GetMetadata("assistant_id"); ok {
-		if id, ok := idVal.(uint64); ok && id > 0 {
-			assistantID = id
-			loaded, err := m.assistantService.Get(m.ctx, auth, id, utils.GetVersionDefinition("latest"),
-				&internal_services.GetAssistantOption{InjectPhoneDeployment: true})
-			if err != nil {
-				return fmt.Errorf("failed to load assistant %d for outbound call: %w", id, err)
-			}
-			session.SetMetadata("assistant", loaded)
-		}
-	}
-	if assistantID == 0 {
+	if assistant == nil {
 		return fmt.Errorf("missing assistant context on session %s", callID)
 	}
 
-	// For outbound, pass conversation_id from session metadata (created by channel pipeline)
-	var conversationID uint64
-	if convIDVal, ok := session.GetMetadata("conversation_id"); ok {
-		if id, ok := convIDVal.(uint64); ok {
-			conversationID = id
-		}
-	}
+	// For outbound, conversation_id is set on the session by MakeCall.
+	// For inbound, it's 0 here — created later by handleSessionEstablished.
+	conversationID := session.GetConversationID()
 
 	m.dispatcher.OnPipeline(m.ctx, sip_infra.SessionEstablishedPipeline{
 		ID:              callID,
@@ -304,7 +286,7 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) 
 		Config:          session.GetConfig(),
 		VaultCredential: session.GetVaultCredential(),
 		Direction:       info.Direction,
-		AssistantID:     assistantID,
+		AssistantID:     assistant.Id,
 		Auth:            auth,
 		FromURI:         fromURI,
 		ConversationID:  conversationID,
@@ -334,12 +316,8 @@ func (m *SIPEngine) onError(session *sip_infra.Session, callErr error) {
 	callID := session.GetCallID()
 	m.logger.Warnw("SIP error", "call_id", callID, "error", callErr)
 
-	convIDVal, hasConv := session.GetMetadata("conversation_id")
-	if !hasConv {
-		return
-	}
-	convID, ok := convIDVal.(uint64)
-	if !ok || convID == 0 {
+	convID := session.GetConversationID()
+	if convID == 0 {
 		return
 	}
 
@@ -348,8 +326,10 @@ func (m *SIPEngine) onError(session *sip_infra.Session, callErr error) {
 		return
 	}
 
-	assistantIDVal, _ := session.GetMetadata("assistant_id")
-	assistantID, _ := assistantIDVal.(uint64)
+	var assistantID uint64
+	if assistant := session.GetAssistant(); assistant != nil {
+		assistantID = assistant.Id
+	}
 
 	setup := &sip_pipeline.CallSetupResult{
 		AssistantID:    assistantID,

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -266,25 +266,24 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) 
 		return fmt.Errorf("session already ended")
 	}
 
-	authVal, _ := session.GetMetadata("auth")
-	auth, _ := authVal.(types.SimplePrinciple)
+	auth := session.GetAuth()
 	if auth == nil {
 		return fmt.Errorf("missing auth on session %s", callID)
 	}
 
 	var assistantID uint64
-	assistantVal, _ := session.GetMetadata("assistant")
-	if assistant, ok := assistantVal.(*internal_assistant_entity.Assistant); ok && assistant != nil {
+	assistant := session.GetAssistant()
+	if assistant != nil {
 		assistantID = assistant.Id
 	} else if idVal, ok := session.GetMetadata("assistant_id"); ok {
 		if id, ok := idVal.(uint64); ok && id > 0 {
 			assistantID = id
-			assistant, err := m.assistantService.Get(m.ctx, auth, id, utils.GetVersionDefinition("latest"),
+			loaded, err := m.assistantService.Get(m.ctx, auth, id, utils.GetVersionDefinition("latest"),
 				&internal_services.GetAssistantOption{InjectPhoneDeployment: true})
 			if err != nil {
 				return fmt.Errorf("failed to load assistant %d for outbound call: %w", id, err)
 			}
-			session.SetMetadata("assistant", assistant)
+			session.SetMetadata("assistant", loaded)
 		}
 	}
 	if assistantID == 0 {
@@ -344,8 +343,7 @@ func (m *SIPEngine) onError(session *sip_infra.Session, callErr error) {
 		return
 	}
 
-	authVal, _ := session.GetMetadata("auth")
-	auth, _ := authVal.(types.SimplePrinciple)
+	auth := session.GetAuth()
 	if auth == nil {
 		return
 	}
@@ -444,6 +442,12 @@ func (m *SIPEngine) fetchSIPConfigAndVaultCredential(auth types.SimplePrinciple,
 	sipConfig, err := sip_infra.ParseConfigFromVault(vaultCred)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse SIP config from vault: %w", err)
+	}
+
+	// Set CallerID to the assistant's DID from the phone deployment.
+	// This is used as the From URI user in outbound INVITEs (prepareOutboundInvite).
+	if did, err := opts.GetString("phone"); err == nil && did != "" {
+		sipConfig.CallerID = strings.TrimPrefix(did, "+")
 	}
 
 	if m.cfg.SIPConfig != nil {
@@ -856,10 +860,7 @@ func (m *SIPEngine) pipelineCreateConversation(ctx context.Context, auth types.S
 // pipelineCallSetup builds the CallSetupResult from auth and IDs.
 // Pure function — conversation must already exist (created by pipeline or channel layer).
 func (m *SIPEngine) pipelineCallSetup(ctx context.Context, session *sip_infra.Session, auth types.SimplePrinciple, assistantID uint64, conversationID uint64) (*sip_pipeline.CallSetupResult, error) {
-	var assistant *internal_assistant_entity.Assistant
-	if assistantVal, ok := session.GetMetadata("assistant"); ok {
-		assistant, _ = assistantVal.(*internal_assistant_entity.Assistant)
-	}
+	assistant := session.GetAssistant()
 	if assistant == nil {
 		var err error
 		assistant, err = m.assistantService.Get(ctx, auth, assistantID, utils.GetVersionDefinition("latest"),
@@ -907,8 +908,7 @@ func (m *SIPEngine) pipelineCallStart(ctx context.Context, session *sip_infra.Se
 		return fmt.Errorf("session_ended_before_start")
 	}
 
-	authVal, _ := session.GetMetadata("auth")
-	auth, _ := authVal.(types.SimplePrinciple)
+	auth := session.GetAuth()
 
 	cc := &callcontext.CallContext{
 		AssistantID:         setup.AssistantID,
@@ -1018,10 +1018,17 @@ func (m *SIPEngine) executeBridgeTransfer(inboundSession *sip_infra.Session, sip
 		cfg = inboundSession.GetConfig()
 	}
 
-	// Use the assistant's DID as the From URI — same as the normal outbound path
-	// where the API caller passes the DID as fromPhone. LocalURI is set by the
-	// SIP stack: inbound = To header (number caller dialed), outbound = From header.
-	fromURI := sip_infra.ExtractDIDFromURI(inboundSession.GetInfo().LocalURI)
+	// cfg.CallerID is the assistant's DID — set by fetchSIPConfigAndVaultCredential
+	// for inbound calls. For outbound calls it may be empty (telephony.parseConfig
+	// doesn't set it), so resolve from the assistant's phone deployment.
+	if cfg.CallerID == "" {
+		if assistant := inboundSession.GetAssistant(); assistant != nil && assistant.AssistantPhoneDeployment != nil {
+			if did, err := assistant.AssistantPhoneDeployment.GetOptions().GetString("phone"); err == nil && did != "" {
+				cfg.CallerID = strings.TrimPrefix(did, "+")
+			}
+		}
+	}
+
 	bridgeCtx, bridgeCancel := context.WithTimeout(inboundSession.Context(), sip_infra.BridgeCallTimeout)
 	defer bridgeCancel()
 
@@ -1029,7 +1036,7 @@ func (m *SIPEngine) executeBridgeTransfer(inboundSession *sip_infra.Session, sip
 	srv := m.server
 	m.mu.RUnlock()
 
-	outboundSession, err := srv.MakeBridgeCall(bridgeCtx, cfg, target, fromURI)
+	outboundSession, err := srv.MakeBridgeCall(bridgeCtx, cfg, target, cfg.CallerID)
 	if err != nil {
 		m.logger.Errorw("Bridge transfer: outbound call failed",
 			"call_id", callID, "target", target, "error", err)


### PR DESCRIPTION
This pull request refactors how authentication and assistant context are handled in SIP telephony sessions, moving from untyped metadata to strongly-typed fields and method signatures. It also ensures the correct caller ID is set for outbound SIP calls, improving reliability and reducing race conditions. The changes affect both the SIP infrastructure and the telephony API integration.

**Typed context and session handling improvements:**

* Replaced untyped `metadata` maps with a strongly-typed `MakeCallOptions` struct in `MakeCall`, ensuring `Auth`, `Assistant`, and `VaultCredential` are passed explicitly and available in all session methods. (`api/assistant-api/sip/infra/server.go`, `api/assistant-api/internal/channel/telephony/internal/sip/telephony.go`) [[1]](diffhunk://#diff-8dbe45afa186e42a6a8503d884682d73071ca181a741c4945754c9c676979115R1435-R1447) [[2]](diffhunk://#diff-8dbe45afa186e42a6a8503d884682d73071ca181a741c4945754c9c676979115L1446-R1465) [[3]](diffhunk://#diff-f534653692e5c8845a6aa23f77064fdcbba18773af2afb178b5d1b45dab7650eL130-R135)
* Updated `SessionConfig` and `Session` to use typed fields for `Auth` (`types.SimplePrinciple`) and `Assistant` (`*internal_assistant_entity.Assistant`), removing the use of `interface{}`. (`api/assistant-api/sip/infra/session.go`) [[1]](diffhunk://#diff-677d1ba0d4f15987c0a583946966bbe2640fe8b3794b3066cbd93347db57aff2L38-R41) [[2]](diffhunk://#diff-677d1ba0d4f15987c0a583946966bbe2640fe8b3794b3066cbd93347db57aff2L70-R73)
* Refactored all session accessors (`GetAuth`, `GetAssistant`) and usage sites to use the new typed fields instead of extracting from metadata. (`api/assistant-api/sip/infra/session.go`, `api/assistant-api/sip/sip.go`, `api/assistant-api/sip/infra/server.go`) [[1]](diffhunk://#diff-677d1ba0d4f15987c0a583946966bbe2640fe8b3794b3066cbd93347db57aff2L477-R487) [[2]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243L269-R286) [[3]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243L347-R346) [[4]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243L859-R863) [[5]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243L910-R911)

**Caller ID and outbound call improvements:**

* Ensured `CallerID` is set from the assistant's DID (phone number) for outbound SIP calls, using the assistant's phone deployment options. This value is now used as the SIP `From` URI user, improving reliability and supporting bridge transfers. (`api/assistant-api/sip/sip.go`, `api/assistant-api/sip/infra/server.go`) [[1]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243R447-R452) [[2]](diffhunk://#diff-8dbe45afa186e42a6a8503d884682d73071ca181a741c4945754c9c676979115R1836-R1845) [[3]](diffhunk://#diff-461ed8828ffc5818b175087e0d17b1c653b30cdd52fb2d449aa4f7b10cd64243L1021-R1039)
* Improved error messages and fallback logic for outbound SIP calls, clarifying requirements for `fromPhone`, `caller_id`, or `sip_username`. (`api/assistant-api/sip/infra/server.go`)

These changes improve code safety, reduce the chance of context-related bugs, and provide better support for SIP telephony features.## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Outbound call context is now passed as a typed options payload and telephony APIs accept assistant objects instead of numeric IDs.
  * Session/auth/assistant are strongly typed with explicit getters/setters; conversation IDs are assigned to sessions at creation.

* **Bug Fixes**
  * Caller identity resolution now prefers configured caller_id with assistant phone as fallback, improving From values and call tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->