### PR TITLE
Add SQLite SQL connector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ SQLite is also supported for simpler single-node or demo setups in the Go servic
 ```bash
 SQLITE__PATH=$PWD/.local/rapida/web.db
 SQLITE__MAX_OPEN_CONNECTION=1
-SQLITE__MAX_IDEAL_CONNECTION=1
+SQLITE__MAX_IDLE_CONNECTION=1
 REDIS__HOST=localhost
 REDIS__PORT=6379
 REDIS__MAX_CONNECTION=5

--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ go build -o bin/web ./cmd/web
 
 Requires PostgreSQL, Redis, OpenSearch running separately.
 
+SQLite is also supported for simpler single-node or demo setups in the Go services. Minimal example:
+
+```bash
+SQLITE__PATH=$PWD/.local/rapida/web.db
+SQLITE__MAX_OPEN_CONNECTION=1
+SQLITE__MAX_IDEAL_CONNECTION=1
+REDIS__HOST=localhost
+REDIS__PORT=6379
+REDIS__MAX_CONNECTION=5
+ASSET_STORE__STORAGE_TYPE=local
+ASSET_STORE__STORAGE_PATH_PREFIX=$HOME/rapida-data/assets/web
+go run ./cmd/web
+```
+
+Current caveat: the checked-in SQL migration files are still PostgreSQL-specific, so Go services skip automatic migrations when `SQLITE__*` is selected. SQLite is best suited for local demos, smoke runs, or single-node experiments against an existing compatible schema or with migration needs handled separately.
+
 ### React UI
 
 ```bash

--- a/api/assistant-api/api/assistant-deployment/assistant_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/assistant_deployment.go
@@ -20,7 +20,7 @@ import (
 type AssistantDeploymentApi struct {
 	cfg               *config.AssistantConfig
 	logger            commons.Logger
-	postgres          connectors.PostgresConnector
+	postgres          connectors.SQLConnector
 	deploymentService internal_services.AssistantDeploymentService
 	storage           storages.Storage
 }
@@ -30,7 +30,7 @@ type assistantDeploymentGrpcApi struct {
 }
 
 func NewAssistantDeploymentGRPCApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 ) protos.AssistantDeploymentServiceServer {
 	return &assistantDeploymentGrpcApi{
 		AssistantDeploymentApi: AssistantDeploymentApi{

--- a/api/assistant-api/api/assistant/assistant.go
+++ b/api/assistant-api/api/assistant/assistant.go
@@ -19,7 +19,7 @@ import (
 type assistantApi struct {
 	cfg                       *config.AssistantConfig
 	logger                    commons.Logger
-	postgres                  connectors.PostgresConnector
+	postgres                  connectors.SQLConnector
 	redis                     connectors.RedisConnector
 	opensearch                connectors.OpenSearchConnector
 	vectordb                  connectors.VectorConnector
@@ -38,7 +38,7 @@ type assistantGrpcApi struct {
 }
 
 func NewAssistantGRPCApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	vectordb connectors.VectorConnector,

--- a/api/assistant-api/api/knowledge/indexer.go
+++ b/api/assistant-api/api/knowledge/indexer.go
@@ -19,7 +19,7 @@ import (
 type indexerApi struct {
 	cfg                      *config.AssistantConfig
 	logger                   commons.Logger
-	postgres                 connectors.PostgresConnector
+	postgres                 connectors.SQLConnector
 	redis                    connectors.RedisConnector
 	knowledgeService         internal_services.KnowledgeService
 	indexerServiceClient     document_client.IndexerServiceClient
@@ -31,7 +31,7 @@ type indexerGrpcApi struct {
 }
 
 func NewDocumentGRPCApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 ) knowledge_api.DocumentServiceServer {

--- a/api/assistant-api/api/knowledge/knowledge.go
+++ b/api/assistant-api/api/knowledge/knowledge.go
@@ -19,7 +19,7 @@ import (
 type knowledgeApi struct {
 	cfg                      *config.AssistantConfig
 	logger                   commons.Logger
-	postgres                 connectors.PostgresConnector
+	postgres                 connectors.SQLConnector
 	redis                    connectors.RedisConnector
 	knowledgeService         internal_services.KnowledgeService
 	indexerServiceClient     document_client.IndexerServiceClient
@@ -31,7 +31,7 @@ type knowledgeGrpcApi struct {
 }
 
 func NewKnowledgeGRPCApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 ) knowledge_api.KnowledgeServiceServer {

--- a/api/assistant-api/api/talk/talk.go
+++ b/api/assistant-api/api/talk/talk.go
@@ -36,7 +36,7 @@ import (
 type ConversationApi struct {
 	cfg        *config.AssistantConfig
 	logger     commons.Logger
-	postgres   connectors.PostgresConnector
+	postgres   connectors.SQLConnector
 	redis      connectors.RedisConnector
 	opensearch connectors.OpenSearchConnector
 	storage    storages.Storage
@@ -82,7 +82,7 @@ func (cApi *ConversationApi) Observability(ctx context.Context, auth types.Simpl
 // newConversationApiCore builds the shared ConversationApi. All three public
 // constructors delegate to this so that deps are created exactly once.
 func newConversationApiCore(cfg *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	sipServer *sip_infra.Server,
@@ -147,7 +147,7 @@ func newConversationApiCore(cfg *config.AssistantConfig, logger commons.Logger,
 }
 
 func NewConversationGRPCApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	vectordb connectors.VectorConnector,
@@ -157,7 +157,7 @@ func NewConversationGRPCApi(config *config.AssistantConfig, logger commons.Logge
 }
 
 func NewWebRtcApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	vectordb connectors.VectorConnector,
@@ -172,7 +172,7 @@ func (cApi *ConversationApi) Pipeline() *channel_pipeline.Dispatcher {
 }
 
 func NewConversationApi(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	vectordb connectors.VectorConnector,

--- a/api/assistant-api/config/config.go
+++ b/api/assistant-api/config/config.go
@@ -68,16 +68,17 @@ type AudioSocketConfig struct {
 }
 
 type AssistantConfig struct {
-	config.AppConfig  `mapstructure:",squash"`
-	PostgresConfig    configs.PostgresConfig    `mapstructure:"postgres" validate:"required"`
-	RedisConfig       configs.RedisConfig       `mapstructure:"redis" validate:"required"`
-	OpenSearchConfig  *configs.OpenSearchConfig `mapstructure:"opensearch"`
-	TelemetryConfig   *configs.TelemetryConfig  `mapstructure:"telemetry"`
-	WeaviateConfig    configs.WeaviateConfig    `mapstructure:"weaviate"`
-	AssetStoreConfig  configs.AssetStoreConfig  `mapstructure:"asset_store" validate:"required"`
-	SIPConfig         *SIPConfig                `mapstructure:"sip"`
-	AudioSocketConfig *AudioSocketConfig        `mapstructure:"audiosocket"`
-	WebRTCConfig      *WebRTCConfig             `mapstructure:"webrtc"`
+	config.AppConfig    `mapstructure:",squash"`
+	PostgresConfig      *configs.PostgresConfig   `mapstructure:"postgres"`
+	SQLiteConfig        *configs.SQLiteConfig     `mapstructure:"sqlite"`
+	RedisConfig         configs.RedisConfig       `mapstructure:"redis" validate:"required"`
+	OpenSearchConfig    *configs.OpenSearchConfig `mapstructure:"opensearch"`
+	TelemetryConfig     *configs.TelemetryConfig  `mapstructure:"telemetry"`
+	WeaviateConfig      configs.WeaviateConfig    `mapstructure:"weaviate"`
+	AssetStoreConfig    configs.AssetStoreConfig  `mapstructure:"asset_store" validate:"required"`
+	SIPConfig           *SIPConfig                `mapstructure:"sip"`
+	AudioSocketConfig   *AudioSocketConfig        `mapstructure:"audiosocket"`
+	WebRTCConfig        *WebRTCConfig             `mapstructure:"webrtc"`
 }
 
 // reading config and intializing configs for application
@@ -114,10 +115,28 @@ func GetApplicationConfig(v *viper.Viper) (*AssistantConfig, error) {
 
 	// valdating the app config
 	validate := validator.New()
+	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
+	if err != nil {
+		log.Printf("%+v\n", err)
+		return nil, err
+	}
+	switch cfg := sqlConfig.(type) {
+	case *configs.PostgresConfig:
+		config.PostgresConfig = cfg
+		config.SQLiteConfig = nil
+	case *configs.SQLiteConfig:
+		config.SQLiteConfig = cfg
+		config.PostgresConfig = nil
+	}
+
 	err = validate.Struct(&config)
 	if err != nil {
 		log.Printf("%+v\n", err)
 		return nil, err
 	}
 	return &config, nil
+}
+
+func (c *AssistantConfig) SQLConfig() configs.SQLConfig {
+	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/assistant-api/config/config.go
+++ b/api/assistant-api/config/config.go
@@ -6,6 +6,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -96,9 +98,14 @@ func InitConfig() (*viper.Viper, error) {
 	}
 
 	if err := vConfig.ReadInConfig(); err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("Error while reading the config: %v", err)
+		var notFound viper.ConfigFileNotFoundError
+		if errors.As(err, &notFound) {
+			if path != "" {
+				return nil, fmt.Errorf("read config file from ENV_PATH: %w", err)
+			}
+			return vConfig, nil
 		}
+		return nil, fmt.Errorf("read config: %w", err)
 	}
 
 	return vConfig, nil
@@ -109,16 +116,13 @@ func GetApplicationConfig(v *viper.Viper) (*AssistantConfig, error) {
 	var config AssistantConfig
 	err := v.Unmarshal(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("unmarshal application config: %w", err)
 	}
 
-	// valdating the app config
 	validate := validator.New()
 	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("resolve SQL config: %w", err)
 	}
 	switch cfg := sqlConfig.(type) {
 	case *configs.PostgresConfig:
@@ -131,12 +135,15 @@ func GetApplicationConfig(v *viper.Viper) (*AssistantConfig, error) {
 
 	err = validate.Struct(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("validate application config: %w", err)
 	}
 	return &config, nil
 }
 
 func (c *AssistantConfig) SQLConfig() (configs.SQLConfig, error) {
-	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	cfg, err := configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	if err != nil {
+		return nil, fmt.Errorf("select SQL config: %w", err)
+	}
+	return cfg, nil
 }

--- a/api/assistant-api/config/config.go
+++ b/api/assistant-api/config/config.go
@@ -137,6 +137,6 @@ func GetApplicationConfig(v *viper.Viper) (*AssistantConfig, error) {
 	return &config, nil
 }
 
-func (c *AssistantConfig) SQLConfig() configs.SQLConfig {
+func (c *AssistantConfig) SQLConfig() (configs.SQLConfig, error) {
 	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/assistant-api/config/config_test.go
+++ b/api/assistant-api/config/config_test.go
@@ -136,8 +136,10 @@ func TestGetApplicationConfig(t *testing.T) {
 		t.Fatalf("appConfig is nil")
 	}
 
-	if appConfig.PostgresConfig.DBName != "assistant_db" {
-		t.Errorf("Expected PostgresConfig.DBName to be 'assistant_db', but got %v", appConfig.PostgresConfig.DBName)
+	if appConfig.PostgresConfig == nil {
+		t.Fatalf("Expected PostgresConfig to be populated, got nil")
+	} else if appConfig.PostgresConfig.DBName != "assistant_db" {
+		t.Errorf("Expected PostgresConfig.DBName to be 'assistant_db', but got %q", appConfig.PostgresConfig.DBName)
 	}
 	if appConfig.AssetStoreConfig.StorageType != "local" {
 		t.Errorf("Expected AssetStoreConfig.StorageType to be 'local', but got %v", appConfig.AssetStoreConfig.StorageType)
@@ -238,5 +240,87 @@ telemetry:
 
 	if _, err := GetApplicationConfig(v); err == nil {
 		t.Fatalf("expected incomplete telemetry opensearch config to fail validation")
+	}
+}
+
+func TestGetApplicationConfig_SQLite(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "workflow-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9007)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "assistant.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "127.0.0.1")
+	vConfig.Set("REDIS__PORT", 6379)
+	vConfig.Set("REDIS__MAX_CONNECTION", 10)
+	vConfig.Set("REDIS__MAX_DB", 0)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/workflow")
+
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	appConfig, err := GetApplicationConfig(vConfig)
+	if err != nil {
+		t.Fatalf("GetApplicationConfig returned an error: %v", err)
+	}
+	if appConfig.SQLiteConfig == nil || appConfig.SQLiteConfig.Path == "" {
+		t.Fatalf("expected SQLiteConfig to be populated, got %#v", appConfig.SQLiteConfig)
+	}
+	if appConfig.PostgresConfig != nil {
+		t.Fatalf("expected PostgresConfig to be nil when sqlite is selected")
+	}
+}
+
+func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "workflow-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9007)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("POSTGRES__HOST", "localhost")
+	vConfig.Set("POSTGRES__DB_NAME", "assistant_db")
+	vConfig.Set("POSTGRES__AUTH__USER", "rapida_user")
+	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
+	vConfig.Set("POSTGRES__PORT", 5432)
+	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 50)
+	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 25)
+	vConfig.Set("POSTGRES__SSL_MODE", "disable")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "assistant.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "127.0.0.1")
+	vConfig.Set("REDIS__PORT", 6379)
+	vConfig.Set("REDIS__MAX_CONNECTION", 10)
+	vConfig.Set("REDIS__MAX_DB", 0)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/workflow")
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	_, err := GetApplicationConfig(vConfig)
+	if err == nil || !strings.Contains(err.Error(), "set only one") {
+		t.Fatalf("expected multi-sql validation error, got %v", err)
 	}
 }

--- a/api/assistant-api/config/config_test.go
+++ b/api/assistant-api/config/config_test.go
@@ -32,7 +32,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 50
-  max_ideal_connection: 25
+  max_idle_connection: 25
   ssl_mode: "disable"
 
 redis:
@@ -254,7 +254,7 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "assistant.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "127.0.0.1")
 	vConfig.Set("REDIS__PORT", 6379)
@@ -264,12 +264,12 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/workflow")
 
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	appConfig, err := GetApplicationConfig(vConfig)
 	if err != nil {
@@ -298,12 +298,12 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
 	vConfig.Set("POSTGRES__PORT", 5432)
 	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 50)
-	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 25)
+	vConfig.Set("POSTGRES__MAX_IDLE_CONNECTION", 25)
 	vConfig.Set("POSTGRES__SSL_MODE", "disable")
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "assistant.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "127.0.0.1")
 	vConfig.Set("REDIS__PORT", 6379)
@@ -312,12 +312,12 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/workflow")
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	_, err := GetApplicationConfig(vConfig)
 	if err == nil || !strings.Contains(err.Error(), "set only one") {

--- a/api/assistant-api/internal/adapters/internal/requestor.go
+++ b/api/assistant-api/internal/adapters/internal/requestor.go
@@ -74,7 +74,7 @@ type genericRequestor struct {
 	assistantToolService internal_services.AssistantToolService
 
 	//
-	postgres      connectors.PostgresConnector
+	postgres      connectors.SQLConnector
 	opensearch    connectors.OpenSearchConnector
 	vectordb      connectors.VectorConnector
 	queryEmbedder internal_agent_embeddings.QueryEmbedding
@@ -139,7 +139,7 @@ func NewGenericRequestor(
 	ctx context.Context,
 	config *config.AssistantConfig,
 	logger commons.Logger, source utils.RapidaSource,
-	postgres connectors.PostgresConnector, opensearch connectors.OpenSearchConnector,
+	postgres connectors.SQLConnector, opensearch connectors.OpenSearchConnector,
 	redis connectors.RedisConnector, storage storages.Storage, streamer internal_type.Streamer,
 	observer observability.Recorder,
 ) *genericRequestor {

--- a/api/assistant-api/internal/adapters/request.go
+++ b/api/assistant-api/internal/adapters/request.go
@@ -24,7 +24,7 @@ type TalkerOptions struct {
 	Context    context.Context
 	Config     *config.AssistantConfig
 	Logger     commons.Logger
-	Postgres   connectors.PostgresConnector
+	Postgres   connectors.SQLConnector
 	OpenSearch connectors.OpenSearchConnector
 	Redis      connectors.RedisConnector
 	Storage    storages.Storage
@@ -58,7 +58,7 @@ func WithLogger(logger commons.Logger) FuncOption {
 	}
 }
 
-func WithPostgres(postgres connectors.PostgresConnector) FuncOption {
+func WithPostgres(postgres connectors.SQLConnector) FuncOption {
 	return func(options *TalkerOptions) {
 		options.Postgres = postgres
 	}

--- a/api/assistant-api/internal/adapters/request_test.go
+++ b/api/assistant-api/internal/adapters/request_test.go
@@ -219,8 +219,8 @@ func TestIdentifierFunctions_AllTypes(t *testing.T) {
 
 // Test expected constructor shape
 func TestNewTalkerFunction_Signature(t *testing.T) {
-	// New accepts functional options that populate TalkerOptions and returns:
-	// (internal_type.Talking, error)
+	// New accepts functional options that populate TalkerOptions (including SQLConnector)
+	// and returns (internal_type.Talking, error).
 
 	t.Run("New accepts functional options", func(t *testing.T) {
 		assert.True(t, true) // Function exists in package

--- a/api/assistant-api/internal/callcontext/store.go
+++ b/api/assistant-api/internal/callcontext/store.go
@@ -18,7 +18,7 @@ import (
 	"github.com/rapidaai/pkg/validator"
 )
 
-// Store provides operations to save and retrieve call contexts from Postgres.
+// Store provides operations to save and retrieve call contexts from the SQL backend.
 //
 // Call contexts bridge the HTTP call-setup request and the media connection.
 // Save creates PENDING; Claim atomically marks the context consumed by the media
@@ -43,25 +43,25 @@ type CallStatusUpdate struct {
 	ProviderStatusCode int
 }
 
-type postgresStore struct {
-	postgres connectors.SQLConnector
-	logger   commons.Logger
+type sqlStore struct {
+	sql    connectors.SQLConnector
+	logger commons.Logger
 }
 
-func NewStore(postgres connectors.SQLConnector, logger commons.Logger) Store {
-	return &postgresStore{
-		postgres: postgres,
-		logger:   logger,
+func NewStore(sql connectors.SQLConnector, logger commons.Logger) Store {
+	return &sqlStore{
+		sql:    sql,
+		logger: logger,
 	}
 }
 
-func (s *postgresStore) Save(ctx context.Context, cc *CallContext) (string, error) {
+func (s *sqlStore) Save(ctx context.Context, cc *CallContext) (string, error) {
 	if cc.ContextID == "" {
 		cc.ContextID = uuid.New().String()
 	}
 	cc.Status = StatusPending
 
-	db := s.postgres.DB(ctx)
+	db := s.sql.DB(ctx)
 	if err := db.Create(cc).Error; err != nil {
 		return "", fmt.Errorf("failed to save call context %s: %w", cc.ContextID, err)
 	}
@@ -72,8 +72,8 @@ func (s *postgresStore) Save(ctx context.Context, cc *CallContext) (string, erro
 	return cc.ContextID, nil
 }
 
-func (s *postgresStore) Get(ctx context.Context, contextID string) (*CallContext, error) {
-	db := s.postgres.DB(ctx)
+func (s *sqlStore) Get(ctx context.Context, contextID string) (*CallContext, error) {
+	db := s.sql.DB(ctx)
 	var cc CallContext
 	if err := db.Where("context_id = ?", contextID).First(&cc).Error; err != nil {
 		return nil, fmt.Errorf("call context not found: %s: %w", contextID, err)
@@ -81,7 +81,7 @@ func (s *postgresStore) Get(ctx context.Context, contextID string) (*CallContext
 	return &cc, nil
 }
 
-func (s *postgresStore) GetByChannelUUID(ctx context.Context, provider string, assistantID uint64, channelUUID string) (*CallContext, error) {
+func (s *sqlStore) GetByChannelUUID(ctx context.Context, provider string, assistantID uint64, channelUUID string) (*CallContext, error) {
 	if !validator.NotBlank(provider) {
 		return nil, fmt.Errorf("provider is required to get call context by channel uuid")
 	}
@@ -92,7 +92,7 @@ func (s *postgresStore) GetByChannelUUID(ctx context.Context, provider string, a
 		return nil, fmt.Errorf("channel uuid is required to get call context")
 	}
 
-	db := s.postgres.DB(ctx)
+	db := s.sql.DB(ctx)
 	var cc CallContext
 	if err := db.
 		Where("provider = ? AND assistant_id = ? AND channel_uuid = ?", provider, assistantID, channelUUID).
@@ -104,8 +104,8 @@ func (s *postgresStore) GetByChannelUUID(ctx context.Context, provider string, a
 }
 
 // Claim atomically transitions PENDING → CLAIMED in a single query.
-func (s *postgresStore) Claim(ctx context.Context, contextID string) (*CallContext, error) {
-	db := s.postgres.DB(ctx)
+func (s *sqlStore) Claim(ctx context.Context, contextID string) (*CallContext, error) {
+	db := s.sql.DB(ctx)
 
 	var cc CallContext
 	result := db.Raw(`
@@ -129,8 +129,8 @@ func (s *postgresStore) Claim(ctx context.Context, contextID string) (*CallConte
 	return &cc, nil
 }
 
-func (s *postgresStore) UpdateField(ctx context.Context, contextID, field, value string) error {
-	db := s.postgres.DB(ctx)
+func (s *sqlStore) UpdateField(ctx context.Context, contextID, field, value string) error {
+	db := s.sql.DB(ctx)
 
 	allowed := map[string]bool{
 		"channel_uuid": true,
@@ -155,8 +155,8 @@ func (s *postgresStore) UpdateField(ctx context.Context, contextID, field, value
 	return nil
 }
 
-func (s *postgresStore) UpdateCallStatus(ctx context.Context, contextID string, status CallStatusUpdate) error {
-	db := s.postgres.DB(ctx)
+func (s *sqlStore) UpdateCallStatus(ctx context.Context, contextID string, status CallStatusUpdate) error {
+	db := s.sql.DB(ctx)
 	updates := map[string]interface{}{
 		"call_status":          status.CallStatus,
 		"call_error":           status.CallError,

--- a/api/assistant-api/internal/callcontext/store.go
+++ b/api/assistant-api/internal/callcontext/store.go
@@ -44,11 +44,11 @@ type CallStatusUpdate struct {
 }
 
 type postgresStore struct {
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	logger   commons.Logger
 }
 
-func NewStore(postgres connectors.PostgresConnector, logger commons.Logger) Store {
+func NewStore(postgres connectors.SQLConnector, logger commons.Logger) Store {
 	return &postgresStore{
 		postgres: postgres,
 		logger:   logger,

--- a/api/assistant-api/internal/callcontext/store_test.go
+++ b/api/assistant-api/internal/callcontext/store_test.go
@@ -10,18 +10,18 @@ import (
 	"gorm.io/gorm"
 )
 
-type testPostgresConnector struct {
+type testSQLConnector struct {
 	db *gorm.DB
 }
 
-func (t *testPostgresConnector) Connect(ctx context.Context) error    { return nil }
-func (t *testPostgresConnector) Name() string                         { return "test-postgres" }
-func (t *testPostgresConnector) IsConnected(ctx context.Context) bool { return t.db != nil }
-func (t *testPostgresConnector) Disconnect(ctx context.Context) error { return nil }
-func (t *testPostgresConnector) Query(ctx context.Context, qry string, dest interface{}) error {
+func (t *testSQLConnector) Connect(ctx context.Context) error    { return nil }
+func (t *testSQLConnector) Name() string                         { return "test-sql" }
+func (t *testSQLConnector) IsConnected(ctx context.Context) bool { return t.db != nil }
+func (t *testSQLConnector) Disconnect(ctx context.Context) error { return nil }
+func (t *testSQLConnector) Query(ctx context.Context, qry string, dest interface{}) error {
 	return t.db.WithContext(ctx).Raw(qry).Scan(dest).Error
 }
-func (t *testPostgresConnector) DB(ctx context.Context) *gorm.DB { return t.db.WithContext(ctx) }
+func (t *testSQLConnector) DB(ctx context.Context) *gorm.DB { return t.db.WithContext(ctx) }
 
 func newTestStore(t *testing.T) (Store, context.Context) {
 	t.Helper()
@@ -70,7 +70,39 @@ func newTestStore(t *testing.T) (Store, context.Context) {
 		t.Fatalf("failed to create logger: %v", err)
 	}
 
-	return NewStore(&testPostgresConnector{db: db}, logger), context.Background()
+	sql := &testSQLConnector{db: db}
+	return NewStore(sql, logger), context.Background()
+}
+
+func TestNewStoreWiresSQLConnector(t *testing.T) {
+	store, _ := newTestStore(t)
+	if _, ok := store.(*sqlStore); !ok {
+		t.Fatalf("NewStore returned %T, want *sqlStore", store)
+	}
+}
+
+func TestStoreGetNotFound(t *testing.T) {
+	store, ctx := newTestStore(t)
+	_, err := store.Get(ctx, "missing-context-id")
+	if err == nil {
+		t.Fatal("expected error for missing context")
+	}
+	if !contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && stringIndex(s, sub) >= 0)
+}
+
+func stringIndex(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestStoreUpdateCallStatus(t *testing.T) {

--- a/api/assistant-api/internal/services/assistant/assistant.deployment.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/assistant.deployment.impl.service.go
@@ -25,13 +25,13 @@ import (
 
 type assistantDeploymentService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	cfg      *config.AssistantConfig
 }
 
 func NewAssistantDeploymentService(cfg *config.AssistantConfig,
 	logger commons.Logger,
-	postgres connectors.PostgresConnector) internal_services.AssistantDeploymentService {
+	postgres connectors.SQLConnector) internal_services.AssistantDeploymentService {
 	return &assistantDeploymentService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/assistant-api/internal/services/assistant/assistant.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/assistant.impl.service.go
@@ -28,12 +28,12 @@ import (
 
 type assistantService struct {
 	logger     commons.Logger
-	postgres   connectors.PostgresConnector
+	postgres   connectors.SQLConnector
 	opensearch connectors.OpenSearchConnector
 	cfg        *config.AssistantConfig
 }
 
-func NewAssistantService(cfg *config.AssistantConfig, logger commons.Logger, postgres connectors.PostgresConnector, opensearch connectors.OpenSearchConnector) internal_services.AssistantService {
+func NewAssistantService(cfg *config.AssistantConfig, logger commons.Logger, postgres connectors.SQLConnector, opensearch connectors.OpenSearchConnector) internal_services.AssistantService {
 	return &assistantService{
 		logger:     logger,
 		postgres:   postgres,

--- a/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
@@ -27,13 +27,13 @@ import (
 
 type assistantConversationService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	storage  storages.Storage
 }
 
 func NewAssistantConversationService(
 	logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	storage storages.Storage) internal_services.AssistantConversationService {
 	return &assistantConversationService{
 		logger:   logger,

--- a/api/assistant-api/internal/services/assistant/knowledge.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/knowledge.impl.service.go
@@ -27,7 +27,7 @@ import (
 
 type assistantKnowledgeService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	storage  storages.Storage
 }
 
@@ -230,7 +230,7 @@ func (eService *assistantKnowledgeService) Update(ctx context.Context, auth type
 }
 
 func NewAssistantKnowledgeService(logger commons.Logger,
-	postgres connectors.PostgresConnector, storage storages.Storage) internal_services.AssistantKnowledgeService {
+	postgres connectors.SQLConnector, storage storages.Storage) internal_services.AssistantKnowledgeService {
 	return &assistantKnowledgeService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/assistant-api/internal/services/assistant/tool.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/tool.impl.service.go
@@ -28,7 +28,7 @@ import (
 
 type assistantToolService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	storage  storages.Storage
 }
 
@@ -277,7 +277,7 @@ func (eService *assistantToolService) CreateOrUpdateExecutionOption(
 	return mtrs, nil
 }
 
-func NewAssistantToolService(logger commons.Logger, postgres connectors.PostgresConnector, storage storages.Storage) internal_services.AssistantToolService {
+func NewAssistantToolService(logger commons.Logger, postgres connectors.SQLConnector, storage storages.Storage) internal_services.AssistantToolService {
 	return &assistantToolService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/assistant-api/internal/services/knowledge/document.impl.service.go
+++ b/api/assistant-api/internal/services/knowledge/document.impl.service.go
@@ -34,7 +34,7 @@ import (
 type knowledgeDocumentService struct {
 	config     *config.AssistantConfig
 	logger     commons.Logger
-	postgres   connectors.PostgresConnector
+	postgres   connectors.SQLConnector
 	opensearch connectors.OpenSearchConnector
 	storage    storages.Storage
 }
@@ -43,7 +43,7 @@ var (
 	KNOWLEDGE_DOCUMENT_PREFIX = "knowledge-document__"
 )
 
-func NewKnowledgeDocumentService(config *config.AssistantConfig, logger commons.Logger, postgres connectors.PostgresConnector, opensearch connectors.OpenSearchConnector) internal_services.KnowledgeDocumentService {
+func NewKnowledgeDocumentService(config *config.AssistantConfig, logger commons.Logger, postgres connectors.SQLConnector, opensearch connectors.OpenSearchConnector) internal_services.KnowledgeDocumentService {
 	return &knowledgeDocumentService{
 		config:     config,
 		logger:     logger,

--- a/api/assistant-api/internal/services/knowledge/knowledge.impl.service.go
+++ b/api/assistant-api/internal/services/knowledge/knowledge.impl.service.go
@@ -29,12 +29,12 @@ import (
 type knowledgeService struct {
 	logger   commons.Logger
 	config   *config.AssistantConfig
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	storage  storages.Storage
 }
 
 func NewKnowledgeService(config *config.AssistantConfig,
-	logger commons.Logger, postgres connectors.PostgresConnector, storage storages.Storage) internal_services.KnowledgeService {
+	logger commons.Logger, postgres connectors.SQLConnector, storage storages.Storage) internal_services.KnowledgeService {
 	return &knowledgeService{
 		logger:   logger,
 		config:   config,

--- a/api/assistant-api/router/assistant.go
+++ b/api/assistant-api/router/assistant.go
@@ -25,7 +25,7 @@ func AssistantApiRoute(
 	S *grpc.Server,
 	engine *gin.Engine,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 	Opensearch connectors.OpenSearchConnector,
 ) {
@@ -64,7 +64,7 @@ func AssistantDeploymentApiRoute(Cfg *config.AssistantConfig,
 	S *grpc.Server,
 	engine *gin.Engine,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector) {
+	Postgres connectors.SQLConnector) {
 	workflow_api.RegisterAssistantDeploymentServiceServer(S,
 		assistantDeploymentApi.NewAssistantDeploymentGRPCApi(Cfg,
 			Logger,
@@ -94,7 +94,7 @@ func AssistantConversationApiRoute(
 	Cfg *config.AssistantConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 	Opensearch connectors.OpenSearchConnector,
 	sipServer *sip_infra.Server,
@@ -121,7 +121,7 @@ func AssistantConversationApiRoute(
 
 func TalkApiRoute(
 	cfg *config.AssistantConfig, engine *gin.Engine, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	sipServer *sip_infra.Server,

--- a/api/assistant-api/router/health_check.go
+++ b/api/assistant-api/router/health_check.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rapidaai/pkg/connectors"
 )
 
-func HealthCheckRoutes(cfg *config.AssistantConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.PostgresConnector) {
+func HealthCheckRoutes(cfg *config.AssistantConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.SQLConnector) {
 	logger.Info("Internal HealthCheckRoutes and Connectors added to engine.")
 	apiv1 := engine.Group("")
 	hcApi := healthCheckApi.New(cfg, logger, postgres)

--- a/api/assistant-api/router/knowledge.go
+++ b/api/assistant-api/router/knowledge.go
@@ -18,7 +18,7 @@ func KnowledgeApiRoute(
 	Cfg *config.AssistantConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 	Opensearch connectors.OpenSearchConnector,
 ) {
@@ -35,7 +35,7 @@ func DocumentApiRoute(
 	Cfg *config.AssistantConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 	Opensearch connectors.OpenSearchConnector,
 

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -37,7 +37,7 @@ type SIPEngine struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	postgres   connectors.PostgresConnector
+	postgres   connectors.SQLConnector
 	redis      connectors.RedisConnector
 	opensearch connectors.OpenSearchConnector
 	storage    storages.Storage
@@ -63,7 +63,7 @@ type SIPEngine struct {
 }
 
 func NewSIPEngine(config *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 	vectordb connectors.VectorConnector) *SIPEngine {

--- a/api/assistant-api/socket/socket.go
+++ b/api/assistant-api/socket/socket.go
@@ -39,7 +39,7 @@ import (
 type audioSocketEngine struct {
 	logger     commons.Logger
 	cfg        *config.AssistantConfig
-	postgres   connectors.PostgresConnector
+	postgres   connectors.SQLConnector
 	redis      connectors.RedisConnector
 	opensearch connectors.OpenSearchConnector
 	storage    storages.Storage
@@ -57,7 +57,7 @@ type audioSocketEngine struct {
 }
 
 func NewAudioSocketEngine(cfg *config.AssistantConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 	opensearch connectors.OpenSearchConnector,
 ) *audioSocketEngine {

--- a/api/endpoint-api/api/endpoint.go
+++ b/api/endpoint-api/api/endpoint.go
@@ -18,7 +18,7 @@ import (
 type endpointApi struct {
 	cfg                *config.EndpointConfig
 	logger             commons.Logger
-	postgres           connectors.PostgresConnector
+	postgres           connectors.SQLConnector
 	endpointService    internal_services.EndpointService
 	endpointLogService internal_services.EndpointLogService
 }
@@ -28,7 +28,7 @@ type endpointGRPCApi struct {
 }
 
 func NewEndpointGRPCApi(config *config.EndpointConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 ) protos.EndpointServiceServer {
 	return &endpointGRPCApi{

--- a/api/endpoint-api/api/invoker-endpoint.go
+++ b/api/endpoint-api/api/invoker-endpoint.go
@@ -29,7 +29,7 @@ import (
 type invokerApi struct {
 	cfg                *config.EndpointConfig
 	logger             commons.Logger
-	postgres           connectors.PostgresConnector
+	postgres           connectors.SQLConnector
 	endpointService    internal_services.EndpointService
 	endpointLogService internal_services.EndpointLogService
 	integrationClient  integration_client.IntegrationServiceClient
@@ -42,7 +42,7 @@ type invokerGRPCApi struct {
 }
 
 func NewInvokerGRPCApi(config *config.EndpointConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector, redis connectors.RedisConnector,
+	postgres connectors.SQLConnector, redis connectors.RedisConnector,
 ) invoker_api.DeploymentServer {
 	return &invokerGRPCApi{
 		invokerApi{

--- a/api/endpoint-api/config/config.go
+++ b/api/endpoint-api/config/config.go
@@ -81,6 +81,6 @@ func GetApplicationConfig(v *viper.Viper) (*EndpointConfig, error) {
 	return &config, nil
 }
 
-func (c *EndpointConfig) SQLConfig() configs.SQLConfig {
+func (c *EndpointConfig) SQLConfig() (configs.SQLConfig, error) {
 	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/endpoint-api/config/config.go
+++ b/api/endpoint-api/config/config.go
@@ -19,7 +19,8 @@ import (
 // Application config structure
 type EndpointConfig struct {
 	config.AppConfig `mapstructure:",squash"`
-	PostgresConfig   configs.PostgresConfig   `mapstructure:"postgres" validate:"required"`
+	PostgresConfig   *configs.PostgresConfig  `mapstructure:"postgres"`
+	SQLiteConfig     *configs.SQLiteConfig    `mapstructure:"sqlite"`
 	RedisConfig      configs.RedisConfig      `mapstructure:"redis" validate:"required"`
 	AssetStoreConfig configs.AssetStoreConfig `mapstructure:"asset_store" validate:"required"`
 }
@@ -58,10 +59,28 @@ func GetApplicationConfig(v *viper.Viper) (*EndpointConfig, error) {
 
 	// valdating the app config
 	validate := validator.New()
+	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
+	if err != nil {
+		log.Printf("%+v\n", err)
+		return nil, err
+	}
+	switch cfg := sqlConfig.(type) {
+	case *configs.PostgresConfig:
+		config.PostgresConfig = cfg
+		config.SQLiteConfig = nil
+	case *configs.SQLiteConfig:
+		config.SQLiteConfig = cfg
+		config.PostgresConfig = nil
+	}
+
 	err = validate.Struct(&config)
 	if err != nil {
 		log.Printf("%+v\n", err)
 		return nil, err
 	}
 	return &config, nil
+}
+
+func (c *EndpointConfig) SQLConfig() configs.SQLConfig {
+	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/endpoint-api/config/config.go
+++ b/api/endpoint-api/config/config.go
@@ -6,6 +6,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 
@@ -40,9 +42,14 @@ func InitConfig() (*viper.Viper, error) {
 	}
 
 	if err := vConfig.ReadInConfig(); err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("Error while reading the config: %v", err)
+		var notFound viper.ConfigFileNotFoundError
+		if errors.As(err, &notFound) {
+			if path != "" {
+				return nil, fmt.Errorf("read config file from ENV_PATH: %w", err)
+			}
+			return vConfig, nil
 		}
+		return nil, fmt.Errorf("read config: %w", err)
 	}
 
 	return vConfig, nil
@@ -53,16 +60,13 @@ func GetApplicationConfig(v *viper.Viper) (*EndpointConfig, error) {
 	var config EndpointConfig
 	err := v.Unmarshal(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("unmarshal application config: %w", err)
 	}
 
-	// valdating the app config
 	validate := validator.New()
 	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("resolve SQL config: %w", err)
 	}
 	switch cfg := sqlConfig.(type) {
 	case *configs.PostgresConfig:
@@ -75,12 +79,15 @@ func GetApplicationConfig(v *viper.Viper) (*EndpointConfig, error) {
 
 	err = validate.Struct(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("validate application config: %w", err)
 	}
 	return &config, nil
 }
 
 func (c *EndpointConfig) SQLConfig() (configs.SQLConfig, error) {
-	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	cfg, err := configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	if err != nil {
+		return nil, fmt.Errorf("select SQL config: %w", err)
+	}
+	return cfg, nil
 }

--- a/api/endpoint-api/config/config_test.go
+++ b/api/endpoint-api/config/config_test.go
@@ -110,8 +110,10 @@ func TestGetApplicationConfig(t *testing.T) {
 		t.Fatalf("appConfig is nil")
 	}
 
-	if appConfig.PostgresConfig.DBName != "endpoint_db" {
-		t.Errorf("Expected PostgresConfig.DBName to be 'endpoint_db', but got %v", appConfig.PostgresConfig.DBName)
+	if appConfig.PostgresConfig == nil {
+		t.Fatalf("Expected PostgresConfig to be populated, got nil")
+	} else if appConfig.PostgresConfig.DBName != "endpoint_db" {
+		t.Errorf("Expected PostgresConfig.DBName to be 'endpoint_db', but got %q", appConfig.PostgresConfig.DBName)
 	}
 	if appConfig.AssetStoreConfig.StorageType != "local" {
 		t.Errorf("Expected AssetStoreConfig.StorageType to be 'local', but got %v", appConfig.AssetStoreConfig.StorageType)
@@ -136,5 +138,84 @@ func TestGetApplicationConfig(t *testing.T) {
 	}
 	if appConfig.Ui.Host != "http://localhost:3000" {
 		t.Errorf("Expected Ui.Host to be 'http://localhost:3000', but got %v", appConfig.Ui.Host)
+	}
+}
+
+func TestGetApplicationConfig_SQLite(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "endpoint-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9005)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "endpoint.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/endpoint")
+
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	appConfig, err := GetApplicationConfig(vConfig)
+	if err != nil {
+		t.Fatalf("GetApplicationConfig returned an error: %v", err)
+	}
+	if appConfig.SQLiteConfig == nil || appConfig.SQLiteConfig.Path == "" {
+		t.Fatalf("expected SQLiteConfig to be populated, got %#v", appConfig.SQLiteConfig)
+	}
+	if appConfig.PostgresConfig != nil {
+		t.Fatalf("expected PostgresConfig to be nil when sqlite is selected")
+	}
+}
+
+func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "endpoint-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9005)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("POSTGRES__HOST", "localhost")
+	vConfig.Set("POSTGRES__DB_NAME", "endpoint_db")
+	vConfig.Set("POSTGRES__AUTH__USER", "rapida_user")
+	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
+	vConfig.Set("POSTGRES__PORT", 5432)
+	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__SSL_MODE", "disable")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "endpoint.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/endpoint")
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	_, err := GetApplicationConfig(vConfig)
+	if err == nil || !strings.Contains(err.Error(), "set only one") {
+		t.Fatalf("expected multi-sql validation error, got %v", err)
 	}
 }

--- a/api/endpoint-api/config/config_test.go
+++ b/api/endpoint-api/config/config_test.go
@@ -31,7 +31,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
 
 redis:
@@ -152,7 +152,7 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "endpoint.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
@@ -161,12 +161,12 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/endpoint")
 
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	appConfig, err := GetApplicationConfig(vConfig)
 	if err != nil {
@@ -195,24 +195,24 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
 	vConfig.Set("POSTGRES__PORT", 5432)
 	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
-	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDLE_CONNECTION", 10)
 	vConfig.Set("POSTGRES__SSL_MODE", "disable")
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "endpoint.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
 	vConfig.Set("REDIS__MAX_CONNECTION", 5)
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/endpoint")
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	_, err := GetApplicationConfig(vConfig)
 	if err == nil || !strings.Contains(err.Error(), "set only one") {

--- a/api/endpoint-api/config/init_config_test.go
+++ b/api/endpoint-api/config/init_config_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2023-2025 RapidaAI
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestInitConfig_ENVPathMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Setenv("ENV_PATH", missing)
+
+	_, err := InitConfig()
+	if err == nil {
+		t.Fatal("expected error when ENV_PATH points to missing file")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("expected wrapped read error, got %v", err)
+	}
+}
+
+func TestInitConfig_ENVPathInvalidYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.yaml")
+	if err := os.WriteFile(path, []byte("not: valid: yaml: [[["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ENV_PATH", path)
+
+	_, err := InitConfig()
+	if err == nil {
+		t.Fatal("expected read config error for invalid yaml")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("expected wrapped read error, got %v", err)
+	}
+}
+
+func TestInitConfig_DefaultPathMissingAllowed(t *testing.T) {
+	t.Setenv("ENV_PATH", "")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	v, err := InitConfig()
+	if err != nil {
+		t.Fatalf("expected nil error when default config file is missing, got %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected viper instance")
+	}
+}
+
+func TestEndpointConfig_SQLConfig_Postgres(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(baseEndpointYAML)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := GetApplicationConfig(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql, err := cfg.SQLConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sql.DriverName() != "postgres" {
+		t.Fatalf("DriverName() = %q, want postgres", sql.DriverName())
+	}
+}
+
+func TestEndpointConfig_SQLConfig_NoBackend(t *testing.T) {
+	cfg := &EndpointConfig{}
+	_, err := cfg.SQLConfig()
+	if err == nil {
+		t.Fatal("expected error when no SQL backend configured")
+	}
+	if !strings.Contains(err.Error(), "select SQL config") {
+		t.Fatalf("expected select SQL config wrap, got %v", err)
+	}
+}

--- a/api/endpoint-api/internal/service/endpoint/service.go
+++ b/api/endpoint-api/internal/service/endpoint/service.go
@@ -22,10 +22,10 @@ import (
 type endpointService struct {
 	cfg      *config.EndpointConfig
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewEndpointService(cfg *config.EndpointConfig, logger commons.Logger, postgres connectors.PostgresConnector) internal_service.EndpointService {
+func NewEndpointService(cfg *config.EndpointConfig, logger commons.Logger, postgres connectors.SQLConnector) internal_service.EndpointService {
 	return &endpointService{
 		cfg:      cfg,
 		logger:   logger,

--- a/api/endpoint-api/internal/service/log/service.go
+++ b/api/endpoint-api/internal/service/log/service.go
@@ -23,10 +23,10 @@ import (
 
 type endpointLogService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewEndpointLogService(logger commons.Logger, postgres connectors.PostgresConnector) internal_service.EndpointLogService {
+func NewEndpointLogService(logger commons.Logger, postgres connectors.SQLConnector) internal_service.EndpointLogService {
 	return &endpointLogService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/endpoint-api/router/endpoint.go
+++ b/api/endpoint-api/router/endpoint.go
@@ -14,7 +14,7 @@ func EndpointReaderApiRoute(
 	Cfg *config.EndpointConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 
 ) {
@@ -25,7 +25,7 @@ func InvokeApiRoute(
 	Cfg *config.EndpointConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 ) {
 	protos.RegisterDeploymentServer(S, endpoint_api.NewInvokerGRPCApi(Cfg, Logger, Postgres, Redis))

--- a/api/endpoint-api/router/health_check.go
+++ b/api/endpoint-api/router/health_check.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rapidaai/pkg/connectors"
 )
 
-func HealthCheckRoutes(cfg *config.EndpointConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.PostgresConnector) {
+func HealthCheckRoutes(cfg *config.EndpointConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.SQLConnector) {
 	logger.Info("Internal HealthCheckRoutes and Connectors added to engine.")
 	apiv1 := engine.Group("")
 	hcApi := healthCheckApi.New(cfg, logger, postgres)

--- a/api/integration-api/api/audit_logging.go
+++ b/api/integration-api/api/audit_logging.go
@@ -25,7 +25,7 @@ type auditLoggingGRPCApi struct {
 	auditLoggingApi
 }
 
-func NewAuditLoggingGRPC(config *config.IntegrationConfig, logger commons.Logger, postgres connectors.PostgresConnector) integration_api.AuditLoggingServiceServer {
+func NewAuditLoggingGRPC(config *config.IntegrationConfig, logger commons.Logger, postgres connectors.SQLConnector) integration_api.AuditLoggingServiceServer {
 	return &auditLoggingGRPCApi{
 		auditLoggingApi{
 			integrationApi: NewInegrationApi(config, logger, postgres),

--- a/api/integration-api/api/integration.go
+++ b/api/integration-api/api/integration.go
@@ -30,7 +30,7 @@ type integrationApi struct {
 	auditService internal_services.AuditService
 }
 
-func NewInegrationApi(cfg *config.IntegrationConfig, logger commons.Logger, postgres connectors.PostgresConnector) integrationApi {
+func NewInegrationApi(cfg *config.IntegrationConfig, logger commons.Logger, postgres connectors.SQLConnector) integrationApi {
 	return integrationApi{cfg: cfg, logger: logger,
 		storage:      storage_files.NewStorage(cfg.AssetStoreConfig, logger),
 		auditService: internal_audit_service.NewAuditService(logger, postgres)}

--- a/api/integration-api/api/unified_provider.go
+++ b/api/integration-api/api/unified_provider.go
@@ -22,7 +22,7 @@ type unifiedProviderGRPCApi struct {
 	integrationApi
 }
 
-func NewUnifiedProviderGRPC(cfg *config.IntegrationConfig, logger commons.Logger, postgres connectors.PostgresConnector) protos.UnifiedProviderServiceServer {
+func NewUnifiedProviderGRPC(cfg *config.IntegrationConfig, logger commons.Logger, postgres connectors.SQLConnector) protos.UnifiedProviderServiceServer {
 	return &unifiedProviderGRPCApi{
 		integrationApi: NewInegrationApi(cfg, logger, postgres),
 	}

--- a/api/integration-api/config/config.go
+++ b/api/integration-api/config/config.go
@@ -14,7 +14,8 @@ import (
 // Application config structure
 type IntegrationConfig struct {
 	config.AppConfig `mapstructure:",squash"`
-	PostgresConfig   configs.PostgresConfig   `mapstructure:"postgres" validate:"required"`
+	PostgresConfig   *configs.PostgresConfig  `mapstructure:"postgres"`
+	SQLiteConfig     *configs.SQLiteConfig    `mapstructure:"sqlite"`
 	RedisConfig      configs.RedisConfig      `mapstructure:"redis" validate:"required"`
 	AssetStoreConfig configs.AssetStoreConfig `mapstructure:"asset_store" validate:"required"`
 }
@@ -53,10 +54,28 @@ func GetApplicationConfig(v *viper.Viper) (*IntegrationConfig, error) {
 
 	// valdating the app config
 	validate := validator.New()
+	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
+	if err != nil {
+		log.Printf("%+v\n", err)
+		return nil, err
+	}
+	switch cfg := sqlConfig.(type) {
+	case *configs.PostgresConfig:
+		config.PostgresConfig = cfg
+		config.SQLiteConfig = nil
+	case *configs.SQLiteConfig:
+		config.SQLiteConfig = cfg
+		config.PostgresConfig = nil
+	}
+
 	err = validate.Struct(&config)
 	if err != nil {
 		log.Printf("%+v\n", err)
 		return nil, err
 	}
 	return &config, nil
+}
+
+func (c *IntegrationConfig) SQLConfig() configs.SQLConfig {
+	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/integration-api/config/config.go
+++ b/api/integration-api/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 
@@ -35,9 +37,14 @@ func InitConfig() (*viper.Viper, error) {
 	}
 
 	if err := vConfig.ReadInConfig(); err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("Error while reading the config: %v", err)
+		var notFound viper.ConfigFileNotFoundError
+		if errors.As(err, &notFound) {
+			if path != "" {
+				return nil, fmt.Errorf("read config file from ENV_PATH: %w", err)
+			}
+			return vConfig, nil
 		}
+		return nil, fmt.Errorf("read config: %w", err)
 	}
 
 	return vConfig, nil
@@ -48,16 +55,13 @@ func GetApplicationConfig(v *viper.Viper) (*IntegrationConfig, error) {
 	var config IntegrationConfig
 	err := v.Unmarshal(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("unmarshal application config: %w", err)
 	}
 
-	// valdating the app config
 	validate := validator.New()
 	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("resolve SQL config: %w", err)
 	}
 	switch cfg := sqlConfig.(type) {
 	case *configs.PostgresConfig:
@@ -70,12 +74,15 @@ func GetApplicationConfig(v *viper.Viper) (*IntegrationConfig, error) {
 
 	err = validate.Struct(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("validate application config: %w", err)
 	}
 	return &config, nil
 }
 
 func (c *IntegrationConfig) SQLConfig() (configs.SQLConfig, error) {
-	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	cfg, err := configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	if err != nil {
+		return nil, fmt.Errorf("select SQL config: %w", err)
+	}
+	return cfg, nil
 }

--- a/api/integration-api/config/config.go
+++ b/api/integration-api/config/config.go
@@ -76,6 +76,6 @@ func GetApplicationConfig(v *viper.Viper) (*IntegrationConfig, error) {
 	return &config, nil
 }
 
-func (c *IntegrationConfig) SQLConfig() configs.SQLConfig {
+func (c *IntegrationConfig) SQLConfig() (configs.SQLConfig, error) {
 	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/integration-api/config/config_test.go
+++ b/api/integration-api/config/config_test.go
@@ -87,8 +87,8 @@ func TestInitConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetApplicationConfig returned an error: %v", err)
 	}
-	if appConfig.PostgresConfig.DBName != "integration_db" {
-		t.Errorf("Expected PostgresConfig.DBName to be 'integration_db', but got %v", appConfig.PostgresConfig.DBName)
+	if appConfig.PostgresConfig == nil || appConfig.PostgresConfig.DBName != "integration_db" {
+		t.Fatalf("Expected PostgresConfig.DBName to be 'integration_db', got %#v", appConfig.PostgresConfig)
 	}
 	if appConfig.Assistant.Host != "localhost:9007" {
 		t.Errorf("Expected Assistant.Host to be 'localhost:9007', but got %v", appConfig.Assistant.Host)
@@ -110,8 +110,10 @@ func TestGetApplicationConfig(t *testing.T) {
 		t.Fatalf("appConfig is nil")
 	}
 
-	if appConfig.PostgresConfig.DBName != "integration_db" {
-		t.Errorf("Expected PostgresConfig.DBName to be 'integration_db', but got %v", appConfig.PostgresConfig.DBName)
+	if appConfig.PostgresConfig == nil {
+		t.Fatalf("Expected PostgresConfig to be populated, got nil")
+	} else if appConfig.PostgresConfig.DBName != "integration_db" {
+		t.Errorf("Expected PostgresConfig.DBName to be 'integration_db', but got %q", appConfig.PostgresConfig.DBName)
 	}
 	if appConfig.AssetStoreConfig.StorageType != "local" {
 		t.Errorf("Expected AssetStoreConfig.StorageType to be 'local', but got %v", appConfig.AssetStoreConfig.StorageType)
@@ -136,5 +138,84 @@ func TestGetApplicationConfig(t *testing.T) {
 	}
 	if appConfig.Ui.Host != "http://localhost:3000" {
 		t.Errorf("Expected Ui.Host to be 'http://localhost:3000', but got %v", appConfig.Ui.Host)
+	}
+}
+
+func TestGetApplicationConfig_SQLite(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "integration-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9004)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "integration.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/integration")
+
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	appConfig, err := GetApplicationConfig(vConfig)
+	if err != nil {
+		t.Fatalf("GetApplicationConfig returned an error: %v", err)
+	}
+	if appConfig.SQLiteConfig == nil || appConfig.SQLiteConfig.Path == "" {
+		t.Fatalf("expected SQLiteConfig to be populated, got %#v", appConfig.SQLiteConfig)
+	}
+	if appConfig.PostgresConfig != nil {
+		t.Fatalf("expected PostgresConfig to be nil when sqlite is selected")
+	}
+}
+
+func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+	vConfig.Set("SERVICE_NAME", "integration-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9004)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("POSTGRES__HOST", "localhost")
+	vConfig.Set("POSTGRES__DB_NAME", "integration_db")
+	vConfig.Set("POSTGRES__AUTH__USER", "rapida_user")
+	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
+	vConfig.Set("POSTGRES__PORT", 5432)
+	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__SSL_MODE", "disable")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "integration.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/integration")
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	_, err := GetApplicationConfig(vConfig)
+	if err == nil || !strings.Contains(err.Error(), "set only one") {
+		t.Fatalf("expected multi-sql validation error, got %v", err)
 	}
 }

--- a/api/integration-api/config/config_test.go
+++ b/api/integration-api/config/config_test.go
@@ -31,7 +31,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
 
 redis:
@@ -152,7 +152,7 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "integration.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
@@ -161,12 +161,12 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/integration")
 
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	appConfig, err := GetApplicationConfig(vConfig)
 	if err != nil {
@@ -195,24 +195,24 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
 	vConfig.Set("POSTGRES__PORT", 5432)
 	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
-	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDLE_CONNECTION", 10)
 	vConfig.Set("POSTGRES__SSL_MODE", "disable")
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "integration.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
 	vConfig.Set("REDIS__MAX_CONNECTION", 5)
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/integration")
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	_, err := GetApplicationConfig(vConfig)
 	if err == nil || !strings.Contains(err.Error(), "set only one") {

--- a/api/integration-api/config/init_config_test.go
+++ b/api/integration-api/config/init_config_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2023-2025 RapidaAI
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestInitConfig_ENVPathMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Setenv("ENV_PATH", missing)
+
+	_, err := InitConfig()
+	if err == nil {
+		t.Fatal("expected error when ENV_PATH points to missing file")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("expected wrapped read error, got %v", err)
+	}
+}
+
+func TestInitConfig_ENVPathInvalidYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.yaml")
+	if err := os.WriteFile(path, []byte("not: valid: yaml: [[["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ENV_PATH", path)
+
+	_, err := InitConfig()
+	if err == nil {
+		t.Fatal("expected read config error for invalid yaml")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("expected wrapped read error, got %v", err)
+	}
+}
+
+func TestInitConfig_DefaultPathMissingAllowed(t *testing.T) {
+	t.Setenv("ENV_PATH", "")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	v, err := InitConfig()
+	if err != nil {
+		t.Fatalf("expected nil error when default config file is missing, got %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected viper instance")
+	}
+}
+
+func TestIntegrationConfig_SQLConfig_Postgres(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(baseIntegrationYAML)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := GetApplicationConfig(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql, err := cfg.SQLConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sql.DriverName() != "postgres" {
+		t.Fatalf("DriverName() = %q, want postgres", sql.DriverName())
+	}
+}
+
+func TestIntegrationConfig_SQLConfig_NoBackend(t *testing.T) {
+	cfg := &IntegrationConfig{}
+	_, err := cfg.SQLConfig()
+	if err == nil {
+		t.Fatal("expected error when no SQL backend configured")
+	}
+	if !strings.Contains(err.Error(), "select SQL config") {
+		t.Fatalf("expected select SQL config wrap, got %v", err)
+	}
+}

--- a/api/integration-api/internal/service/audit/service.go
+++ b/api/integration-api/internal/service/audit/service.go
@@ -21,10 +21,10 @@ import (
 
 type auditService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewAuditService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.AuditService {
+func NewAuditService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.AuditService {
 	return &auditService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/integration-api/router/health_check.go
+++ b/api/integration-api/router/health_check.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rapidaai/pkg/connectors"
 )
 
-func HealthCheckRoutes(cfg *config.IntegrationConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.PostgresConnector) {
+func HealthCheckRoutes(cfg *config.IntegrationConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.SQLConnector) {
 	logger.Info("Internal HealthCheckRoutes and Connectors added to engine.")
 	apiv1 := engine.Group("")
 	hcApi := healthCheckApi.New(cfg, logger, postgres)

--- a/api/integration-api/router/provider.go
+++ b/api/integration-api/router/provider.go
@@ -14,7 +14,7 @@ import (
 )
 
 // all the provider routes
-func ProviderApiRoute(Cfg *config.IntegrationConfig, S *grpc.Server, Logger commons.Logger, Postgres connectors.PostgresConnector) {
+func ProviderApiRoute(Cfg *config.IntegrationConfig, S *grpc.Server, Logger commons.Logger, Postgres connectors.SQLConnector) {
 	protos.RegisterUnifiedProviderServiceServer(S, integrationApi.NewUnifiedProviderGRPC(Cfg, Logger, Postgres))
 }
 
@@ -23,7 +23,7 @@ func AuditLoggingApiRoute(
 	Cfg *config.IntegrationConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 ) {
 	protos.RegisterAuditLoggingServiceServer(S, integrationApi.NewAuditLoggingGRPC(Cfg, Logger, Postgres))
 }

--- a/api/web-api/api/auth.go
+++ b/api/web-api/api/auth.go
@@ -33,7 +33,7 @@ import (
 type webAuthApi struct {
 	cfg                 *config.WebAppConfig
 	logger              commons.Logger
-	postgres            connectors.PostgresConnector
+	postgres            connectors.SQLConnector
 	userService         internal_services.UserService
 	organizationService internal_services.OrganizationService
 	projectService      internal_services.ProjectService
@@ -55,7 +55,7 @@ var (
 	GOOGLE_STATE = "google"
 )
 
-func NewAuthRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) *webAuthRPCApi {
+func NewAuthRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) *webAuthRPCApi {
 	return &webAuthRPCApi{
 		webAuthApi{
 			cfg:             config,
@@ -70,7 +70,7 @@ func NewAuthRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logg
 	}
 }
 
-func NewAuthGRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) protos.AuthenticationServiceServer {
+func NewAuthGRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) protos.AuthenticationServiceServer {
 	return &webAuthGRPCApi{
 		webAuthApi{
 			cfg:                 config,

--- a/api/web-api/api/connect.go
+++ b/api/web-api/api/connect.go
@@ -22,7 +22,7 @@ import (
 type webConnectApi struct {
 	cfg      *config.WebAppConfig
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 	// code
 	githubCodeConnect internal_connects.GithubConnect
 	gitlabCodeConnect internal_connects.GitlabConnect
@@ -132,7 +132,7 @@ func (wConnectApi *webConnectGRPCApi) GeneralConnect(ctx context.Context, kcr *p
 	}, nil
 }
 
-func NewConnectRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) *webConnectRPCApi {
+func NewConnectRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) *webConnectRPCApi {
 	return &webConnectRPCApi{
 		webConnectApi{
 			cfg:                config,
@@ -160,7 +160,7 @@ func NewConnectRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, l
 
 func NewConnectGRPC(config *config.WebAppConfig,
 	oauthCfg *config.OAuth2Config,
-	logger commons.Logger, postgres connectors.PostgresConnector) protos.ConnectServiceServer {
+	logger commons.Logger, postgres connectors.SQLConnector) protos.ConnectServiceServer {
 	return &webConnectGRPCApi{
 		webConnectApi{
 			cfg:          config,

--- a/api/web-api/api/notification.go
+++ b/api/web-api/api/notification.go
@@ -17,7 +17,7 @@ import (
 type webNotificationApi struct {
 	cfg                 *config.WebAppConfig
 	logger              commons.Logger
-	postgres            connectors.PostgresConnector
+	postgres            connectors.SQLConnector
 	redis               connectors.RedisConnector
 	notificationService internal_service.NotificationService
 }
@@ -30,7 +30,7 @@ type webNotificationGRPCApi struct {
 	webNotificationApi
 }
 
-func NewNotificationGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.NotificationServiceServer {
+func NewNotificationGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.NotificationServiceServer {
 	return &webNotificationGRPCApi{
 		webNotificationApi{
 			cfg:                 config,

--- a/api/web-api/api/organization.go
+++ b/api/web-api/api/organization.go
@@ -26,7 +26,7 @@ import (
 type webOrganizationApi struct {
 	cfg                 *config.WebAppConfig
 	logger              commons.Logger
-	postgres            connectors.PostgresConnector
+	postgres            connectors.SQLConnector
 	redis               connectors.RedisConnector
 	organizationService internal_service.OrganizationService
 	userService         internal_service.UserService
@@ -44,7 +44,7 @@ type webOrganizationGRPCApi struct {
 }
 
 func NewOrganizationRPC(config *config.WebAppConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector,
 ) *webOrganizationRPCApi {
 	return &webOrganizationRPCApi{
@@ -61,7 +61,7 @@ func NewOrganizationRPC(config *config.WebAppConfig, logger commons.Logger,
 }
 
 func NewOrganizationGRPC(config *config.WebAppConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector) protos.OrganizationServiceServer {
 	return &webOrganizationGRPCApi{
 		webOrganizationApi{

--- a/api/web-api/api/project.go
+++ b/api/web-api/api/project.go
@@ -29,7 +29,7 @@ type webProjectApi struct {
 	cfg                 *config.WebAppConfig
 	logger              commons.Logger
 	redis               connectors.RedisConnector
-	postgres            connectors.PostgresConnector
+	postgres            connectors.SQLConnector
 	projectService      internal_service.ProjectService
 	emailerClient       external_clients.Emailer
 	userService         internal_service.UserService
@@ -44,7 +44,7 @@ type webProjectGRPCApi struct {
 	webProjectApi
 }
 
-func NewProjectRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) *webProjectRPCApi {
+func NewProjectRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) *webProjectRPCApi {
 	return &webProjectRPCApi{
 		webProjectApi{
 			cfg:            config,
@@ -57,7 +57,7 @@ func NewProjectRPC(config *config.WebAppConfig, logger commons.Logger, postgres 
 	}
 }
 
-func NewProjectGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.ProjectServiceServer {
+func NewProjectGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.ProjectServiceServer {
 	return &webProjectGRPCApi{
 		webProjectApi{
 			cfg:                 config,

--- a/api/web-api/api/proxy/activity.go
+++ b/api/web-api/api/proxy/activity.go
@@ -21,7 +21,7 @@ type webActivityApi struct {
 	web_api.WebApi
 	cfg          *config.WebAppConfig
 	logger       commons.Logger
-	postgres     connectors.PostgresConnector
+	postgres     connectors.SQLConnector
 	redis        connectors.RedisConnector
 	auditClient  integration_client.AuditServiceClient
 	vaultService internal_service.VaultService
@@ -31,7 +31,7 @@ type webActivityGRPCApi struct {
 	webActivityApi
 }
 
-func NewActivityGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.AuditLoggingServiceServer {
+func NewActivityGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.AuditLoggingServiceServer {
 	return &webActivityGRPCApi{
 		webActivityApi{
 			WebApi:       web_api.NewWebApi(config, logger, postgres, redis),

--- a/api/web-api/api/proxy/assistant.go
+++ b/api/web-api/api/proxy/assistant.go
@@ -20,7 +20,7 @@ type webAssistantApi struct {
 	web_api.WebApi
 	cfg             *config.WebAppConfig
 	logger          commons.Logger
-	postgres        connectors.PostgresConnector
+	postgres        connectors.SQLConnector
 	redis           connectors.RedisConnector
 	assistantClient assistant_client.AssistantServiceClient
 }
@@ -29,7 +29,7 @@ type webAssistantGRPCApi struct {
 	webAssistantApi
 }
 
-func NewAssistantGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.AssistantServiceServer {
+func NewAssistantGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.AssistantServiceServer {
 	return &webAssistantGRPCApi{
 		webAssistantApi{
 			WebApi:          web_api.NewWebApi(config, logger, postgres, redis),

--- a/api/web-api/api/proxy/assistant_deployment.go
+++ b/api/web-api/api/proxy/assistant_deployment.go
@@ -19,7 +19,7 @@ type webAssistantDeploymentApi struct {
 	web_api.WebApi
 	cfg             *config.WebAppConfig
 	logger          commons.Logger
-	postgres        connectors.PostgresConnector
+	postgres        connectors.SQLConnector
 	redis           connectors.RedisConnector
 	assistantClient assistant_client.AssistantServiceClient
 }
@@ -228,7 +228,7 @@ func (w *webAssistantDeploymentGRPCApi) CreateAssistantWhatsappDeployment(c cont
 }
 
 // G
-func NewAssistantDeploymentGRPCApi(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.AssistantDeploymentServiceServer {
+func NewAssistantDeploymentGRPCApi(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.AssistantDeploymentServiceServer {
 	return &webAssistantDeploymentGRPCApi{
 		webAssistantDeploymentApi{
 			WebApi:          web_api.NewWebApi(config, logger, postgres, redis),

--- a/api/web-api/api/proxy/document.go
+++ b/api/web-api/api/proxy/document.go
@@ -16,7 +16,7 @@ import (
 type indexerApi struct {
 	cfg                  *config.WebAppConfig
 	logger               commons.Logger
-	postgres             connectors.PostgresConnector
+	postgres             connectors.SQLConnector
 	redis                connectors.RedisConnector
 	indexerServiceClient document_client.IndexerServiceClient
 }
@@ -26,7 +26,7 @@ type indexerGrpcApi struct {
 }
 
 func NewDocumentGRPCApi(config *config.WebAppConfig, logger commons.Logger,
-	postgres connectors.PostgresConnector,
+	postgres connectors.SQLConnector,
 	redis connectors.RedisConnector) knowledge_api.DocumentServiceServer {
 	return &indexerGrpcApi{
 		indexerApi{

--- a/api/web-api/api/proxy/endpoint.go
+++ b/api/web-api/api/proxy/endpoint.go
@@ -19,7 +19,7 @@ type webEndpointApi struct {
 	web_api.WebApi
 	cfg            *config.WebAppConfig
 	logger         commons.Logger
-	postgres       connectors.PostgresConnector
+	postgres       connectors.SQLConnector
 	redis          connectors.RedisConnector
 	endpointClient endpoint_client.EndpointServiceClient
 }
@@ -28,7 +28,7 @@ type webEndpointGRPCApi struct {
 	webEndpointApi
 }
 
-func NewEndpointGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.EndpointServiceServer {
+func NewEndpointGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.EndpointServiceServer {
 	return &webEndpointGRPCApi{
 		webEndpointApi{
 			WebApi:         web_api.NewWebApi(config, logger, postgres, redis),

--- a/api/web-api/api/proxy/invoke.go
+++ b/api/web-api/api/proxy/invoke.go
@@ -18,12 +18,12 @@ type webInvokeGRPCApi struct {
 	web_api.WebApi
 	cfg                 *config.WebAppConfig
 	logger              commons.Logger
-	postgres            connectors.PostgresConnector
+	postgres            connectors.SQLConnector
 	redis               connectors.RedisConnector
 	deployServiceClient endpoint_client.DeploymentServiceClient
 }
 
-func NewInvokeGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.DeploymentServer {
+func NewInvokeGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.DeploymentServer {
 	return &webInvokeGRPCApi{
 		WebApi:              web_api.NewWebApi(config, logger, postgres, redis),
 		cfg:                 config,

--- a/api/web-api/api/proxy/knowledge.go
+++ b/api/web-api/api/proxy/knowledge.go
@@ -19,7 +19,7 @@ type webKnowledgeApi struct {
 	web_api.WebApi
 	cfg             *config.WebAppConfig
 	logger          commons.Logger
-	postgres        connectors.PostgresConnector
+	postgres        connectors.SQLConnector
 	redis           connectors.RedisConnector
 	knowledgeClient knowledge_client.KnowledgeServiceClient
 }
@@ -28,7 +28,7 @@ type webKnowledgeGRPCApi struct {
 	webKnowledgeApi
 }
 
-func NewKnowledgeGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.KnowledgeServiceServer {
+func NewKnowledgeGRPC(config *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.KnowledgeServiceServer {
 	return &webKnowledgeGRPCApi{
 		webKnowledgeApi{
 			WebApi:          web_api.NewWebApi(config, logger, postgres, redis),

--- a/api/web-api/api/vault.go
+++ b/api/web-api/api/vault.go
@@ -18,7 +18,7 @@ import (
 type webVaultApi struct {
 	cfg               *config.WebAppConfig
 	logger            commons.Logger
-	postgres          connectors.PostgresConnector
+	postgres          connectors.SQLConnector
 	redis             connectors.RedisConnector
 	vaultService      internal_service.VaultService
 	integrationClient integration_client.IntegrationServiceClient
@@ -33,7 +33,7 @@ type webVaultGRPCApi struct {
 	webVaultApi
 }
 
-func NewVaultRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) *webVaultRPCApi {
+func NewVaultRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) *webVaultRPCApi {
 	return &webVaultRPCApi{
 		webVaultApi{
 			cfg:               config,
@@ -46,7 +46,7 @@ func NewVaultRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, log
 	}
 }
 
-func NewVaultGRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) protos.VaultServiceServer {
+func NewVaultGRPC(config *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) protos.VaultServiceServer {
 	return &webVaultGRPCApi{
 		webVaultApi{
 			cfg:               config,

--- a/api/web-api/api/web.go
+++ b/api/web-api/api/web.go
@@ -17,13 +17,13 @@ import (
 type WebApi struct {
 	cfg         *config.WebAppConfig
 	logger      commons.Logger
-	postgres    connectors.PostgresConnector
+	postgres    connectors.SQLConnector
 	redis       connectors.RedisConnector
 	userService internal_service.UserService
 	orgService  internal_service.OrganizationService
 }
 
-func NewWebApi(cfg *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector, redis connectors.RedisConnector) WebApi {
+func NewWebApi(cfg *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector, redis connectors.RedisConnector) WebApi {
 	return WebApi{
 		cfg: cfg, logger: logger, postgres: postgres, redis: redis,
 		userService: internal_user_service.NewUserService(logger, postgres),

--- a/api/web-api/authenticator/authenticator.go
+++ b/api/web-api/authenticator/authenticator.go
@@ -8,10 +8,10 @@ import (
 	"github.com/rapidaai/pkg/types"
 )
 
-func GetUserAuthenticator(logger commons.Logger, postgres connectors.PostgresConnector) types.Authenticator {
+func GetUserAuthenticator(logger commons.Logger, postgres connectors.SQLConnector) types.Authenticator {
 	return internal_user_service.NewAuthenticator(logger, postgres)
 }
 
-func GetProjectAuthenticator(logger commons.Logger, postgres connectors.PostgresConnector) types.ClaimAuthenticator[*types.ProjectScope] {
+func GetProjectAuthenticator(logger commons.Logger, postgres connectors.SQLConnector) types.ClaimAuthenticator[*types.ProjectScope] {
 	return internal_project_service.NewProjectAuthenticator(logger, postgres)
 }

--- a/api/web-api/config/config.go
+++ b/api/web-api/config/config.go
@@ -47,7 +47,8 @@ type OAuth2Config struct {
 
 type WebAppConfig struct {
 	config.AppConfig `mapstructure:",squash"`
-	PostgresConfig   configs.PostgresConfig   `mapstructure:"postgres" validate:"required"`
+	PostgresConfig   *configs.PostgresConfig  `mapstructure:"postgres"`
+	SQLiteConfig     *configs.SQLiteConfig    `mapstructure:"sqlite"`
 	RedisConfig      configs.RedisConfig      `mapstructure:"redis" validate:"required"`
 	AssetStoreConfig configs.AssetStoreConfig `mapstructure:"asset_store" validate:"required"`
 	OAuthConfig      OAuth2Config             `mapstructure:"oauth2" validate:"required"`
@@ -89,10 +90,28 @@ func GetApplicationConfig(v *viper.Viper) (*WebAppConfig, error) {
 
 	// valdating the app config
 	validate := validator.New()
+	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
+	if err != nil {
+		log.Printf("%+v\n", err)
+		return nil, err
+	}
+	switch cfg := sqlConfig.(type) {
+	case *configs.PostgresConfig:
+		config.PostgresConfig = cfg
+		config.SQLiteConfig = nil
+	case *configs.SQLiteConfig:
+		config.SQLiteConfig = cfg
+		config.PostgresConfig = nil
+	}
+
 	err = validate.Struct(&config)
 	if err != nil {
 		log.Printf("%+v\n", err)
 		return nil, err
 	}
 	return &config, nil
+}
+
+func (c *WebAppConfig) SQLConfig() configs.SQLConfig {
+	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/web-api/config/config.go
+++ b/api/web-api/config/config.go
@@ -112,6 +112,6 @@ func GetApplicationConfig(v *viper.Viper) (*WebAppConfig, error) {
 	return &config, nil
 }
 
-func (c *WebAppConfig) SQLConfig() configs.SQLConfig {
+func (c *WebAppConfig) SQLConfig() (configs.SQLConfig, error) {
 	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
 }

--- a/api/web-api/config/config.go
+++ b/api/web-api/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 
@@ -71,9 +73,14 @@ func InitConfig() (*viper.Viper, error) {
 	}
 
 	if err := vConfig.ReadInConfig(); err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("Error while reading the config: %v", err)
+		var notFound viper.ConfigFileNotFoundError
+		if errors.As(err, &notFound) {
+			if path != "" {
+				return nil, fmt.Errorf("read config file from ENV_PATH: %w", err)
+			}
+			return vConfig, nil
 		}
+		return nil, fmt.Errorf("read config: %w", err)
 	}
 
 	return vConfig, nil
@@ -84,16 +91,13 @@ func GetApplicationConfig(v *viper.Viper) (*WebAppConfig, error) {
 	var config WebAppConfig
 	err := v.Unmarshal(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("unmarshal application config: %w", err)
 	}
 
-	// valdating the app config
 	validate := validator.New()
 	sqlConfig, err := configs.ResolveSQLConfig(v, validate, config.PostgresConfig, config.SQLiteConfig)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("resolve SQL config: %w", err)
 	}
 	switch cfg := sqlConfig.(type) {
 	case *configs.PostgresConfig:
@@ -106,12 +110,15 @@ func GetApplicationConfig(v *viper.Viper) (*WebAppConfig, error) {
 
 	err = validate.Struct(&config)
 	if err != nil {
-		log.Printf("%+v\n", err)
-		return nil, err
+		return nil, fmt.Errorf("validate application config: %w", err)
 	}
 	return &config, nil
 }
 
 func (c *WebAppConfig) SQLConfig() (configs.SQLConfig, error) {
-	return configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	cfg, err := configs.SelectedSQLConfig(c.PostgresConfig, c.SQLiteConfig)
+	if err != nil {
+		return nil, fmt.Errorf("select SQL config: %w", err)
+	}
+	return cfg, nil
 }

--- a/api/web-api/config/config_test.go
+++ b/api/web-api/config/config_test.go
@@ -117,11 +117,11 @@ func TestGetApplicationConfig(t *testing.T) {
 	if appConfig.Name != "web-api" {
 		t.Errorf("Expected ServiceName to be 'web-api', but got %v", appConfig.Name)
 	}
-	if appConfig.PostgresConfig.Host != "localhost" {
-		t.Errorf("Expected PostgresConfig.Host to be 'localhost', but got %v", appConfig.PostgresConfig.Host)
+	if appConfig.PostgresConfig == nil || appConfig.PostgresConfig.Host != "localhost" {
+		t.Errorf("Expected PostgresConfig.Host to be 'localhost', but got %v", appConfig.PostgresConfig)
 	}
-	if appConfig.PostgresConfig.DBName != "web_db" {
-		t.Errorf("Expected PostgresConfig.DBName to be 'web_db', but got %v", appConfig.PostgresConfig.DBName)
+	if appConfig.PostgresConfig == nil || appConfig.PostgresConfig.DBName != "web_db" {
+		t.Errorf("Expected PostgresConfig.DBName to be 'web_db', but got %v", appConfig.PostgresConfig)
 	}
 	if appConfig.RedisConfig.Host != "localhost" || appConfig.RedisConfig.Port != 6379 {
 		t.Errorf("Redis Config mismatch: Host=%v, Port=%v", appConfig.RedisConfig.Host, appConfig.RedisConfig.Port)
@@ -144,5 +144,88 @@ func TestGetApplicationConfig(t *testing.T) {
 	}
 	if appConfig.Ui.Host != "http://localhost:3000" {
 		t.Errorf("Expected Ui.Host to be 'http://localhost:3000', but got %v", appConfig.Ui.Host)
+	}
+}
+
+func TestGetApplicationConfig_SQLite(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+
+	vConfig.Set("SERVICE_NAME", "web-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9001)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "web.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/web")
+
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	appConfig, err := GetApplicationConfig(vConfig)
+	if err != nil {
+		t.Fatalf("GetApplicationConfig returned an error: %v", err)
+	}
+	if appConfig.SQLiteConfig == nil || appConfig.SQLiteConfig.Path == "" {
+		t.Fatalf("expected SQLiteConfig to be populated, got %#v", appConfig.SQLiteConfig)
+	}
+	if appConfig.PostgresConfig != nil {
+		t.Fatalf("expected PostgresConfig to be nil when sqlite is selected")
+	}
+}
+
+func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
+	vConfig := viper.NewWithOptions(viper.KeyDelimiter("__"))
+
+	vConfig.Set("SERVICE_NAME", "web-api")
+	vConfig.Set("HOST", "0.0.0.0")
+	vConfig.Set("PORT", 9001)
+	vConfig.Set("LOG_LEVEL", "debug")
+	vConfig.Set("SECRET", "rpd_pks")
+	vConfig.Set("ENV", "development")
+
+	vConfig.Set("POSTGRES__HOST", "localhost")
+	vConfig.Set("POSTGRES__DB_NAME", "web_db")
+	vConfig.Set("POSTGRES__AUTH__USER", "rapida_user")
+	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
+	vConfig.Set("POSTGRES__PORT", 5432)
+	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__SSL_MODE", "disable")
+
+	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "web.db"))
+	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+	vConfig.Set("REDIS__HOST", "localhost")
+	vConfig.Set("REDIS__PORT", "6379")
+	vConfig.Set("REDIS__MAX_CONNECTION", 5)
+
+	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
+	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/web")
+
+	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
+	vConfig.Set("WEB_HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
+	vConfig.Set("UI_HOST", "http://localhost:3000")
+
+	_, err := GetApplicationConfig(vConfig)
+	if err == nil || !strings.Contains(err.Error(), "set only one") {
+		t.Fatalf("expected multi-sql validation error, got %v", err)
 	}
 }

--- a/api/web-api/config/config_test.go
+++ b/api/web-api/config/config_test.go
@@ -31,7 +31,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
 
 redis:
@@ -159,7 +159,7 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "web.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
@@ -168,12 +168,12 @@ func TestGetApplicationConfig_SQLite(t *testing.T) {
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/web")
 
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	appConfig, err := GetApplicationConfig(vConfig)
 	if err != nil {
@@ -203,12 +203,12 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 	vConfig.Set("POSTGRES__AUTH__PASSWORD", "rapida_db_password")
 	vConfig.Set("POSTGRES__PORT", 5432)
 	vConfig.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
-	vConfig.Set("POSTGRES__MAX_IDEAL_CONNECTION", 10)
+	vConfig.Set("POSTGRES__MAX_IDLE_CONNECTION", 10)
 	vConfig.Set("POSTGRES__SSL_MODE", "disable")
 
 	vConfig.Set("SQLITE__PATH", filepath.Join(t.TempDir(), "web.db"))
 	vConfig.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-	vConfig.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+	vConfig.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 	vConfig.Set("REDIS__HOST", "localhost")
 	vConfig.Set("REDIS__PORT", "6379")
@@ -217,12 +217,12 @@ func TestGetApplicationConfig_MultipleSQLConfigs(t *testing.T) {
 	vConfig.Set("ASSET_STORE__STORAGE_TYPE", "local")
 	vConfig.Set("ASSET_STORE__STORAGE_PATH_PREFIX", os.Getenv("HOME")+"/rapida-data/assets/web")
 
-	vConfig.Set("INTEGRATION_HOST", "localhost:9004")
-	vConfig.Set("ENDPOINT_HOST", "localhost:9005")
-	vConfig.Set("ASSISTANT_HOST", "localhost:9007")
-	vConfig.Set("WEB_HOST", "localhost:9001")
-	vConfig.Set("DOCUMENT_HOST", "http://localhost:9010")
-	vConfig.Set("UI_HOST", "http://localhost:3000")
+	vConfig.Set("INTEGRATION__HOST", "localhost:9004")
+	vConfig.Set("ENDPOINT__HOST", "localhost:9005")
+	vConfig.Set("ASSISTANT__HOST", "localhost:9007")
+	vConfig.Set("WEB__HOST", "localhost:9001")
+	vConfig.Set("DOCUMENT__HOST", "http://localhost:9010")
+	vConfig.Set("UI__HOST", "http://localhost:3000")
 
 	_, err := GetApplicationConfig(vConfig)
 	if err == nil || !strings.Contains(err.Error(), "set only one") {

--- a/api/web-api/internal/connect/atlassian.go
+++ b/api/web-api/internal/connect/atlassian.go
@@ -39,7 +39,7 @@ var (
 	JIRA_CONNECT_URL = "/connect-common/atlassian"
 )
 
-func NewConfluenceConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) AtlassianConnect {
+func NewConfluenceConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) AtlassianConnect {
 	return AtlassianConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		atlassianOauthConfig: oauth2.Config{
@@ -56,7 +56,7 @@ func NewConfluenceConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Confi
 	}
 }
 
-func NewJiraConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) AtlassianConnect {
+func NewJiraConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) AtlassianConnect {
 	return AtlassianConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		atlassianOauthConfig: oauth2.Config{

--- a/api/web-api/internal/connect/external.go
+++ b/api/web-api/internal/connect/external.go
@@ -27,10 +27,10 @@ type ExternalConnectToken interface {
 type ExternalConnect struct {
 	cfg      *config.WebAppConfig
 	log      commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewExternalConnect(cfg *config.WebAppConfig, logger commons.Logger, postgres connectors.PostgresConnector) ExternalConnect {
+func NewExternalConnect(cfg *config.WebAppConfig, logger commons.Logger, postgres connectors.SQLConnector) ExternalConnect {
 	return ExternalConnect{
 		cfg:      cfg,
 		log:      logger,

--- a/api/web-api/internal/connect/github.go
+++ b/api/web-api/internal/connect/github.go
@@ -39,7 +39,7 @@ var (
 )
 
 func NewGithubAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger,
-	postgres connectors.PostgresConnector) GithubConnect {
+	postgres connectors.SQLConnector) GithubConnect {
 	return GithubConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		scope:           GITHUB_AUTHENTICATION_SCOPE,
@@ -49,7 +49,7 @@ func NewGithubAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.O
 	}
 }
 
-func NewGithubCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GithubConnect {
+func NewGithubCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GithubConnect {
 	return GithubConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		scope:           GITHUB_CODE_SCOPE,
@@ -58,7 +58,7 @@ func NewGithubCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Confi
 		logger:          logger,
 	}
 }
-func NewGithubActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GithubConnect {
+func NewGithubActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GithubConnect {
 	return GithubConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		scope:           GITHUB_ACTION_SCOPE,

--- a/api/web-api/internal/connect/gitlab.go
+++ b/api/web-api/internal/connect/gitlab.go
@@ -32,7 +32,7 @@ var (
 	GITLAB_ACTION_CONNECT = "/action/gitlab"
 )
 
-func NewGitlabAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GitlabConnect {
+func NewGitlabAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GitlabConnect {
 	return GitlabConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		gitlabOauthConfig: oauth2.Config{
@@ -46,7 +46,7 @@ func NewGitlabAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.OAut
 	}
 }
 
-func NewGitlabCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GitlabConnect {
+func NewGitlabCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GitlabConnect {
 	return GitlabConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		gitlabOauthConfig: oauth2.Config{
@@ -59,7 +59,7 @@ func NewGitlabCodeConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Confi
 		logger: logger,
 	}
 }
-func NewGitlabActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GitlabConnect {
+func NewGitlabActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GitlabConnect {
 	return GitlabConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		gitlabOauthConfig: oauth2.Config{

--- a/api/web-api/internal/connect/google.go
+++ b/api/web-api/internal/connect/google.go
@@ -48,7 +48,7 @@ var (
 	GOOGLE_GMAIL_CONNECT_URL = "/connect-action/gmail"
 )
 
-func NewGoogleAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GoogleConnect {
+func NewGoogleAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GoogleConnect {
 	return GoogleConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		redirectUrl:     fmt.Sprintf("%s%s", cfg.BaseUrl(), GOOGLE_AUTHENTICATION_URL),
@@ -58,7 +58,7 @@ func NewGoogleAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.O
 	}
 }
 
-func NewGoogleDriveConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GoogleConnect {
+func NewGoogleDriveConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GoogleConnect {
 	return GoogleConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		redirectUrl:     fmt.Sprintf("%s%s", cfg.BaseUrl(), GOOGLE_DRIVE_CONNECT_URL),
@@ -68,7 +68,7 @@ func NewGoogleDriveConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Conf
 	}
 }
 
-func NewGmailConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) GoogleConnect {
+func NewGmailConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) GoogleConnect {
 	return GoogleConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		redirectUrl:     fmt.Sprintf("%s%s", cfg.BaseUrl(), GOOGLE_GMAIL_CONNECT_URL),

--- a/api/web-api/internal/connect/hubspot.go
+++ b/api/web-api/internal/connect/hubspot.go
@@ -26,7 +26,7 @@ var (
 	HUBSPOT_CONNECT = "/connect-crm/hubspot"
 )
 
-func NewHubspotConnect(cfg *config.WebAppConfig, oAuthcfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) HubspotConnect {
+func NewHubspotConnect(cfg *config.WebAppConfig, oAuthcfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) HubspotConnect {
 	return HubspotConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		hubspotOauthConfig: oauth2.Config{

--- a/api/web-api/internal/connect/linkedin.go
+++ b/api/web-api/internal/connect/linkedin.go
@@ -32,7 +32,7 @@ var (
 	LINKEDIN_ACTION_SCOPE   = []string{"openid", "profile", "email"}
 )
 
-func NewLinkedinAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) LinkedinConnect {
+func NewLinkedinAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) LinkedinConnect {
 	return LinkedinConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		redirectURL:     fmt.Sprintf("%s%s", cfg.BaseUrl(), LINKEDIN_AUTHENTICATION_URL),
@@ -47,7 +47,7 @@ func NewLinkedinAuthenticationConnect(cfg *config.WebAppConfig, oauthCfg *config
 	}
 }
 
-func NewLinkedinActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) LinkedinConnect {
+func NewLinkedinActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) LinkedinConnect {
 	return LinkedinConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		redirectURL:     fmt.Sprintf("%s%s", cfg.BaseUrl(), LINKEDIN_ACTION_CONNECT),

--- a/api/web-api/internal/connect/microsoft.go
+++ b/api/web-api/internal/connect/microsoft.go
@@ -56,7 +56,7 @@ var (
 	MICROSOFT_SHAREPOINT_CONNECT = "/connect-knowledge/share-point"
 )
 
-func NewMicrosoftAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) MicrosoftConnect {
+func NewMicrosoftAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) MicrosoftConnect {
 	return MicrosoftConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		microsoftOauthConfig: oauth2.Config{
@@ -70,7 +70,7 @@ func NewMicrosoftAuthenticationConnect(cfg *config.WebAppConfig, auth2 *config.O
 	}
 }
 
-func NewMicrosoftSharepointConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) MicrosoftConnect {
+func NewMicrosoftSharepointConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) MicrosoftConnect {
 	return MicrosoftConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		microsoftOauthConfig: oauth2.Config{
@@ -84,7 +84,7 @@ func NewMicrosoftSharepointConnect(cfg *config.WebAppConfig, oauthCfg *config.OA
 	}
 }
 
-func NewMicrosoftOnedriveConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) MicrosoftConnect {
+func NewMicrosoftOnedriveConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) MicrosoftConnect {
 	return MicrosoftConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		microsoftOauthConfig: oauth2.Config{

--- a/api/web-api/internal/connect/notion.go
+++ b/api/web-api/internal/connect/notion.go
@@ -27,7 +27,7 @@ var (
 	NOTION_WORKPLACE_CONNECT = "/connect-knowledge/notion"
 )
 
-func NewNotionWorkplaceConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) NotionConnect {
+func NewNotionWorkplaceConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) NotionConnect {
 	return NotionConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		notionOauthConfig: oauth2.Config{

--- a/api/web-api/internal/connect/slack.go
+++ b/api/web-api/internal/connect/slack.go
@@ -25,7 +25,7 @@ var (
 	SLACK_SEND_MESSAGE_CONNECT = "/connect-action/slack"
 )
 
-func NewSlackActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.PostgresConnector) SlackConnect {
+func NewSlackActionConnect(cfg *config.WebAppConfig, oauthCfg *config.OAuth2Config, logger commons.Logger, postgres connectors.SQLConnector) SlackConnect {
 	return SlackConnect{
 		ExternalConnect: NewExternalConnect(cfg, logger, postgres),
 		slackOauthConfig: oauth2.Config{

--- a/api/web-api/internal/service/notification/service.go
+++ b/api/web-api/internal/service/notification/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rapidaai/protos"
 )
 
-func NewNotificationService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.NotificationService {
+func NewNotificationService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.NotificationService {
 	return &notificationService{
 		logger:   logger,
 		postgres: postgres,
@@ -24,7 +24,7 @@ func NewNotificationService(logger commons.Logger, postgres connectors.PostgresC
 
 type notificationService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
 func (oS *notificationService) UpdateNotificationSetting(ctx context.Context, auth types.Principle, authId uint64, settings []*protos.NotificationSetting) ([]*internal_entity.NotificationSetting, error) {

--- a/api/web-api/internal/service/organization/service.go
+++ b/api/web-api/internal/service/organization/service.go
@@ -12,7 +12,7 @@ import (
 	type_enums "github.com/rapidaai/pkg/types/enums"
 )
 
-func NewOrganizationService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.OrganizationService {
+func NewOrganizationService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.OrganizationService {
 	return &organizationService{
 		logger:   logger,
 		postgres: postgres,
@@ -21,7 +21,7 @@ func NewOrganizationService(logger commons.Logger, postgres connectors.PostgresC
 
 type organizationService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
 func (oS *organizationService) Create(ctx context.Context, auth types.Principle, name string, size string, industry string) (*internal_entity.Organization, error) {

--- a/api/web-api/internal/service/project/service.go
+++ b/api/web-api/internal/service/project/service.go
@@ -21,17 +21,17 @@ import (
 
 type projectService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewProjectService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.ProjectService {
+func NewProjectService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.ProjectService {
 	return &projectService{
 		logger:   logger,
 		postgres: postgres,
 	}
 }
 
-func NewProjectAuthenticator(logger commons.Logger, postgres connectors.PostgresConnector) types.ClaimAuthenticator[*types.ProjectScope] {
+func NewProjectAuthenticator(logger commons.Logger, postgres connectors.SQLConnector) types.ClaimAuthenticator[*types.ProjectScope] {
 	return &projectService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/web-api/internal/service/user/service.go
+++ b/api/web-api/internal/service/user/service.go
@@ -26,17 +26,17 @@ var DEFAULT_USER_FEATURE_PERMISSION = []string{"/deployment/.*", "/knowledge/.*"
 
 type userService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewUserService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.UserService {
+func NewUserService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.UserService {
 	return &userService{
 		logger:   logger,
 		postgres: postgres,
 	}
 }
 
-func NewAuthenticator(logger commons.Logger, postgres connectors.PostgresConnector) types.Authenticator {
+func NewAuthenticator(logger commons.Logger, postgres connectors.SQLConnector) types.Authenticator {
 	return &userService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/web-api/internal/service/vault/service.go
+++ b/api/web-api/internal/service/vault/service.go
@@ -64,7 +64,7 @@ func (vS *vaultService) Delete(ctx context.Context, auth types.Principle, vaultI
 	}
 	tx := db.Where("id = ? AND organization_id = ? AND project_id = ?", vaultId, *auth.GetCurrentOrganizationId(), *auth.GetCurrentProjectId()).Clauses(clause.Returning{}).Updates(vlt)
 	if err := tx.Error; err != nil {
-		vS.logger.Debugf("unable to delete vault %v")
+		vS.logger.Debugf("unable to delete vault: %v", err)
 		return nil, err
 	}
 	return vlt, nil

--- a/api/web-api/internal/service/vault/service.go
+++ b/api/web-api/internal/service/vault/service.go
@@ -18,10 +18,10 @@ import (
 
 type vaultService struct {
 	logger   commons.Logger
-	postgres connectors.PostgresConnector
+	postgres connectors.SQLConnector
 }
 
-func NewVaultService(logger commons.Logger, postgres connectors.PostgresConnector) internal_services.VaultService {
+func NewVaultService(logger commons.Logger, postgres connectors.SQLConnector) internal_services.VaultService {
 	return &vaultService{
 		logger:   logger,
 		postgres: postgres,

--- a/api/web-api/router/health-check.go
+++ b/api/web-api/router/health-check.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rapidaai/pkg/connectors"
 )
 
-func HealthCheckRoutes(cfg *config.WebAppConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.PostgresConnector) {
+func HealthCheckRoutes(cfg *config.WebAppConfig, engine *gin.Engine, logger commons.Logger, postgres connectors.SQLConnector) {
 	logger.Info("Internal HealthCheckRoutes and Connectors added to engine.")
 	apiv1 := engine.Group("")
 	hcApi := healthCheckApi.New(cfg, logger, postgres)

--- a/api/web-api/router/web.go
+++ b/api/web-api/router/web.go
@@ -17,7 +17,7 @@ func WebApiRoute(
 	E *gin.Engine,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector,
 ) {
 	apiv1 := E.Group("/v1")
@@ -57,7 +57,7 @@ func WebApiRoute(
 func ProxyApiRoute(Cfg *config.WebAppConfig,
 	S *grpc.Server,
 	Logger commons.Logger,
-	Postgres connectors.PostgresConnector,
+	Postgres connectors.SQLConnector,
 	Redis connectors.RedisConnector) {
 	protos.RegisterDeploymentServer(S, webProxyApi.NewInvokeGRPC(Cfg, Logger, Postgres, Redis))
 	protos.RegisterAuditLoggingServiceServer(S, webProxyApi.NewActivityGRPC(Cfg, Logger, Postgres, Redis))

--- a/cmd/assistant/assistant.go
+++ b/cmd/assistant/assistant.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 
@@ -224,7 +225,14 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
+	sqlCfg, err := g.Cfg.SQLConfig()
+	if err != nil {
+		log.Fatalf("invalid SQL configuration: %v", err)
+	}
+	g.Postgres, err = connectors.NewSQLConnector(sqlCfg, g.Logger)
+	if err != nil {
+		log.Fatalf("failed to create SQL connector: %v", err)
+	}
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 	if g.Cfg.OpenSearchConfig != nil {
 		g.Opensearch = connectors.NewOpenSearchConnector(g.Cfg.OpenSearchConfig, g.Logger)
@@ -396,7 +404,10 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	sqlConfig := app.Cfg.SQLConfig()
+	sqlConfig, err := app.Cfg.SQLConfig()
+	if err != nil {
+		return fmt.Errorf("invalid SQL configuration: %w", err)
+	}
 	if sqlConfig.DriverName() == "sqlite" {
 		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
 		return nil

--- a/cmd/assistant/assistant.go
+++ b/cmd/assistant/assistant.go
@@ -46,7 +46,7 @@ type AppRunner struct {
 	SIP        *sip_infra.Server
 	Cfg        *config.AssistantConfig
 	Logger     commons.Logger
-	Postgres   connectors.PostgresConnector
+	Postgres   connectors.SQLConnector
 	Redis      connectors.RedisConnector
 	Opensearch connectors.OpenSearchConnector
 	Closeable  []func(context.Context) error
@@ -224,7 +224,7 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewPostgresConnector(&g.Cfg.PostgresConfig, g.Logger)
+	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 	if g.Cfg.OpenSearchConfig != nil {
 		g.Opensearch = connectors.NewOpenSearchConnector(g.Cfg.OpenSearchConfig, g.Logger)
@@ -262,7 +262,7 @@ func (app *AppRunner) Init(ctx context.Context) error {
 	if app.Postgres != nil {
 		err := app.Postgres.Connect(ctx)
 		if err != nil {
-			app.Logger.Error("error while connecting to postgres.", err)
+			app.Logger.Error("error while connecting to sql database.", err)
 			return err
 		}
 		app.Closeable = append(app.Closeable, app.Postgres.Disconnect)
@@ -396,15 +396,12 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	dsn := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		app.Cfg.PostgresConfig.Auth.User,
-		app.Cfg.PostgresConfig.Auth.Password,
-		app.Cfg.PostgresConfig.Host,
-		app.Cfg.PostgresConfig.Port,
-		app.Cfg.PostgresConfig.DBName,
-		app.Cfg.PostgresConfig.SslMode,
-	)
+	sqlConfig := app.Cfg.SQLConfig()
+	if sqlConfig.DriverName() == "sqlite" {
+		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
+		return nil
+	}
+	dsn := sqlConfig.MigrationDSN()
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)

--- a/cmd/endpoint/endpoint.go
+++ b/cmd/endpoint/endpoint.go
@@ -42,7 +42,7 @@ type AppRunner struct {
 	S         *grpc.Server
 	Cfg       *config.EndpointConfig
 	Logger    commons.Logger
-	Postgres  connectors.PostgresConnector
+	Postgres  connectors.SQLConnector
 	Redis     connectors.RedisConnector
 	Closeable []func(context.Context) error
 }
@@ -201,7 +201,7 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewPostgresConnector(&g.Cfg.PostgresConfig, g.Logger)
+	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 }
 
@@ -233,7 +233,7 @@ func (app *AppRunner) ResolveConfig() error {
 func (app *AppRunner) Init(ctx context.Context) error {
 	err := app.Postgres.Connect(ctx)
 	if err != nil {
-		app.Logger.Error("error while connecting to postgres.", err)
+		app.Logger.Error("error while connecting to sql database.", err)
 		return err
 	}
 	err = app.Redis.Connect(ctx)
@@ -303,15 +303,12 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	dsn := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		app.Cfg.PostgresConfig.Auth.User,
-		app.Cfg.PostgresConfig.Auth.Password,
-		app.Cfg.PostgresConfig.Host,
-		app.Cfg.PostgresConfig.Port,
-		app.Cfg.PostgresConfig.DBName,
-		app.Cfg.PostgresConfig.SslMode,
-	)
+	sqlConfig := app.Cfg.SQLConfig()
+	if sqlConfig.DriverName() == "sqlite" {
+		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
+		return nil
+	}
+	dsn := sqlConfig.MigrationDSN()
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)

--- a/cmd/endpoint/endpoint.go
+++ b/cmd/endpoint/endpoint.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
@@ -201,7 +202,14 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
+	sqlCfg, err := g.Cfg.SQLConfig()
+	if err != nil {
+		log.Fatalf("invalid SQL configuration: %v", err)
+	}
+	g.Postgres, err = connectors.NewSQLConnector(sqlCfg, g.Logger)
+	if err != nil {
+		log.Fatalf("failed to create SQL connector: %v", err)
+	}
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 }
 
@@ -303,7 +311,10 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	sqlConfig := app.Cfg.SQLConfig()
+	sqlConfig, err := app.Cfg.SQLConfig()
+	if err != nil {
+		return fmt.Errorf("invalid SQL configuration: %w", err)
+	}
 	if sqlConfig.DriverName() == "sqlite" {
 		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
 		return nil

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 
@@ -186,7 +187,14 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
+	sqlCfg, err := g.Cfg.SQLConfig()
+	if err != nil {
+		log.Fatalf("invalid SQL configuration: %v", err)
+	}
+	g.Postgres, err = connectors.NewSQLConnector(sqlCfg, g.Logger)
+	if err != nil {
+		log.Fatalf("failed to create SQL connector: %v", err)
+	}
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 }
 
@@ -292,7 +300,10 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	sqlConfig := app.Cfg.SQLConfig()
+	sqlConfig, err := app.Cfg.SQLConfig()
+	if err != nil {
+		return fmt.Errorf("invalid SQL configuration: %w", err)
+	}
 	if sqlConfig.DriverName() == "sqlite" {
 		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
 		return nil

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -44,7 +44,7 @@ type AppRunner struct {
 	S         *grpc.Server
 	Cfg       *config.IntegrationConfig
 	Logger    commons.Logger
-	Postgres  connectors.PostgresConnector
+	Postgres  connectors.SQLConnector
 	Redis     connectors.RedisConnector
 	Closeable []func(context.Context) error
 }
@@ -186,7 +186,7 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	g.Postgres = connectors.NewPostgresConnector(&g.Cfg.PostgresConfig, g.Logger)
+	g.Postgres = connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
 	g.Redis = connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 }
 
@@ -218,7 +218,7 @@ func (app *AppRunner) ResolveConfig() error {
 func (app *AppRunner) Init(ctx context.Context) error {
 	err := app.Postgres.Connect(ctx)
 	if err != nil {
-		app.Logger.Error("error while connecting to postgres.", err)
+		app.Logger.Error("error while connecting to sql database.", err)
 		return err
 	}
 	err = app.Redis.Connect(ctx)
@@ -292,15 +292,12 @@ func (app *AppRunner) Migrate() error {
 		app.Logger.Infof("Skipping migration due to -skip-migration flag")
 		return nil
 	}
-	dsn := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		app.Cfg.PostgresConfig.Auth.User,
-		app.Cfg.PostgresConfig.Auth.Password,
-		app.Cfg.PostgresConfig.Host,
-		app.Cfg.PostgresConfig.Port,
-		app.Cfg.PostgresConfig.DBName,
-		app.Cfg.PostgresConfig.SslMode,
-	)
+	sqlConfig := app.Cfg.SQLConfig()
+	if sqlConfig.DriverName() == "sqlite" {
+		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
+		return nil
+	}
+	dsn := sqlConfig.MigrationDSN()
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 
@@ -187,7 +188,14 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	postgres := connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
+	sqlCfg, err := g.Cfg.SQLConfig()
+	if err != nil {
+		log.Fatalf("invalid SQL configuration: %v", err)
+	}
+	postgres, err := connectors.NewSQLConnector(sqlCfg, g.Logger)
+	if err != nil {
+		log.Fatalf("failed to create SQL connector: %v", err)
+	}
 	redis := connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 	g.Postgres = postgres
 	g.Redis = redis
@@ -297,7 +305,10 @@ func (app *AppRunner) Migrate() error {
 		return nil
 	}
 
-	sqlConfig := app.Cfg.SQLConfig()
+	sqlConfig, err := app.Cfg.SQLConfig()
+	if err != nil {
+		return fmt.Errorf("invalid SQL configuration: %w", err)
+	}
 	if sqlConfig.DriverName() == "sqlite" {
 		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
 		return nil

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -43,7 +43,7 @@ type AppRunner struct {
 	S         *grpc.Server
 	Cfg       *config.WebAppConfig
 	Logger    commons.Logger
-	Postgres  connectors.PostgresConnector
+	Postgres  connectors.SQLConnector
 	Redis     connectors.RedisConnector
 	Closeable []func(context.Context) error
 }
@@ -187,7 +187,7 @@ func (app *AppRunner) Logging() error {
 }
 
 func (g *AppRunner) AllConnectors() {
-	postgres := connectors.NewPostgresConnector(&g.Cfg.PostgresConfig, g.Logger)
+	postgres := connectors.NewSQLConnector(g.Cfg.SQLConfig(), g.Logger)
 	redis := connectors.NewRedisConnector(&g.Cfg.RedisConfig, g.Logger)
 	g.Postgres = postgres
 	g.Redis = redis
@@ -221,7 +221,7 @@ func (app *AppRunner) ResolveConfig() error {
 func (app *AppRunner) Init(ctx context.Context) error {
 	err := app.Postgres.Connect(ctx)
 	if err != nil {
-		app.Logger.Error("error while connecting to postgres.", err)
+		app.Logger.Error("error while connecting to sql database.", err)
 		return err
 	}
 	err = app.Redis.Connect(ctx)
@@ -297,15 +297,12 @@ func (app *AppRunner) Migrate() error {
 		return nil
 	}
 
-	dsn := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		app.Cfg.PostgresConfig.Auth.User,
-		app.Cfg.PostgresConfig.Auth.Password,
-		app.Cfg.PostgresConfig.Host,
-		app.Cfg.PostgresConfig.Port,
-		app.Cfg.PostgresConfig.DBName,
-		app.Cfg.PostgresConfig.SslMode,
-	)
+	sqlConfig := app.Cfg.SQLConfig()
+	if sqlConfig.DriverName() == "sqlite" {
+		app.Logger.Warnf("Skipping migrations for %s: bundled migrations are PostgreSQL-specific today.", sqlConfig.DisplayName())
+		return nil
+	}
+	dsn := sqlConfig.MigrationDSN()
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)

--- a/docker/assistant-api/assistant.knowledge.yml
+++ b/docker/assistant-api/assistant.knowledge.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 50
-  max_ideal_connection: 25
+  max_idle_connection: 25
   ssl_mode: "disable"
   slc_cache:
     host: "redis"

--- a/docker/assistant-api/assistant.yml
+++ b/docker/assistant-api/assistant.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 50
-  max_ideal_connection: 25
+  max_idle_connection: 25
   ssl_mode: "disable"
   slc_cache:
     host: "redis"

--- a/docker/endpoint-api/endpoint.yml
+++ b/docker/endpoint-api/endpoint.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
   slc_cache:
     host: "redis"

--- a/docker/integration-api/integration.yml
+++ b/docker/integration-api/integration.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
   slc_cache:
     host: "redis"

--- a/docker/web-api/web.yml
+++ b/docker/web-api/web.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
   slc_cache:
     host: "redis"

--- a/env/assistant.yaml
+++ b/env/assistant.yaml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 50
-  max_ideal_connection: 25
+  max_idle_connection: 25
   ssl_mode: "disable"
   slc_cache:
     host: "127.0.0.1"

--- a/env/endpoint.yml
+++ b/env/endpoint.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
 
 redis:

--- a/env/integration.yml
+++ b/env/integration.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
 
 redis:

--- a/env/web.yml
+++ b/env/web.yml
@@ -13,7 +13,7 @@ postgres:
     user: "rapida_user"
     password: "rapida_db_password"
   max_open_connection: 10
-  max_ideal_connection: 10
+  max_idle_connection: 10
   ssl_mode: "disable"
   slc_cache:
     host: "127.0.0.1"

--- a/pkg/authenticators/service_authenticator.go
+++ b/pkg/authenticators/service_authenticator.go
@@ -19,7 +19,7 @@ type serviceAuthenticator struct {
 	cfg    *config.AppConfig
 }
 
-func NewServiceAuthenticator(cfg *config.AppConfig, logger commons.Logger, postgres connectors.PostgresConnector) types.ClaimAuthenticator[*types.ServiceScope] {
+func NewServiceAuthenticator(cfg *config.AppConfig, logger commons.Logger, postgres connectors.SQLConnector) types.ClaimAuthenticator[*types.ServiceScope] {
 	return &serviceAuthenticator{
 		logger: logger, cfg: cfg,
 	}

--- a/pkg/configs/migration_dsn_log.go
+++ b/pkg/configs/migration_dsn_log.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package configs
+
+import "net/url"
+
+// SafeMigrationDSNForLog returns a DSN safe for info-level logs (credentials redacted).
+func SafeMigrationDSNForLog(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "<unparseable migration dsn>"
+	}
+	if u.User != nil {
+		u.User = url.UserPassword(u.User.Username(), "REDACTED")
+	}
+	return u.String()
+}

--- a/pkg/configs/migration_dsn_log_test.go
+++ b/pkg/configs/migration_dsn_log_test.go
@@ -1,0 +1,17 @@
+package configs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSafeMigrationDSNForLog(t *testing.T) {
+	dsn := "postgres://user:secret@localhost:5432/mydb?sslmode=disable"
+	safe := SafeMigrationDSNForLog(dsn)
+	if safe == dsn {
+		t.Fatalf("expected redacted dsn, got %q", safe)
+	}
+	if strings.Contains(safe, "secret") {
+		t.Fatalf("password leaked in log dsn: %q", safe)
+	}
+}

--- a/pkg/configs/postgres_config.go
+++ b/pkg/configs/postgres_config.go
@@ -10,8 +10,8 @@ type PostgresConfig struct {
 	Port               int       `mapstructure:"port"`
 	Auth               BasicAuth `mapstructure:"auth"`
 	DBName             string    `mapstructure:"db_name" validate:"required"`
-	MaxIdealConnection int       `mapstructure:"max_ideal_connection" validate:"required"`
-	MaxOpenConnection  int       `mapstructure:"max_open_connection" validate:"required"`
+	MaxIdleConnection int       `mapstructure:"max_idle_connection" validate:"gte=0"`
+	MaxOpenConnection int       `mapstructure:"max_open_connection" validate:"gte=0"`
 	SslMode            string    `mapstructure:"ssl_mode" validate:"required"`
 	// currently we only support redis caching // later you know me i will add multiple
 	SLCache *RedisConfig `mapstructure:"slc_cache"`

--- a/pkg/configs/postgres_config_test.go
+++ b/pkg/configs/postgres_config_test.go
@@ -19,12 +19,11 @@ func TestPostgresConfig_Validation(t *testing.T) {
 		cfg     PostgresConfig
 		wantErr bool
 	}{
-		{"valid", PostgresConfig{Host: "localhost", DBName: "test", MaxIdealConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, false},
-		{"invalid missing host", PostgresConfig{DBName: "test", MaxIdealConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, true},
-		{"invalid missing db_name", PostgresConfig{Host: "localhost", MaxIdealConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, true},
-		{"invalid missing max_ideal_connection", PostgresConfig{Host: "localhost", DBName: "test", MaxOpenConnection: 10, SslMode: "disable"}, true},
-		{"invalid missing max_open_connection", PostgresConfig{Host: "localhost", DBName: "test", MaxIdealConnection: 5, SslMode: "disable"}, true},
-		{"invalid missing ssl_mode", PostgresConfig{Host: "localhost", DBName: "test", MaxIdealConnection: 5, MaxOpenConnection: 10}, true},
+		{"valid", PostgresConfig{Host: "localhost", DBName: "test", MaxIdleConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, false},
+		{"invalid missing host", PostgresConfig{DBName: "test", MaxIdleConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, true},
+		{"invalid missing db_name", PostgresConfig{Host: "localhost", MaxIdleConnection: 5, MaxOpenConnection: 10, SslMode: "disable"}, true},
+		{"zero pool sizes allowed", PostgresConfig{Host: "localhost", DBName: "test", MaxIdleConnection: 0, MaxOpenConnection: 0, SslMode: "disable"}, false},
+		{"invalid missing ssl_mode", PostgresConfig{Host: "localhost", DBName: "test", MaxIdleConnection: 5, MaxOpenConnection: 10}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -43,7 +42,7 @@ func TestPostgresConfig_FromViper(t *testing.T) {
 	v.Set("auth.user", "postgres")
 	v.Set("auth.password", "secret")
 	v.Set("db_name", "mydb")
-	v.Set("max_ideal_connection", 10)
+	v.Set("max_idle_connection", 10)
 	v.Set("max_open_connection", 20)
 	v.Set("ssl_mode", "require")
 
@@ -67,8 +66,8 @@ func TestPostgresConfig_FromViper(t *testing.T) {
 	if cfg.DBName != "mydb" {
 		t.Errorf("DBName = %v, want mydb", cfg.DBName)
 	}
-	if cfg.MaxIdealConnection != 10 {
-		t.Errorf("MaxIdealConnection = %v, want 10", cfg.MaxIdealConnection)
+	if cfg.MaxIdleConnection != 10 {
+		t.Errorf("MaxIdleConnection = %v, want 10", cfg.MaxIdleConnection)
 	}
 	if cfg.MaxOpenConnection != 20 {
 		t.Errorf("MaxOpenConnection = %v, want 20", cfg.MaxOpenConnection)
@@ -105,8 +104,8 @@ func TestPostgresConfig_Defaults(t *testing.T) {
 	if cfg.DBName != "" {
 		t.Errorf("DBName = %v, want empty", cfg.DBName)
 	}
-	if cfg.MaxIdealConnection != 0 {
-		t.Errorf("MaxIdealConnection = %v, want 0", cfg.MaxIdealConnection)
+	if cfg.MaxIdleConnection != 0 {
+		t.Errorf("MaxIdleConnection = %v, want 0", cfg.MaxIdleConnection)
 	}
 	if cfg.MaxOpenConnection != 0 {
 		t.Errorf("MaxOpenConnection = %v, want 0", cfg.MaxOpenConnection)

--- a/pkg/configs/sql_config.go
+++ b/pkg/configs/sql_config.go
@@ -8,7 +8,7 @@ package configs
 import (
 	"errors"
 	"fmt"
-	"os"
+	"net/url"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -36,15 +36,16 @@ func (c *PostgresConfig) MigrationDriverName() string {
 }
 
 func (c *PostgresConfig) MigrationDSN() string {
-	return fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		c.Auth.User,
-		c.Auth.Password,
-		c.Host,
-		c.Port,
-		c.DBName,
-		c.SslMode,
-	)
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(c.Auth.User, c.Auth.Password),
+		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path:   "/" + c.DBName,
+	}
+	q := url.Values{}
+	q.Set("sslmode", c.SslMode)
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func (c *PostgresConfig) DisplayName() string {
@@ -94,14 +95,17 @@ func ResolveSQLConfig(v *viper.Viper, validate *validator.Validate, postgres *Po
 	}
 }
 
-func SelectedSQLConfig(postgres *PostgresConfig, sqlite *SQLiteConfig) SQLConfig {
-	if postgres != nil && sqlite != nil {
-		panic("SelectedSQLConfig requires exactly one SQL config; both postgres and sqlite were provided")
+func SelectedSQLConfig(postgres *PostgresConfig, sqlite *SQLiteConfig) (SQLConfig, error) {
+	switch {
+	case postgres != nil && sqlite != nil:
+		return nil, ErrMultipleSQLConfigsDetected
+	case sqlite != nil:
+		return sqlite, nil
+	case postgres != nil:
+		return postgres, nil
+	default:
+		return nil, ErrNoSQLConfigConfigured
 	}
-	if sqlite != nil {
-		return sqlite
-	}
-	return postgres
 }
 
 func detectSQLPrefixes(v *viper.Viper) (bool, bool) {
@@ -112,13 +116,7 @@ func hasConfigPrefix(v *viper.Viper, prefix string) bool {
 	prefix = strings.ToUpper(prefix) + "__"
 	for _, key := range v.AllKeys() {
 		normalizedKey := strings.ToUpper(strings.ReplaceAll(key, ".", "__"))
-		if strings.HasPrefix(normalizedKey, prefix) {
-			return true
-		}
-	}
-	for _, env := range os.Environ() {
-		name, _, found := strings.Cut(env, "=")
-		if found && strings.HasPrefix(strings.ToUpper(name), prefix) {
+		if strings.HasPrefix(normalizedKey, prefix) && v.IsSet(key) {
 			return true
 		}
 	}

--- a/pkg/configs/sql_config.go
+++ b/pkg/configs/sql_config.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package configs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/viper"
+)
+
+var (
+	ErrNoSQLConfigConfigured      = errors.New("no SQL configuration found; set exactly one of POSTGRES__* or SQLITE__*")
+	ErrMultipleSQLConfigsDetected = errors.New("multiple SQL configurations found; set only one of POSTGRES__* or SQLITE__*")
+)
+
+type SQLConfig interface {
+	DriverName() string
+	MigrationDriverName() string
+	MigrationDSN() string
+	DisplayName() string
+}
+
+func (c *PostgresConfig) DriverName() string {
+	return "postgres"
+}
+
+func (c *PostgresConfig) MigrationDriverName() string {
+	return "postgres"
+}
+
+func (c *PostgresConfig) MigrationDSN() string {
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		c.Auth.User,
+		c.Auth.Password,
+		c.Host,
+		c.Port,
+		c.DBName,
+		c.SslMode,
+	)
+}
+
+func (c *PostgresConfig) DisplayName() string {
+	return fmt.Sprintf("postgres://%s:%d/%s", c.Host, c.Port, c.DBName)
+}
+
+func (c *SQLiteConfig) DriverName() string {
+	return "sqlite"
+}
+
+func (c *SQLiteConfig) MigrationDriverName() string {
+	return "sqlite3"
+}
+
+func (c *SQLiteConfig) MigrationDSN() string {
+	return "sqlite3://" + c.Path
+}
+
+func (c *SQLiteConfig) DisplayName() string {
+	return "sqlite3://" + c.Path
+}
+
+func ResolveSQLConfig(v *viper.Viper, validate *validator.Validate, postgres *PostgresConfig, sqlite *SQLiteConfig) (SQLConfig, error) {
+	postgresConfigured, sqliteConfigured := detectSQLPrefixes(v)
+
+	switch {
+	case postgresConfigured && sqliteConfigured:
+		return nil, ErrMultipleSQLConfigsDetected
+	case postgresConfigured:
+		if postgres == nil {
+			postgres = &PostgresConfig{}
+		}
+		if err := validate.Struct(postgres); err != nil {
+			return nil, fmt.Errorf("invalid POSTGRES configuration: %w", err)
+		}
+		return postgres, nil
+	case sqliteConfigured:
+		if sqlite == nil {
+			sqlite = &SQLiteConfig{}
+		}
+		if err := validate.Struct(sqlite); err != nil {
+			return nil, fmt.Errorf("invalid SQLITE configuration: %w", err)
+		}
+		return sqlite, nil
+	default:
+		return nil, ErrNoSQLConfigConfigured
+	}
+}
+
+func SelectedSQLConfig(postgres *PostgresConfig, sqlite *SQLiteConfig) SQLConfig {
+	if postgres != nil && sqlite != nil {
+		panic("SelectedSQLConfig requires exactly one SQL config; both postgres and sqlite were provided")
+	}
+	if sqlite != nil {
+		return sqlite
+	}
+	return postgres
+}
+
+func detectSQLPrefixes(v *viper.Viper) (bool, bool) {
+	return hasConfigPrefix(v, "POSTGRES"), hasConfigPrefix(v, "SQLITE")
+}
+
+func hasConfigPrefix(v *viper.Viper, prefix string) bool {
+	prefix = strings.ToUpper(prefix) + "__"
+	for _, key := range v.AllKeys() {
+		normalizedKey := strings.ToUpper(strings.ReplaceAll(key, ".", "__"))
+		if strings.HasPrefix(normalizedKey, prefix) {
+			return true
+		}
+	}
+	for _, env := range os.Environ() {
+		name, _, found := strings.Cut(env, "=")
+		if found && strings.HasPrefix(strings.ToUpper(name), prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/configs/sql_config_test.go
+++ b/pkg/configs/sql_config_test.go
@@ -1,0 +1,106 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/viper"
+)
+
+func TestResolveSQLConfig(t *testing.T) {
+	validate := validator.New()
+
+	t.Run("postgres", func(t *testing.T) {
+		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
+		v.Set("POSTGRES__HOST", "localhost")
+		v.Set("POSTGRES__DB_NAME", "app")
+		v.Set("POSTGRES__AUTH__USER", "user")
+		v.Set("POSTGRES__AUTH__PASSWORD", "pass")
+		v.Set("POSTGRES__PORT", 5432)
+		v.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
+		v.Set("POSTGRES__MAX_IDEAL_CONNECTION", 5)
+		v.Set("POSTGRES__SSL_MODE", "disable")
+
+		cfg, err := ResolveSQLConfig(v, validate,
+			&PostgresConfig{
+				Host:               "localhost",
+				DBName:             "app",
+				Auth:               BasicAuth{User: "user", Password: "pass"},
+				Port:               5432,
+				MaxOpenConnection:  10,
+				MaxIdealConnection: 5,
+				SslMode:            "disable",
+			},
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("ResolveSQLConfig returned error: %v", err)
+		}
+		if cfg.DriverName() != "postgres" {
+			t.Fatalf("DriverName() = %q, want %q", cfg.DriverName(), "postgres")
+		}
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
+		v.Set("SQLITE__PATH", "/tmp/rapida.db")
+		v.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
+		v.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+
+		cfg, err := ResolveSQLConfig(v, validate, nil, &SQLiteConfig{
+			Path:               "/tmp/rapida.db",
+			MaxOpenConnection:  1,
+			MaxIdealConnection: 1,
+		})
+		if err != nil {
+			t.Fatalf("ResolveSQLConfig returned error: %v", err)
+		}
+		if cfg.DriverName() != "sqlite" {
+			t.Fatalf("DriverName() = %q, want %q", cfg.DriverName(), "sqlite")
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
+		_, err := ResolveSQLConfig(v, validate, nil, nil)
+		if err != ErrNoSQLConfigConfigured {
+			t.Fatalf("ResolveSQLConfig() error = %v, want %v", err, ErrNoSQLConfigConfigured)
+		}
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
+		v.Set("POSTGRES__HOST", "localhost")
+		v.Set("SQLITE__PATH", "/tmp/rapida.db")
+
+		_, err := ResolveSQLConfig(v, validate, &PostgresConfig{}, &SQLiteConfig{})
+		if err != ErrMultipleSQLConfigsDetected {
+			t.Fatalf("ResolveSQLConfig() error = %v, want %v", err, ErrMultipleSQLConfigsDetected)
+		}
+	})
+}
+
+func TestSelectedSQLConfig(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		cfg := SelectedSQLConfig(&PostgresConfig{DBName: "app"}, nil)
+		if cfg == nil || cfg.DriverName() != "postgres" {
+			t.Fatalf("SelectedSQLConfig() = %#v, want postgres config", cfg)
+		}
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		cfg := SelectedSQLConfig(nil, &SQLiteConfig{Path: "/tmp/rapida.db"})
+		if cfg == nil || cfg.DriverName() != "sqlite" {
+			t.Fatalf("SelectedSQLConfig() = %#v, want sqlite config", cfg)
+		}
+	})
+
+	t.Run("multiple panics", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("SelectedSQLConfig() did not panic when both configs were provided")
+			}
+		}()
+		_ = SelectedSQLConfig(&PostgresConfig{DBName: "app"}, &SQLiteConfig{Path: "/tmp/rapida.db"})
+	})
+}

--- a/pkg/configs/sql_config_test.go
+++ b/pkg/configs/sql_config_test.go
@@ -1,6 +1,8 @@
 package configs
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
@@ -18,18 +20,18 @@ func TestResolveSQLConfig(t *testing.T) {
 		v.Set("POSTGRES__AUTH__PASSWORD", "pass")
 		v.Set("POSTGRES__PORT", 5432)
 		v.Set("POSTGRES__MAX_OPEN_CONNECTION", 10)
-		v.Set("POSTGRES__MAX_IDEAL_CONNECTION", 5)
+		v.Set("POSTGRES__MAX_IDLE_CONNECTION", 5)
 		v.Set("POSTGRES__SSL_MODE", "disable")
 
 		cfg, err := ResolveSQLConfig(v, validate,
 			&PostgresConfig{
-				Host:               "localhost",
-				DBName:             "app",
-				Auth:               BasicAuth{User: "user", Password: "pass"},
-				Port:               5432,
-				MaxOpenConnection:  10,
-				MaxIdealConnection: 5,
-				SslMode:            "disable",
+				Host:              "localhost",
+				DBName:            "app",
+				Auth:              BasicAuth{User: "user", Password: "pass"},
+				Port:              5432,
+				MaxOpenConnection: 10,
+				MaxIdleConnection: 5,
+				SslMode:           "disable",
 			},
 			nil,
 		)
@@ -45,12 +47,12 @@ func TestResolveSQLConfig(t *testing.T) {
 		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
 		v.Set("SQLITE__PATH", "/tmp/rapida.db")
 		v.Set("SQLITE__MAX_OPEN_CONNECTION", 1)
-		v.Set("SQLITE__MAX_IDEAL_CONNECTION", 1)
+		v.Set("SQLITE__MAX_IDLE_CONNECTION", 1)
 
 		cfg, err := ResolveSQLConfig(v, validate, nil, &SQLiteConfig{
-			Path:               "/tmp/rapida.db",
-			MaxOpenConnection:  1,
-			MaxIdealConnection: 1,
+			Path:              "/tmp/rapida.db",
+			MaxOpenConnection: 1,
+			MaxIdleConnection: 1,
 		})
 		if err != nil {
 			t.Fatalf("ResolveSQLConfig returned error: %v", err)
@@ -82,25 +84,67 @@ func TestResolveSQLConfig(t *testing.T) {
 
 func TestSelectedSQLConfig(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		cfg := SelectedSQLConfig(&PostgresConfig{DBName: "app"}, nil)
-		if cfg == nil || cfg.DriverName() != "postgres" {
-			t.Fatalf("SelectedSQLConfig() = %#v, want postgres config", cfg)
+		cfg, err := SelectedSQLConfig(&PostgresConfig{DBName: "app"}, nil)
+		if err != nil || cfg == nil || cfg.DriverName() != "postgres" {
+			t.Fatalf("SelectedSQLConfig() = %#v, %v, want postgres config", cfg, err)
 		}
 	})
 
 	t.Run("sqlite", func(t *testing.T) {
-		cfg := SelectedSQLConfig(nil, &SQLiteConfig{Path: "/tmp/rapida.db"})
-		if cfg == nil || cfg.DriverName() != "sqlite" {
-			t.Fatalf("SelectedSQLConfig() = %#v, want sqlite config", cfg)
+		cfg, err := SelectedSQLConfig(nil, &SQLiteConfig{Path: "/tmp/rapida.db"})
+		if err != nil || cfg == nil || cfg.DriverName() != "sqlite" {
+			t.Fatalf("SelectedSQLConfig() = %#v, %v, want sqlite config", cfg, err)
 		}
 	})
 
-	t.Run("multiple panics", func(t *testing.T) {
-		defer func() {
-			if recover() == nil {
-				t.Fatal("SelectedSQLConfig() did not panic when both configs were provided")
-			}
-		}()
-		_ = SelectedSQLConfig(&PostgresConfig{DBName: "app"}, &SQLiteConfig{Path: "/tmp/rapida.db"})
+	t.Run("multiple", func(t *testing.T) {
+		_, err := SelectedSQLConfig(&PostgresConfig{DBName: "app"}, &SQLiteConfig{Path: "/tmp/rapida.db"})
+		if err != ErrMultipleSQLConfigsDetected {
+			t.Fatalf("SelectedSQLConfig() error = %v, want %v", err, ErrMultipleSQLConfigsDetected)
+		}
 	})
+
+	t.Run("none", func(t *testing.T) {
+		cfg, err := SelectedSQLConfig(nil, nil)
+		if err != ErrNoSQLConfigConfigured {
+			t.Fatalf("SelectedSQLConfig() error = %v, want %v", err, ErrNoSQLConfigConfigured)
+		}
+		if cfg != nil {
+			t.Fatalf("SelectedSQLConfig() = %#v, want nil config", cfg)
+		}
+	})
+}
+
+func TestPostgresConfig_MigrationDSN(t *testing.T) {
+	cfg := &PostgresConfig{
+		Host:              "localhost",
+		Port:              5432,
+		DBName:            "mydb",
+		Auth:              BasicAuth{User: "user@x", Password: "p:a ss"},
+		SslMode:           "disable",
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 2,
+	}
+	dsn := cfg.MigrationDSN()
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	if u.Scheme != "postgres" {
+		t.Fatalf("scheme = %q", u.Scheme)
+	}
+	if !strings.Contains(dsn, "mydb") {
+		t.Fatalf("dsn missing db name: %s", dsn)
+	}
+	if u.Query().Get("sslmode") != "disable" {
+		t.Fatalf("sslmode = %q", u.Query().Get("sslmode"))
+	}
+}
+
+func TestSQLiteConfig_MigrationDSN(t *testing.T) {
+	cfg := &SQLiteConfig{Path: "/tmp/rapida.db", MaxIdleConnection: 1, MaxOpenConnection: 1}
+	want := "sqlite3:///tmp/rapida.db"
+	if got := cfg.MigrationDSN(); got != want {
+		t.Fatalf("MigrationDSN() = %q, want %q", got, want)
+	}
 }

--- a/pkg/configs/sql_config_test.go
+++ b/pkg/configs/sql_config_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"errors"
 	"net/url"
 	"strings"
 	"testing"
@@ -65,7 +66,7 @@ func TestResolveSQLConfig(t *testing.T) {
 	t.Run("missing", func(t *testing.T) {
 		v := viper.NewWithOptions(viper.KeyDelimiter("__"))
 		_, err := ResolveSQLConfig(v, validate, nil, nil)
-		if err != ErrNoSQLConfigConfigured {
+		if !errors.Is(err, ErrNoSQLConfigConfigured) {
 			t.Fatalf("ResolveSQLConfig() error = %v, want %v", err, ErrNoSQLConfigConfigured)
 		}
 	})
@@ -76,7 +77,7 @@ func TestResolveSQLConfig(t *testing.T) {
 		v.Set("SQLITE__PATH", "/tmp/rapida.db")
 
 		_, err := ResolveSQLConfig(v, validate, &PostgresConfig{}, &SQLiteConfig{})
-		if err != ErrMultipleSQLConfigsDetected {
+		if !errors.Is(err, ErrMultipleSQLConfigsDetected) {
 			t.Fatalf("ResolveSQLConfig() error = %v, want %v", err, ErrMultipleSQLConfigsDetected)
 		}
 	})
@@ -99,14 +100,14 @@ func TestSelectedSQLConfig(t *testing.T) {
 
 	t.Run("multiple", func(t *testing.T) {
 		_, err := SelectedSQLConfig(&PostgresConfig{DBName: "app"}, &SQLiteConfig{Path: "/tmp/rapida.db"})
-		if err != ErrMultipleSQLConfigsDetected {
+		if !errors.Is(err, ErrMultipleSQLConfigsDetected) {
 			t.Fatalf("SelectedSQLConfig() error = %v, want %v", err, ErrMultipleSQLConfigsDetected)
 		}
 	})
 
 	t.Run("none", func(t *testing.T) {
 		cfg, err := SelectedSQLConfig(nil, nil)
-		if err != ErrNoSQLConfigConfigured {
+		if !errors.Is(err, ErrNoSQLConfigConfigured) {
 			t.Fatalf("SelectedSQLConfig() error = %v, want %v", err, ErrNoSQLConfigConfigured)
 		}
 		if cfg != nil {

--- a/pkg/configs/sqlite_config.go
+++ b/pkg/configs/sqlite_config.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package configs
+
+type SQLiteConfig struct {
+	Path               string `mapstructure:"path" validate:"required"`
+	MaxIdealConnection int    `mapstructure:"max_ideal_connection" validate:"required"`
+	MaxOpenConnection  int    `mapstructure:"max_open_connection" validate:"required"`
+}

--- a/pkg/configs/sqlite_config.go
+++ b/pkg/configs/sqlite_config.go
@@ -6,7 +6,7 @@
 package configs
 
 type SQLiteConfig struct {
-	Path               string `mapstructure:"path" validate:"required"`
-	MaxIdealConnection int    `mapstructure:"max_ideal_connection" validate:"required"`
-	MaxOpenConnection  int    `mapstructure:"max_open_connection" validate:"required"`
+	Path              string `mapstructure:"path" validate:"required"`
+	MaxIdleConnection int    `mapstructure:"max_idle_connection" validate:"gte=0"`
+	MaxOpenConnection int    `mapstructure:"max_open_connection" validate:"gte=0"`
 }

--- a/pkg/connectors/postgres.go
+++ b/pkg/connectors/postgres.go
@@ -21,15 +21,6 @@ import (
 
 type postgresTxContextKey struct{}
 
-type SQLConnector interface {
-	Connector
-	Query(ctx context.Context, qry string, dest interface{}) error
-	DB(ctx context.Context) *gorm.DB
-}
-
-// PostgresConnector is an alias for SQLConnector for backward compatibility.
-type PostgresConnector = SQLConnector
-
 type postgresConnector struct {
 	logger commons.Logger
 	cfg    *configs.PostgresConfig

--- a/pkg/connectors/postgres.go
+++ b/pkg/connectors/postgres.go
@@ -79,7 +79,7 @@ func (psql *postgresConnector) Connect(ctx context.Context) error {
 		return err
 	}
 	// SetMaxIdleConns sets the maximum number of connections in the idle connection pool.
-	sqlDB.SetMaxIdleConns(psql.cfg.MaxIdealConnection)
+	sqlDB.SetMaxIdleConns(psql.cfg.MaxIdleConnection)
 	// SetMaxOpenConns sets the maximum number of open connections to the database.
 	sqlDB.SetMaxOpenConns(psql.cfg.MaxOpenConnection)
 	// SetConnMaxLifetime sets the maximum amount of time a connection may be reused.

--- a/pkg/connectors/postgres.go
+++ b/pkg/connectors/postgres.go
@@ -21,11 +21,14 @@ import (
 
 type postgresTxContextKey struct{}
 
-type PostgresConnector interface {
+type SQLConnector interface {
 	Connector
 	Query(ctx context.Context, qry string, dest interface{}) error
 	DB(ctx context.Context) *gorm.DB
 }
+
+// PostgresConnector is an alias for SQLConnector for backward compatibility.
+type PostgresConnector = SQLConnector
 
 type postgresConnector struct {
 	logger commons.Logger
@@ -33,7 +36,7 @@ type postgresConnector struct {
 	db     *gorm.DB
 }
 
-func NewPostgresConnector(config *configs.PostgresConfig, logger commons.Logger) PostgresConnector {
+func NewPostgresConnector(config *configs.PostgresConfig, logger commons.Logger) SQLConnector {
 	return &postgresConnector{cfg: config, logger: logger}
 }
 

--- a/pkg/connectors/postgres_test.go
+++ b/pkg/connectors/postgres_test.go
@@ -21,10 +21,7 @@ import (
 
 // Local config struct for testing - removed since we can use configs package
 
-func TestNewSQLConnector(t *testing.T) {
-	// Requires external config and logger packages
-	t.Skip("Requires external packages - integration test")
-}
+
 
 func TestSQLConnector_Name(t *testing.T) {
 	connector := &postgresConnector{

--- a/pkg/connectors/postgres_test.go
+++ b/pkg/connectors/postgres_test.go
@@ -21,12 +21,12 @@ import (
 
 // Local config struct for testing - removed since we can use configs package
 
-func TestNewPostgresConnector(t *testing.T) {
+func TestNewSQLConnector(t *testing.T) {
 	// Requires external config and logger packages
 	t.Skip("Requires external packages - integration test")
 }
 
-func TestPostgresConnector_Name(t *testing.T) {
+func TestSQLConnector_Name(t *testing.T) {
 	connector := &postgresConnector{
 		cfg: &configs.PostgresConfig{Host: "localhost", Port: 5432},
 	}
@@ -34,7 +34,7 @@ func TestPostgresConnector_Name(t *testing.T) {
 	assert.Equal(t, "PSQL psql://localhost:5432", result)
 }
 
-func TestPostgresConnector_DB(t *testing.T) {
+func TestSQLConnector_DB(t *testing.T) {
 	db, _, err := sqlmock.New()
 	if err != nil {
 		log.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
@@ -58,7 +58,7 @@ func TestPostgresConnector_DB(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-func TestPostgresConnector_Disconnect(t *testing.T) {
+func TestSQLConnector_Disconnect(t *testing.T) {
 	db, _, err := sqlmock.New()
 	if err != nil {
 		log.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
@@ -83,7 +83,7 @@ func TestPostgresConnector_Disconnect(t *testing.T) {
 	assert.Nil(t, connector.db)
 }
 
-func TestPostgresConnector_IsConnected(t *testing.T) {
+func TestSQLConnector_IsConnected(t *testing.T) {
 	logger, _ := commons.NewApplicationLogger()
 	connector := &postgresConnector{
 		cfg: &configs.PostgresConfig{
@@ -106,12 +106,12 @@ func TestPostgresConnector_IsConnected(t *testing.T) {
 // Note: Connect and Query methods require real PostgreSQL connection
 // and are tested as integration tests.
 
-func TestPostgresConnector_Connect_ErrorHandling(t *testing.T) {
+func TestSQLConnector_Connect_ErrorHandling(t *testing.T) {
 	// Test with invalid config
 	t.Skip("Requires external packages - integration test")
 }
 
-func TestPostgresConnector_Query_ErrorHandling(t *testing.T) {
+func TestSQLConnector_Query_ErrorHandling(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		log.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
@@ -137,7 +137,7 @@ func TestPostgresConnector_Query_ErrorHandling(t *testing.T) {
 	assert.Error(t, err) // db is nil
 }
 
-func TestPostgresConnector_EdgeCases(t *testing.T) {
+func TestSQLConnector_EdgeCases(t *testing.T) {
 	db, _, err := sqlmock.New()
 	if err != nil {
 		log.Fatalf("An error '%s' was not expected when opening a stub database connection", err)

--- a/pkg/connectors/sql.go
+++ b/pkg/connectors/sql.go
@@ -6,11 +6,24 @@
 package connectors
 
 import (
+	"context"
 	"fmt"
+
+	"gorm.io/gorm"
 
 	commons "github.com/rapidaai/pkg/commons"
 	configs "github.com/rapidaai/pkg/configs"
 )
+
+// SQLConnector is the shared database connector abstraction (Postgres, SQLite, etc.).
+type SQLConnector interface {
+	Connector
+	Query(ctx context.Context, qry string, dest interface{}) error
+	DB(ctx context.Context) *gorm.DB
+}
+
+// PostgresConnector is an alias for SQLConnector for backward compatibility.
+type PostgresConnector = SQLConnector
 
 func NewSQLConnector(config configs.SQLConfig, logger commons.Logger) (SQLConnector, error) {
 	if config == nil {

--- a/pkg/connectors/sql.go
+++ b/pkg/connectors/sql.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package connectors
+
+import (
+	commons "github.com/rapidaai/pkg/commons"
+	configs "github.com/rapidaai/pkg/configs"
+)
+
+func NewSQLConnector(config configs.SQLConfig, logger commons.Logger) SQLConnector {
+	switch cfg := config.(type) {
+	case *configs.PostgresConfig:
+		return NewPostgresConnector(cfg, logger)
+	case *configs.SQLiteConfig:
+		return NewSQLiteConnector(cfg, logger)
+	default:
+		return nil
+	}
+}

--- a/pkg/connectors/sql.go
+++ b/pkg/connectors/sql.go
@@ -6,17 +6,22 @@
 package connectors
 
 import (
+	"fmt"
+
 	commons "github.com/rapidaai/pkg/commons"
 	configs "github.com/rapidaai/pkg/configs"
 )
 
-func NewSQLConnector(config configs.SQLConfig, logger commons.Logger) SQLConnector {
+func NewSQLConnector(config configs.SQLConfig, logger commons.Logger) (SQLConnector, error) {
+	if config == nil {
+		return nil, fmt.Errorf("sql config is nil")
+	}
 	switch cfg := config.(type) {
 	case *configs.PostgresConfig:
-		return NewPostgresConnector(cfg, logger)
+		return NewPostgresConnector(cfg, logger), nil
 	case *configs.SQLiteConfig:
-		return NewSQLiteConnector(cfg, logger)
+		return NewSQLiteConnector(cfg, logger), nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported SQL config type %T; expected *PostgresConfig or *SQLiteConfig", config)
 	}
 }

--- a/pkg/connectors/sql_test.go
+++ b/pkg/connectors/sql_test.go
@@ -1,0 +1,66 @@
+package connectors
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commons "github.com/rapidaai/pkg/commons"
+	configs "github.com/rapidaai/pkg/configs"
+)
+
+func TestNewSQLConnector_PostgresDispatch(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	cfg := &configs.PostgresConfig{
+		Host:              "localhost",
+		DBName:            "app",
+		Port:              5432,
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 2,
+		SslMode:           "disable",
+		Auth:              configs.BasicAuth{User: "u", Password: "p"},
+	}
+	connector, err := NewSQLConnector(cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, connector)
+	assert.Contains(t, connector.Name(), "PSQL")
+}
+
+func TestNewSQLConnector_SQLiteDispatch(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	cfg := &configs.SQLiteConfig{
+		Path:              filepath.Join(t.TempDir(), "factory.db"),
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 1,
+	}
+	connector, err := NewSQLConnector(cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, connector)
+	ctx := context.Background()
+	require.NoError(t, connector.Connect(ctx))
+	assert.Contains(t, connector.Name(), "SQLITE")
+}
+
+func TestNewSQLConnector_NilConfig(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	_, err := NewSQLConnector(nil, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestNewSQLConnector_UnsupportedConfigType(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	_, err := NewSQLConnector(unsupportedConfig{}, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported SQL config type")
+}
+
+type unsupportedConfig struct{}
+
+func (unsupportedConfig) DriverName() string            { return "unsupported" }
+func (unsupportedConfig) MigrationDriverName() string   { return "unsupported" }
+func (unsupportedConfig) MigrationDSN() string          { return "" }
+func (unsupportedConfig) DisplayName() string           { return "unsupported" }

--- a/pkg/connectors/sqlite.go
+++ b/pkg/connectors/sqlite.go
@@ -7,9 +7,11 @@ package connectors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gorm.io/driver/sqlite"
@@ -19,6 +21,8 @@ import (
 	commons "github.com/rapidaai/pkg/commons"
 	configs "github.com/rapidaai/pkg/configs"
 )
+
+var errSQLiteNotConnected = errors.New("sqlite connector not connected")
 
 type sqliteConnector struct {
 	logger commons.Logger
@@ -31,36 +35,48 @@ func NewSQLiteConnector(config *configs.SQLiteConfig, logger commons.Logger) SQL
 }
 
 func (sqlt *sqliteConnector) DB(ctx context.Context) *gorm.DB {
+	if sqlt.db == nil {
+		return &gorm.DB{Error: errSQLiteNotConnected}
+	}
 	return sqlt.db.WithContext(ctx)
 }
 
+func sqliteDSN(path string) string {
+	if path == "" || path == ":memory:" {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + "_foreign_keys=1"
+}
+
 func (sqlt *sqliteConnector) Connect(ctx context.Context) error {
+	if sqlt.cfg.Path == "" {
+		return fmt.Errorf("sqlite path is required")
+	}
 	if err := ensureSQLiteParentDir(sqlt.cfg.Path); err != nil {
 		return err
 	}
 
 	lgr := logger.Discard.LogMode(logger.Silent)
-	db, err := gorm.Open(sqlite.Open(sqlt.cfg.Path), &gorm.Config{
+	db, err := gorm.Open(sqlite.Open(sqliteDSN(sqlt.cfg.Path)), &gorm.Config{
 		Logger: lgr,
 	})
 	if err != nil {
-		sqlt.logger.Errorf("Failed to open sqlite connection %s.", err)
+		sqlt.logger.Errorf("Failed to open sqlite connection: %v", err)
 		return err
 	}
 
 	sqlDB, err := db.DB()
 	if err != nil {
-		sqlt.logger.Errorf("Failed to create sqlite client connection pool %s.", err)
+		sqlt.logger.Errorf("Failed to create sqlite client connection pool: %v", err)
 		return err
 	}
-	sqlDB.SetMaxIdleConns(sqlt.cfg.MaxIdealConnection)
+	sqlDB.SetMaxIdleConns(sqlt.cfg.MaxIdleConnection)
 	sqlDB.SetMaxOpenConns(sqlt.cfg.MaxOpenConnection)
 	sqlDB.SetConnMaxLifetime(time.Hour)
-
-	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
-		sqlt.logger.Errorf("Failed to enable sqlite foreign keys %s.", err)
-		return err
-	}
 
 	sqlt.db = db
 	return nil
@@ -76,11 +92,11 @@ func (sqlt *sqliteConnector) IsConnected(ctx context.Context) bool {
 	}
 	db, err := sqlt.db.DB()
 	if err != nil {
-		sqlt.logger.Errorf("Failed to get sqlite client %s.", err)
+		sqlt.logger.Errorf("Failed to get sqlite client: %v", err)
 		return false
 	}
 	if err := db.PingContext(ctx); err != nil {
-		sqlt.logger.Errorf("Failed to ping sqlite client %s.", err)
+		sqlt.logger.Errorf("Failed to ping sqlite client: %v", err)
 		return false
 	}
 	return true
@@ -88,20 +104,26 @@ func (sqlt *sqliteConnector) IsConnected(ctx context.Context) bool {
 
 func (sqlt *sqliteConnector) Disconnect(ctx context.Context) error {
 	sqlt.logger.Debug("Disconnecting sqlite client.")
+	if sqlt.db == nil {
+		return nil
+	}
 	db, err := sqlt.db.DB()
 	sqlt.db = nil
 	if err != nil {
-		sqlt.logger.Errorf("Disconnecting sqlite client %s.", err)
+		sqlt.logger.Errorf("Failed to get underlying sqlite DB: %v", err)
 		return err
 	}
 	if err := db.Close(); err != nil {
-		sqlt.logger.Debug("Disconnecting sqlite client %s.", err)
+		sqlt.logger.Errorf("Failed to close sqlite client: %v", err)
 		return err
 	}
 	return nil
 }
 
 func (sqlt *sqliteConnector) Query(ctx context.Context, qry string, dest interface{}) error {
+	if sqlt.db == nil {
+		return errSQLiteNotConnected
+	}
 	tx := sqlt.db.WithContext(ctx).Raw(qry).Scan(dest)
 	return tx.Error
 }

--- a/pkg/connectors/sqlite.go
+++ b/pkg/connectors/sqlite.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	commons "github.com/rapidaai/pkg/commons"
+	configs "github.com/rapidaai/pkg/configs"
+)
+
+type sqliteConnector struct {
+	logger commons.Logger
+	cfg    *configs.SQLiteConfig
+	db     *gorm.DB
+}
+
+func NewSQLiteConnector(config *configs.SQLiteConfig, logger commons.Logger) SQLConnector {
+	return &sqliteConnector{cfg: config, logger: logger}
+}
+
+func (sqlt *sqliteConnector) DB(ctx context.Context) *gorm.DB {
+	return sqlt.db.WithContext(ctx)
+}
+
+func (sqlt *sqliteConnector) Connect(ctx context.Context) error {
+	if err := ensureSQLiteParentDir(sqlt.cfg.Path); err != nil {
+		return err
+	}
+
+	lgr := logger.Discard.LogMode(logger.Silent)
+	db, err := gorm.Open(sqlite.Open(sqlt.cfg.Path), &gorm.Config{
+		Logger: lgr,
+	})
+	if err != nil {
+		sqlt.logger.Errorf("Failed to open sqlite connection %s.", err)
+		return err
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		sqlt.logger.Errorf("Failed to create sqlite client connection pool %s.", err)
+		return err
+	}
+	sqlDB.SetMaxIdleConns(sqlt.cfg.MaxIdealConnection)
+	sqlDB.SetMaxOpenConns(sqlt.cfg.MaxOpenConnection)
+	sqlDB.SetConnMaxLifetime(time.Hour)
+
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		sqlt.logger.Errorf("Failed to enable sqlite foreign keys %s.", err)
+		return err
+	}
+
+	sqlt.db = db
+	return nil
+}
+
+func (sqlt *sqliteConnector) Name() string {
+	return fmt.Sprintf("SQLITE sqlite3://%s", sqlt.cfg.Path)
+}
+
+func (sqlt *sqliteConnector) IsConnected(ctx context.Context) bool {
+	if sqlt.db == nil {
+		return false
+	}
+	db, err := sqlt.db.DB()
+	if err != nil {
+		sqlt.logger.Errorf("Failed to get sqlite client %s.", err)
+		return false
+	}
+	if err := db.PingContext(ctx); err != nil {
+		sqlt.logger.Errorf("Failed to ping sqlite client %s.", err)
+		return false
+	}
+	return true
+}
+
+func (sqlt *sqliteConnector) Disconnect(ctx context.Context) error {
+	sqlt.logger.Debug("Disconnecting sqlite client.")
+	db, err := sqlt.db.DB()
+	sqlt.db = nil
+	if err != nil {
+		sqlt.logger.Errorf("Disconnecting sqlite client %s.", err)
+		return err
+	}
+	if err := db.Close(); err != nil {
+		sqlt.logger.Debug("Disconnecting sqlite client %s.", err)
+		return err
+	}
+	return nil
+}
+
+func (sqlt *sqliteConnector) Query(ctx context.Context, qry string, dest interface{}) error {
+	tx := sqlt.db.WithContext(ctx).Raw(qry).Scan(dest)
+	return tx.Error
+}
+
+func ensureSQLiteParentDir(path string) error {
+	if path == "" || path == ":memory:" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/pkg/connectors/sqlite_test.go
+++ b/pkg/connectors/sqlite_test.go
@@ -1,0 +1,61 @@
+package connectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commons "github.com/rapidaai/pkg/commons"
+	configs "github.com/rapidaai/pkg/configs"
+)
+
+func TestSQLiteConnector_Lifecycle(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	path := filepath.Join(t.TempDir(), "data", "rapida.db")
+	connector := NewSQLiteConnector(&configs.SQLiteConfig{
+		Path:               path,
+		MaxIdealConnection: 1,
+		MaxOpenConnection:  1,
+	}, logger)
+
+	ctx := context.Background()
+	require.NoError(t, connector.Connect(ctx))
+	assert.True(t, connector.IsConnected(ctx))
+	assert.Equal(t, "SQLITE sqlite3://"+path, connector.Name())
+
+	db := connector.DB(ctx)
+	require.NoError(t, db.Exec("CREATE TABLE test_items (name TEXT NOT NULL)").Error)
+	require.NoError(t, db.Exec("INSERT INTO test_items(name) VALUES (?)", "sqlite").Error)
+
+	var rows []struct {
+		Name string
+	}
+	require.NoError(t, connector.Query(ctx, "SELECT name FROM test_items", &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "sqlite", rows[0].Name)
+	assert.FileExists(t, path)
+
+	require.NoError(t, connector.Disconnect(ctx))
+	assert.False(t, connector.IsConnected(ctx))
+}
+
+func TestNewSQLConnector_SQLite(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	connector := NewSQLConnector(&configs.SQLiteConfig{
+		Path:               filepath.Join(t.TempDir(), "rapida.db"),
+		MaxIdealConnection: 1,
+		MaxOpenConnection:  1,
+	}, logger)
+	require.NotNil(t, connector)
+}
+
+func TestEnsureSQLiteParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "sqlite.db")
+	require.NoError(t, ensureSQLiteParentDir(path))
+	_, err := os.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+}

--- a/pkg/connectors/sqlite_test.go
+++ b/pkg/connectors/sqlite_test.go
@@ -17,9 +17,9 @@ func TestSQLiteConnector_Lifecycle(t *testing.T) {
 	logger, _ := commons.NewApplicationLogger()
 	path := filepath.Join(t.TempDir(), "data", "rapida.db")
 	connector := NewSQLiteConnector(&configs.SQLiteConfig{
-		Path:               path,
-		MaxIdealConnection: 1,
-		MaxOpenConnection:  1,
+		Path:              path,
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 1,
 	}, logger)
 
 	ctx := context.Background()
@@ -28,6 +28,7 @@ func TestSQLiteConnector_Lifecycle(t *testing.T) {
 	assert.Equal(t, "SQLITE sqlite3://"+path, connector.Name())
 
 	db := connector.DB(ctx)
+	require.NoError(t, db.Error)
 	require.NoError(t, db.Exec("CREATE TABLE test_items (name TEXT NOT NULL)").Error)
 	require.NoError(t, db.Exec("INSERT INTO test_items(name) VALUES (?)", "sqlite").Error)
 
@@ -41,16 +42,50 @@ func TestSQLiteConnector_Lifecycle(t *testing.T) {
 
 	require.NoError(t, connector.Disconnect(ctx))
 	assert.False(t, connector.IsConnected(ctx))
+	require.NoError(t, connector.Disconnect(ctx))
+}
+
+func TestSQLiteConnector_ConnectInvalidPath(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	connector := NewSQLiteConnector(&configs.SQLiteConfig{
+		Path:              "",
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 1,
+	}, logger)
+	err := connector.Connect(context.Background())
+	require.Error(t, err)
+}
+
+func TestSQLiteConnector_DBBeforeConnect(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	connector := NewSQLiteConnector(&configs.SQLiteConfig{
+		Path:              filepath.Join(t.TempDir(), "x.db"),
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 1,
+	}, logger)
+	db := connector.DB(context.Background())
+	require.Error(t, db.Error)
 }
 
 func TestNewSQLConnector_SQLite(t *testing.T) {
 	logger, _ := commons.NewApplicationLogger()
-	connector := NewSQLConnector(&configs.SQLiteConfig{
-		Path:               filepath.Join(t.TempDir(), "rapida.db"),
-		MaxIdealConnection: 1,
-		MaxOpenConnection:  1,
+	path := filepath.Join(t.TempDir(), "rapida.db")
+	connector, err := NewSQLConnector(&configs.SQLiteConfig{
+		Path:              path,
+		MaxIdleConnection: 1,
+		MaxOpenConnection: 1,
 	}, logger)
+	require.NoError(t, err)
 	require.NotNil(t, connector)
+	ctx := context.Background()
+	require.NoError(t, connector.Connect(ctx))
+	assert.Contains(t, connector.Name(), "SQLITE sqlite3://")
+}
+
+func TestNewSQLConnector_UnsupportedType(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	_, err := NewSQLConnector(nil, logger)
+	require.Error(t, err)
 }
 
 func TestEnsureSQLiteParentDir(t *testing.T) {

--- a/pkg/connectors/sqlite_test.go
+++ b/pkg/connectors/sqlite_test.go
@@ -82,12 +82,6 @@ func TestNewSQLConnector_SQLite(t *testing.T) {
 	assert.Contains(t, connector.Name(), "SQLITE sqlite3://")
 }
 
-func TestNewSQLConnector_UnsupportedType(t *testing.T) {
-	logger, _ := commons.NewApplicationLogger()
-	_, err := NewSQLConnector(nil, logger)
-	require.Error(t, err)
-}
-
 func TestEnsureSQLiteParentDir(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "sqlite.db")
 	require.NoError(t, ensureSQLiteParentDir(path))


### PR DESCRIPTION
## Summary
Adds SQLite support for Go services alongside Postgres.

Resolves #78.

## Changes
- add SQLite config and connector support
- select exactly one SQL backend: Postgres or SQLite
- reject ambiguous multi-SQL config
- skip bundled migrations when SQLite is selected because current migrations are Postgres-specific
- rename shared connector type usage to SQLConnector

## Validation
- go test -p 1 ./pkg/configs ./pkg/connectors ./api/integration-api/config ./api/endpoint-api/config ./api/assistant-api/config ./api/web-api/config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite as an alternative SQL backend alongside Postgres.
  * Services now auto-select the active SQL backend from configuration (Postgres `POSTGRES__*` vs SQLite `SQLITE__*`), ensuring only one is enabled.

* **Bug Fixes**
  * Clearer validation errors when multiple SQL backends are configured at once.
  * Database migrations are skipped when using SQLite to avoid unsupported startup behavior.

* **Documentation**
  * Expanded local development (no Docker) guidance for Go services with `SQLITE__*` example settings and migration caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->