### PR TITLE
feat: add OpenAI-compatible LLM provider (vLLM/Ollama/etc.)

### DIFF
--- a/api/integration-api/internal/caller/caller.go
+++ b/api/integration-api/internal/caller/caller.go
@@ -9,6 +9,7 @@ import (
 	internal_anthropic_callers "github.com/rapidaai/api/integration-api/internal/caller/anthropic"
 	internal_azure_callers "github.com/rapidaai/api/integration-api/internal/caller/azure"
 	internal_cohere_callers "github.com/rapidaai/api/integration-api/internal/caller/cohere"
+	internal_custom_llm_callers "github.com/rapidaai/api/integration-api/internal/caller/custom_llm"
 	internal_gemini_callers "github.com/rapidaai/api/integration-api/internal/caller/gemini"
 	internal_huggingface_callers "github.com/rapidaai/api/integration-api/internal/caller/huggingface"
 	internal_mistral_callers "github.com/rapidaai/api/integration-api/internal/caller/mistral"
@@ -24,22 +25,25 @@ import (
 type IntegrationProvider string
 
 const (
-	OPENAI      IntegrationProvider = "openai"
-	ANTHROPIC   IntegrationProvider = "anthropic"
-	GEMINI      IntegrationProvider = "gemini"
-	VERTEXAI    IntegrationProvider = "vertexai"
-	AZURE       IntegrationProvider = "azure-foundry"
-	COHERE      IntegrationProvider = "cohere"
-	MISTRAL     IntegrationProvider = "mistral"
-	REPLICATE   IntegrationProvider = "replicate"
-	HUGGINGFACE IntegrationProvider = "huggingface"
-	VOYAGEAI    IntegrationProvider = "voyageai"
+	OPENAI     IntegrationProvider = "openai"
+	CUSTOM_LLM IntegrationProvider = "custom-llm"
+	ANTHROPIC         IntegrationProvider = "anthropic"
+	GEMINI            IntegrationProvider = "gemini"
+	VERTEXAI          IntegrationProvider = "vertexai"
+	AZURE             IntegrationProvider = "azure-foundry"
+	COHERE            IntegrationProvider = "cohere"
+	MISTRAL           IntegrationProvider = "mistral"
+	REPLICATE         IntegrationProvider = "replicate"
+	HUGGINGFACE       IntegrationProvider = "huggingface"
+	VOYAGEAI          IntegrationProvider = "voyageai"
 )
 
 func GetLargeLanguageCaller(logger commons.Logger, provider string, credential *protos.Credential) (internal_types.LargeLanguageCaller, error) {
 	switch IntegrationProvider(provider) {
 	case OPENAI:
 		return internal_openai_callers.NewLargeLanguageCaller(logger, credential), nil
+	case CUSTOM_LLM:
+		return internal_custom_llm_callers.NewLargeLanguageCaller(logger, credential), nil
 	case ANTHROPIC:
 		return internal_anthropic_callers.NewLargeLanguageCaller(logger, credential), nil
 	case GEMINI:
@@ -99,6 +103,8 @@ func GetVerifier(logger commons.Logger, provider string, credential *protos.Cred
 	switch IntegrationProvider(provider) {
 	case OPENAI:
 		return internal_openai_callers.NewVerifyCredentialCaller(logger, credential), nil
+	case CUSTOM_LLM:
+		return internal_custom_llm_callers.NewVerifyCredentialCaller(logger, credential), nil
 	case ANTHROPIC:
 		return internal_anthropic_callers.NewVerifyCredentialCaller(logger, credential), nil
 	case GEMINI:

--- a/api/integration-api/internal/caller/custom_llm/custom_llm.go
+++ b/api/integration-api/internal/caller/custom_llm/custom_llm.go
@@ -1,0 +1,150 @@
+// Rapida – Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_custom_llm_callers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+	integration_api "github.com/rapidaai/protos"
+)
+
+type CustomLLM struct {
+	logger     commons.Logger
+	credential internal_callers.CredentialResolver
+}
+
+const (
+	CRED_API_COMPATIBILITY = "apiCompatibility"
+	CRED_BASE_URL          = "baseUrl"
+	CRED_HEADERS           = "headers"
+)
+
+const (
+	CompatOpenAI    = "openai"
+	CompatAnthropic = "anthropic"
+	CompatCustom    = "custom"
+)
+
+const (
+	ChatRoleAssistant string = "assistant"
+	ChatRoleFunction  string = "function"
+	ChatRoleSystem    string = "system"
+	ChatRoleTool      string = "tool"
+	ChatRoleUser      string = "user"
+)
+
+func customLLM(logger commons.Logger, credential *integration_api.Credential) CustomLLM {
+	_credential := credential.GetValue().AsMap()
+	return CustomLLM{
+		logger: logger,
+		credential: func() map[string]interface{} {
+			return _credential
+		},
+	}
+}
+
+func (cl *CustomLLM) GetClient() (*openai.Client, error) {
+	credentials := cl.credential()
+
+	compat := strings.ToLower(strings.TrimSpace(stringValue(credentials, CRED_API_COMPATIBILITY)))
+	if compat == "" {
+		compat = CompatOpenAI
+	}
+	if compat != CompatOpenAI {
+		return nil, fmt.Errorf("custom-llm: api compatibility %q is not implemented", compat)
+	}
+
+	baseURL := strings.TrimSpace(stringValue(credentials, CRED_BASE_URL))
+	if baseURL == "" {
+		cl.logger.Errorf("custom-llm: missing base url")
+		return nil, errors.New("custom-llm: base url must be a non-empty string")
+	}
+
+	opts := []option.RequestOption{
+		option.WithBaseURL(baseURL),
+	}
+	for k, v := range parseHeaders(credentials[CRED_HEADERS]) {
+		opts = append(opts, option.WithHeader(k, v))
+	}
+
+	client := openai.NewClient(opts...)
+	return &client, nil
+}
+
+func (cl *CustomLLM) GetCompletionUsages(usages openai.CompletionUsage) []*integration_api.Metric {
+	metrics := make([]*integration_api.Metric, 0)
+	metrics = append(metrics, &integration_api.Metric{
+		Name:        type_enums.OUTPUT_TOKEN.String(),
+		Value:       fmt.Sprintf("%d", usages.CompletionTokens),
+		Description: "LLM Output token",
+	})
+
+	metrics = append(metrics, &integration_api.Metric{
+		Name:        type_enums.INPUT_TOKEN.String(),
+		Value:       fmt.Sprintf("%d", usages.PromptTokens),
+		Description: "LLM Input Token",
+	})
+
+	metrics = append(metrics, &integration_api.Metric{
+		Name:        type_enums.TOTAL_TOKEN.String(),
+		Value:       fmt.Sprintf("%d", usages.TotalTokens),
+		Description: "Total Token",
+	})
+	return metrics
+}
+
+func stringValue(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+func parseHeaders(raw interface{}) map[string]string {
+	out := map[string]string{}
+	if raw == nil {
+		return out
+	}
+	switch v := raw.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return out
+		}
+		var decoded map[string]interface{}
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+			return out
+		}
+		for k, val := range decoded {
+			if s, ok := val.(string); ok {
+				out[k] = s
+			} else {
+				out[k] = fmt.Sprintf("%v", val)
+			}
+		}
+	case map[string]interface{}:
+		for k, val := range v {
+			if s, ok := val.(string); ok {
+				out[k] = s
+			} else {
+				out[k] = fmt.Sprintf("%v", val)
+			}
+		}
+	}
+	return out
+}

--- a/api/integration-api/internal/caller/custom_llm/llm.go
+++ b/api/integration-api/internal/caller/custom_llm/llm.go
@@ -1,0 +1,561 @@
+package internal_custom_llm_callers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
+
+	internal_caller_metrics "github.com/rapidaai/api/integration-api/internal/caller/metrics"
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
+)
+
+type largeLanguageCaller struct {
+	CustomLLM
+}
+
+func NewLargeLanguageCaller(logger commons.Logger, credential *protos.Credential) internal_callers.LargeLanguageCaller {
+	return &largeLanguageCaller{
+		CustomLLM: customLLM(logger, credential),
+	}
+}
+
+func (llc *largeLanguageCaller) GetChatCompletion(
+	ctx context.Context,
+	allMessages []*protos.Message,
+	options *internal_callers.ChatCompletionOptions,
+) (*protos.Message, []*protos.Metric, error) {
+	metrics := internal_caller_metrics.NewMetricBuilder(options.RequestId)
+	metrics.OnStart()
+
+	client, err := llc.GetClient()
+	if err != nil {
+		llc.logger.Errorf("chat completion unable to get client for custom-llm %v", err)
+		return nil, metrics.OnFailure().Build(), err
+	}
+
+	llmRequest := llc.getChatCompleteParameter(options, false)
+	llmRequest.Messages = llc.buildHistory(allMessages)
+
+	options.PreHook(utils.ToJson(llmRequest))
+
+	resp, err := client.Chat.Completions.New(ctx, llmRequest)
+	if err != nil {
+		llc.logger.Errorf("chat completion failed to get response from custom-llm %v", err)
+		failure := metrics.OnFailure().Build()
+		payload := map[string]interface{}{"error": err}
+		if resp != nil {
+			payload["result"] = resp
+		}
+		options.PostHook(payload, failure)
+		return nil, failure, err
+	}
+
+	assistantMsg := &protos.AssistantMessage{
+		Contents:  make([]string, 0),
+		ToolCalls: make([]*protos.ToolCall, 0),
+	}
+
+	for _, choice := range resp.Choices {
+		if choice.Message.Content != "" {
+			assistantMsg.Contents = append(assistantMsg.Contents, choice.Message.Content)
+		}
+		for _, tool := range choice.Message.ToolCalls {
+			if tool.Type == "function" {
+				assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, &protos.ToolCall{
+					Id:   tool.ID,
+					Type: string(tool.Type),
+					Function: &protos.FunctionCall{
+						Name:      tool.Function.Name,
+						Arguments: tool.Function.Arguments,
+					},
+				})
+			}
+		}
+	}
+
+	message := &protos.Message{
+		Role: ChatRoleAssistant,
+		Message: &protos.Message_Assistant{
+			Assistant: assistantMsg,
+		},
+	}
+
+	metrics.OnAddMetrics(llc.GetCompletionUsages(resp.Usage)...)
+
+	options.PostHook(map[string]interface{}{
+		"result": resp,
+	}, metrics.OnSuccess().Build())
+	return message, metrics.Build(), nil
+}
+
+func (llc *largeLanguageCaller) StreamChatCompletion(
+	ctx context.Context,
+	allMessages []*protos.Message,
+	options *internal_callers.ChatCompletionOptions,
+	onStream func(string, *protos.Message) error,
+	onMetrics func(string, *protos.Message, []*protos.Metric) error,
+	onError func(string, error),
+) error {
+	start := time.Now()
+	metrics := internal_caller_metrics.NewMetricBuilder(options.RequestId)
+	metrics.OnStart()
+	var firstTokenTime *time.Time
+
+	client, err := llc.GetClient()
+	if err != nil {
+		llc.logger.Errorf("chat completion unable to get client for custom-llm: %v", err)
+		onError(options.Request.GetRequestId(), err)
+		options.PostHook(map[string]interface{}{
+			"error": err,
+		}, metrics.OnFailure().Build())
+		return err
+	}
+
+	completionsOptions := llc.getChatCompleteParameter(options, true)
+	completionsOptions.Messages = llc.buildHistory(allMessages)
+	options.PreHook(utils.ToJson(completionsOptions))
+	llc.logger.Benchmark("custom_llm.llm.GetChatCompletion.llmRequestPrepare", time.Since(start))
+
+	resp := client.Chat.Completions.NewStreaming(ctx, completionsOptions)
+	if resp.Err() != nil {
+		llc.logger.Errorf("Failed to get chat completions stream: %v", resp.Err())
+		options.PostHook(map[string]interface{}{
+			"result": utils.ToJson(resp),
+			"error":  resp.Err(),
+		}, metrics.OnFailure().Build())
+		onError(options.Request.GetRequestId(), resp.Err())
+		return resp.Err()
+	}
+	defer resp.Close()
+	assistantMsg := &protos.AssistantMessage{
+		Contents:  make([]string, 0),
+		ToolCalls: make([]*protos.ToolCall, 0),
+	}
+	contentBuffer := make([]string, 0)
+	hasToolCalls := false
+
+	accumulate := openai.ChatCompletionAccumulator{}
+	for resp.Next() {
+		chatCompletions := resp.Current()
+		accumulate.AddChunk(chatCompletions)
+
+		if tool, ok := accumulate.JustFinishedToolCall(); ok {
+			hasToolCalls = true
+			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, &protos.ToolCall{
+				Id:   tool.ID,
+				Type: "function",
+				Function: &protos.FunctionCall{
+					Name:      tool.Name,
+					Arguments: tool.Arguments,
+				},
+			})
+		}
+
+		for i, choice := range chatCompletions.Choices {
+			if len(choice.Delta.ToolCalls) > 0 {
+				hasToolCalls = true
+			}
+
+			content := choice.Delta.Content
+			if content != "" {
+				if len(contentBuffer) <= i {
+					contentBuffer = append(contentBuffer, content)
+				} else {
+					contentBuffer[i] += content
+				}
+
+				if !hasToolCalls {
+					if firstTokenTime == nil {
+						now := time.Now()
+						firstTokenTime = &now
+					}
+					tokenMsg := &protos.Message{
+						Role: ChatRoleAssistant,
+						Message: &protos.Message_Assistant{
+							Assistant: &protos.AssistantMessage{
+								Contents: []string{content},
+							},
+						},
+					}
+					if err := onStream(options.Request.GetRequestId(), tokenMsg); err != nil {
+						llc.logger.Warnf("error streaming token: %v", err)
+					}
+				}
+			}
+		}
+	}
+
+	if resp.Err() != nil {
+		llc.logger.Errorf("Failed while reading chat completions stream: %v", resp.Err())
+		options.PostHook(map[string]interface{}{
+			"result": utils.ToJson(resp),
+			"error":  resp.Err(),
+		}, metrics.OnFailure().Build())
+		onError(options.Request.GetRequestId(), resp.Err())
+		return resp.Err()
+	}
+
+	assistantMsg.Contents = contentBuffer
+	protoMsg := &protos.Message{
+		Role: ChatRoleAssistant,
+		Message: &protos.Message_Assistant{
+			Assistant: assistantMsg,
+		},
+	}
+
+	metrics.OnAddMetrics(llc.GetCompletionUsages(accumulate.Usage)...)
+
+	if firstTokenTime != nil {
+		metrics.OnAddMetrics(&protos.Metric{
+			Name:        type_enums.TIME_TO_FIRST_TOKEN.String(),
+			Value:       fmt.Sprintf("%d", firstTokenTime.Sub(start)),
+			Description: "Time to receive first token from LLM",
+		})
+	}
+	metrics.OnSuccess()
+	onMetrics(options.Request.GetRequestId(), protoMsg, metrics.Build())
+	options.PostHook(map[string]interface{}{
+		"result": utils.ToJson(accumulate),
+	}, metrics.Build())
+
+	return nil
+}
+
+func (llc *largeLanguageCaller) buildHistory(allMessages []*protos.Message) []openai.ChatCompletionMessageParamUnion {
+	msg := make([]openai.ChatCompletionMessageParamUnion, 0)
+	for _, cntn := range allMessages {
+		switch cntn.GetRole() {
+		case ChatRoleUser:
+			if user := cntn.GetUser(); user != nil {
+				msg = append(msg, openai.UserMessage(user.GetContent()))
+			}
+		case ChatRoleAssistant:
+			if assistant := cntn.GetAssistant(); assistant != nil {
+				txtContent := strings.Join(assistant.GetContents(), "")
+				toolCalls := assistant.GetToolCalls()
+				assistantMessage := openai.ChatCompletionAssistantMessageParam{}
+				if len(txtContent) > 0 || len(toolCalls) > 0 {
+					if len(txtContent) > 0 {
+						assistantMessage.Content = openai.ChatCompletionAssistantMessageParamContentUnion{
+							OfString: openai.String(txtContent),
+						}
+					}
+					if len(toolCalls) > 0 {
+						fctCall := make([]openai.ChatCompletionMessageToolCallParam, 0)
+						for _, ttc := range toolCalls {
+							fctCall = append(fctCall, openai.ChatCompletionMessageToolCallParam{
+								ID: ttc.GetId(),
+								Function: openai.ChatCompletionMessageToolCallFunctionParam{
+									Name:      ttc.GetFunction().GetName(),
+									Arguments: ttc.GetFunction().GetArguments(),
+								},
+							})
+						}
+						assistantMessage.ToolCalls = fctCall
+					}
+					msg = append(msg, openai.ChatCompletionMessageParamUnion{
+						OfAssistant: &assistantMessage,
+					})
+				}
+			}
+
+		case ChatRoleSystem:
+			if system := cntn.GetSystem(); system != nil {
+				txtContent := system.GetContent()
+				if len(txtContent) > 0 {
+					msg = append(msg, openai.SystemMessage(txtContent))
+				}
+			}
+
+		case ChatRoleTool:
+			if tool := cntn.GetTool(); tool != nil {
+				for _, t := range tool.GetTools() {
+					msg = append(msg, openai.ToolMessage(t.GetContent(), t.GetId()))
+				}
+			}
+		}
+	}
+	return msg
+}
+
+func (llc *largeLanguageCaller) getChatCompleteParameter(
+	opts *internal_callers.ChatCompletionOptions,
+	streaming bool,
+) openai.ChatCompletionNewParams {
+	options := openai.ChatCompletionNewParams{}
+	if streaming {
+		options.StreamOptions = openai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: openai.Bool(true),
+		}
+	}
+	if len(opts.ToolDefinitions) > 0 {
+		fns := make([]openai.ChatCompletionToolParam, 0, len(opts.ToolDefinitions))
+		for _, tl := range opts.ToolDefinitions {
+			if tl.Type != "function" {
+				continue
+			}
+			fn := tl.Function
+			if fn == nil {
+				continue
+			}
+			funcDef := openai.FunctionDefinitionParam{
+				Name: fn.Name,
+			}
+			if fn.Description != "" {
+				funcDef.Description = openai.String(fn.Description)
+			}
+			if fn.Parameters != nil {
+				funcDef.Parameters = fn.Parameters.ToMap()
+			} else {
+				funcDef.Parameters = map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				}
+			}
+			fns = append(fns, openai.ChatCompletionToolParam{
+				Function: funcDef,
+			})
+		}
+		options.Tools = fns
+	}
+
+	if rawName, ok := opts.ModelParameter["model.name"]; ok {
+		if modelName, err := utils.AnyToString(rawName); err == nil {
+			options.Model = modelName
+		}
+	}
+
+	if rawParams, ok := opts.ModelParameter["model.parameters"]; ok {
+		llc.applyModelParameters(&options, opts, rawParams)
+	}
+	return options
+}
+
+func (llc *largeLanguageCaller) applyModelParameters(
+	options *openai.ChatCompletionNewParams,
+	opts *internal_callers.ChatCompletionOptions,
+	raw interface{},
+) {
+	params := map[string]interface{}{}
+	switch v := raw.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return
+		}
+		if err := json.Unmarshal([]byte(trimmed), &params); err != nil {
+			llc.logger.Warnf("custom-llm: failed to parse model.parameters: %v", err)
+			return
+		}
+	case map[string]interface{}:
+		params = v
+	default:
+		return
+	}
+
+	for key, value := range params {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "user":
+			if user, ok := anyToString(value); ok {
+				options.User = openai.String(user)
+			}
+		case "reasoning_effort":
+			if re, ok := anyToString(value); ok {
+				options.ReasoningEffort = shared.ReasoningEffort(re)
+			}
+		case "seed":
+			if seed, ok := anyToInt64(value); ok {
+				options.Seed = openai.Int(seed)
+			}
+		case "top_logprobs":
+			if tl, ok := anyToInt64(value); ok {
+				options.TopLogprobs = openai.Int(tl)
+			}
+		case "metadata":
+			format, _ := anyToString(value)
+			var mtd map[string]string
+			if err := json.Unmarshal([]byte(format), &mtd); err == nil {
+				options.Metadata = shared.Metadata(mtd)
+			}
+		case "frequency_penalty":
+			if fp, ok := anyToFloat64(value); ok {
+				options.FrequencyPenalty = openai.Float(fp)
+			}
+		case "temperature":
+			if temp, ok := anyToFloat64(value); ok {
+				options.Temperature = openai.Float(temp)
+			}
+		case "top_p":
+			if topP, ok := anyToFloat64(value); ok {
+				options.TopP = openai.Float(topP)
+			}
+		case "presence_penalty":
+			if pp, ok := anyToFloat64(value); ok {
+				options.PresencePenalty = openai.Float(pp)
+			}
+		case "max_tokens", "max_completion_tokens":
+			if maxTokens, ok := anyToInt64(value); ok {
+				options.MaxTokens = openai.Int(maxTokens)
+			}
+		case "stop":
+			if stopStr, ok := anyToString(value); ok {
+				for _, stopper := range strings.Split(stopStr, ",") {
+					if strings.TrimSpace(stopper) != "" {
+						options.Stop.OfStringArray = append(options.Stop.OfStringArray, stopper)
+					}
+				}
+			}
+		case "tool_choice":
+			if choice, ok := anyToString(value); ok && len(opts.ToolDefinitions) > 0 {
+				switch choice {
+				case "auto":
+					options.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+						OfAuto: openai.String("auto"),
+					}
+				case "required":
+					options.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+						OfAuto: openai.String("required"),
+					}
+				case "none":
+					options.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+						OfAuto: openai.String("none"),
+					}
+				default:
+					llc.logger.Warnf("custom-llm: unrecognized tool_choice value %q; leaving tool_choice unset", choice)
+				}
+			}
+		case "response_format":
+			format, ok := anyToJSON(value)
+			if !ok {
+				continue
+			}
+			_type, ok := format["type"].(string)
+			if !ok {
+				continue
+			}
+			switch _type {
+			case "json_object":
+				options.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+					OfJSONObject: &openai.ResponseFormatJSONObjectParam{},
+				}
+			case "text":
+				textParam := shared.NewResponseFormatTextParam()
+				options.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+					OfText: &textParam,
+				}
+			case "json_schema":
+				schemaData, ok := format["json_schema"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				jsonSchemaParam := shared.ResponseFormatJSONSchemaJSONSchemaParam{}
+				jsonData, err := json.Marshal(schemaData)
+				if err != nil {
+					llc.logger.Warnf("custom-llm: failed to marshal json_schema: %v", err)
+					continue
+				}
+				if err := json.Unmarshal(jsonData, &jsonSchemaParam); err != nil {
+					llc.logger.Warnf("custom-llm: failed to unmarshal json_schema: %v", err)
+					continue
+				}
+				options.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+					OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+						JSONSchema: jsonSchemaParam,
+					},
+				}
+			}
+		}
+	}
+}
+
+func anyToString(v interface{}) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", t), "0"), "."), true
+	case bool:
+		if t {
+			return "true", true
+		}
+		return "false", true
+	case nil:
+		return "", false
+	default:
+		return fmt.Sprintf("%v", t), true
+	}
+}
+
+func anyToInt64(v interface{}) (int64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return int64(t), true
+	case int:
+		return int64(t), true
+	case int64:
+		return t, true
+	case string:
+		s := strings.TrimSpace(t)
+		if s == "" {
+			return 0, false
+		}
+		var f float64
+		if _, err := fmt.Sscanf(s, "%f", &f); err == nil {
+			return int64(f), true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
+}
+
+func anyToFloat64(v interface{}) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case string:
+		s := strings.TrimSpace(t)
+		if s == "" {
+			return 0, false
+		}
+		var f float64
+		if _, err := fmt.Sscanf(s, "%f", &f); err == nil {
+			return f, true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
+}
+
+func anyToJSON(v interface{}) (map[string]interface{}, bool) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		return t, true
+	case string:
+		s := strings.TrimSpace(t)
+		if s == "" {
+			return nil, false
+		}
+		out := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(s), &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}

--- a/api/integration-api/internal/caller/custom_llm/llm_test.go
+++ b/api/integration-api/internal/caller/custom_llm/llm_test.go
@@ -1,0 +1,144 @@
+// Rapida – Open Source Voice AI Orchestration Platform
+// Copyright (C) 2023-2025 Prashant Srivastav <prashant@rapida.ai>
+// Licensed under a modified GPL-2.0. See the LICENSE file for details.
+package internal_custom_llm_callers
+
+import (
+	"testing"
+
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/protos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func newTestLogger() commons.Logger {
+	lgr, _ := commons.NewApplicationLogger()
+	return lgr
+}
+
+func newTestCaller() *largeLanguageCaller {
+	return &largeLanguageCaller{
+		CustomLLM: CustomLLM{
+			logger:     newTestLogger(),
+			credential: func() map[string]interface{} { return map[string]interface{}{} },
+		},
+	}
+}
+
+func TestBuildHistory_MixedMessages(t *testing.T) {
+	caller := newTestCaller()
+	msgs := []*protos.Message{
+		{Role: "system", Message: &protos.Message_System{System: &protos.SystemMessage{Content: "Be brief"}}},
+		{Role: "user", Message: &protos.Message_User{User: &protos.UserMessage{Content: "Hi"}}},
+		{Role: "assistant", Message: &protos.Message_Assistant{Assistant: &protos.AssistantMessage{Contents: []string{"Hello"}}}},
+		{Role: "tool", Message: &protos.Message_Tool{Tool: &protos.ToolMessage{Tools: []*protos.ToolMessage_Tool{{Id: "call_1", Name: "get_weather", Content: `{"temp":72}`}}}}},
+	}
+
+	history := caller.buildHistory(msgs)
+	require.Len(t, history, 4)
+	assert.NotNil(t, history[0].OfSystem)
+	assert.NotNil(t, history[1].OfUser)
+	assert.NotNil(t, history[2].OfAssistant)
+	assert.NotNil(t, history[3].OfTool)
+}
+
+func TestBuildHistory_AssistantWithToolCall(t *testing.T) {
+	caller := newTestCaller()
+	msgs := []*protos.Message{
+		{
+			Role: "assistant",
+			Message: &protos.Message_Assistant{
+				Assistant: &protos.AssistantMessage{
+					ToolCalls: []*protos.ToolCall{
+						{
+							Id:   "call_1",
+							Type: "function",
+							Function: &protos.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"NYC"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	history := caller.buildHistory(msgs)
+	require.Len(t, history, 1)
+	require.NotNil(t, history[0].OfAssistant)
+	require.Len(t, history[0].OfAssistant.ToolCalls, 1)
+	assert.Equal(t, "call_1", history[0].OfAssistant.ToolCalls[0].ID)
+	assert.Equal(t, "get_weather", history[0].OfAssistant.ToolCalls[0].Function.Name)
+}
+
+func newCredentialCaller(t *testing.T, credentials map[string]interface{}) *largeLanguageCaller {
+	t.Helper()
+	value, err := structpb.NewStruct(credentials)
+	require.NoError(t, err)
+	credential := &protos.Credential{Value: value}
+	return NewLargeLanguageCaller(newTestLogger(), credential).(*largeLanguageCaller)
+}
+
+func TestGetClient_RequiresBaseURL(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{"apiCompatibility": "openai"})
+	_, err := caller.GetClient()
+	require.Error(t, err)
+}
+
+func TestGetClient_RejectsEmptyBaseURL(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{"apiCompatibility": "openai", "baseUrl": "  "})
+	_, err := caller.GetClient()
+	require.Error(t, err)
+}
+
+func TestGetClient_RejectsNonStringBaseURL(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{"apiCompatibility": "openai", "baseUrl": 123})
+	_, err := caller.GetClient()
+	require.Error(t, err)
+}
+
+func TestGetClient_DefaultsToOpenAICompatibility(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{"baseUrl": "http://localhost:8000/v1"})
+	client, err := caller.GetClient()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestGetClient_UsesConfiguredBaseURL(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{"apiCompatibility": "openai", "baseUrl": "http://localhost:8000/v1"})
+	client, err := caller.GetClient()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestGetClient_AllowsHeaders(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{
+		"apiCompatibility": "openai",
+		"baseUrl":          "http://localhost:8000/v1",
+		"headers":          `{"Authorization":"Bearer abc","X-Custom":"value"}`,
+	})
+	client, err := caller.GetClient()
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestGetClient_RejectsAnthropicCompat(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{
+		"apiCompatibility": "anthropic",
+		"baseUrl":          "http://localhost:8000/v1",
+	})
+	_, err := caller.GetClient()
+	require.Error(t, err)
+}
+
+func TestGetClient_RejectsCustomCompat(t *testing.T) {
+	caller := newCredentialCaller(t, map[string]interface{}{
+		"apiCompatibility": "custom",
+		"baseUrl":          "http://localhost:8000/v1",
+	})
+	_, err := caller.GetClient()
+	require.Error(t, err)
+}

--- a/api/integration-api/internal/caller/custom_llm/verify-credential.go
+++ b/api/integration-api/internal/caller/custom_llm/verify-credential.go
@@ -1,0 +1,37 @@
+package internal_custom_llm_callers
+
+import (
+	"context"
+	"time"
+
+	internal_callers "github.com/rapidaai/api/integration-api/internal/type"
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/protos"
+)
+
+type verifyCredentialCaller struct {
+	CustomLLM
+}
+
+func NewVerifyCredentialCaller(logger commons.Logger, credential *protos.Credential) internal_callers.Verifier {
+	return &verifyCredentialCaller{
+		CustomLLM: customLLM(logger, credential),
+	}
+}
+
+func (stc *verifyCredentialCaller) CredentialVerifier(
+	ctx context.Context,
+	options *internal_callers.CredentialVerifierOptions) (*string, error) {
+	client, err := stc.GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	if _, err := client.Models.List(ctx); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/ui/src/app/components/base/modal/create-provider-credential-modal/index.tsx
+++ b/ui/src/app/components/base/modal/create-provider-credential-modal/index.tsx
@@ -21,7 +21,12 @@ import {
   TertiaryButton,
 } from '@/app/components/carbon/button';
 import { Stack, TextInput, TextArea } from '@/app/components/carbon/form';
-import { Dropdown, Button } from '@carbon/react';
+import {
+  Dropdown,
+  Button,
+  Select as CarbonSelect,
+  SelectItem,
+} from '@carbon/react';
 import { Add, TrashCan } from '@carbon/icons-react';
 import { connectionConfig } from '@/configs';
 import { useProviderContext } from '@/context/provider-context';
@@ -192,6 +197,25 @@ export function CreateProviderCredentialDialog(
                   value={config[x.name] || ''}
                   onChange={value => handleConfigChange(x.name, value)}
                 />
+              ) : x.type === 'select' ? (
+                <CarbonSelect
+                  key={idx}
+                  id={`config-${x.name}`}
+                  labelText={x.label}
+                  value={config[x.name] || ''}
+                  onChange={e =>
+                    handleConfigChange(x.name, (e.target as HTMLSelectElement).value)
+                  }
+                >
+                  <SelectItem value="" text={`Select ${x.label.toLowerCase()}`} />
+                  {(x.choices ?? []).map(c => (
+                    <SelectItem
+                      key={c.value}
+                      value={c.value}
+                      text={c.label}
+                    />
+                  ))}
+                </CarbonSelect>
               ) : (
                 <TextInput
                   key={idx}

--- a/ui/src/providers/config-loader.ts
+++ b/ui/src/providers/config-loader.ts
@@ -104,7 +104,11 @@ const MODEL_SELECTOR_CATEGORIES: ReadonlySet<ProviderConfigCategory> = new Set([
   'text',
 ]);
 const TEXT_MODEL_DATA_CANDIDATES = ['text-models.json', 'models.json'] as const;
-const TEXT_CUSTOM_MODEL_PROVIDERS = new Set(['azure-foundry', 'vertexai']);
+const TEXT_CUSTOM_MODEL_PROVIDERS = new Set([
+  'azure-foundry',
+  'vertexai',
+  'custom-llm',
+]);
 
 function warnProviderLoadFailure(
   scope: 'config' | 'data',

--- a/ui/src/providers/custom-llm/text-models.json
+++ b/ui/src/providers/custom-llm/text-models.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "custom/model",
+    "name": "custom-model",
+    "config": {
+      "parameters": [
+        {
+          "key": "model.parameters",
+          "label": "Model Parameters",
+          "type": "key_value",
+          "advanced": true,
+          "required": false,
+          "colSpan": 2,
+          "helpText": "Provider-specific parameters as key/value pairs (e.g. temperature, top_p, max_tokens, frequency_penalty, presence_penalty, stop)."
+        }
+      ]
+    }
+  }
+]

--- a/ui/src/providers/index.ts
+++ b/ui/src/providers/index.ts
@@ -16,6 +16,8 @@ export interface RapidaProvider {
     name: string;
     type: string;
     label: string;
+    required?: boolean;
+    choices?: { label: string; value: string }[];
   }[];
 }
 

--- a/ui/src/providers/provider.development.json
+++ b/ui/src/providers/provider.development.json
@@ -326,6 +326,41 @@
         "website": "https://openai.com"
     },
     {
+        "code": "custom-llm",
+        "name": "Custom LLM",
+        "description": "Connect to any LLM server. Choose an API compatibility (OpenAI-compatible, Anthropic-compatible, or custom), provide a base URL and optional headers. Useful for self-hosted runtimes such as vLLM, Ollama, LM Studio, or Text Generation Inference.",
+        "image": "https://rapida-assets-01.s3.ap-south-1.amazonaws.com/providers/1987967168452493312.svg",
+        "featureList": [
+            "text",
+            "external"
+        ],
+        "configurations": [
+            {
+                "name": "apiCompatibility",
+                "type": "select",
+                "label": "API Compatibility",
+                "choices": [
+                    { "label": "OpenAI-compatible", "value": "openai" },
+                    { "label": "Anthropic-compatible", "value": "anthropic" },
+                    { "label": "Custom", "value": "custom" }
+                ]
+            },
+            {
+                "name": "baseUrl",
+                "type": "string",
+                "label": "Base URL"
+            },
+            {
+                "name": "headers",
+                "type": "key_value",
+                "label": "Headers",
+                "required": false
+            }
+        ],
+        "humanname": "Custom LLM",
+        "website": "https://platform.openai.com/docs/api-reference/chat"
+    },
+    {
         "code": "mistral",
         "name": "Mistral",
         "description": "Mistral specializes in creating fast, secure, open-source large language models (LLMs).",

--- a/ui/src/providers/provider.production.json
+++ b/ui/src/providers/provider.production.json
@@ -326,6 +326,41 @@
         "website": "https://openai.com"
     },
     {
+        "code": "custom-llm",
+        "name": "Custom LLM",
+        "description": "Connect to any LLM server. Choose an API compatibility (OpenAI-compatible, Anthropic-compatible, or custom), provide a base URL and optional headers. Useful for self-hosted runtimes such as vLLM, Ollama, LM Studio, or Text Generation Inference.",
+        "image": "https://rapida-assets-01.s3.ap-south-1.amazonaws.com/providers/1987967168452493312.svg",
+        "featureList": [
+            "text",
+            "external"
+        ],
+        "configurations": [
+            {
+                "name": "apiCompatibility",
+                "type": "select",
+                "label": "API Compatibility",
+                "choices": [
+                    { "label": "OpenAI-compatible", "value": "openai" },
+                    { "label": "Anthropic-compatible", "value": "anthropic" },
+                    { "label": "Custom", "value": "custom" }
+                ]
+            },
+            {
+                "name": "baseUrl",
+                "type": "string",
+                "label": "Base URL"
+            },
+            {
+                "name": "headers",
+                "type": "key_value",
+                "label": "Headers",
+                "required": false
+            }
+        ],
+        "humanname": "Custom LLM",
+        "website": "https://platform.openai.com/docs/api-reference/chat"
+    },
+    {
         "code": "mistral",
         "name": "Mistral",
         "description": "Mistral specializes in creating fast, secure, open-source large language models (LLMs).",

--- a/ui/src/utils/messages.tsx
+++ b/ui/src/utils/messages.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 /**
  * This function has two roles:
  * 1) If the `id` is empty it assings something so does i18next doesn't throw error. Typescript should prevent this anyway
@@ -14,59 +12,22 @@ export const _t = (id: string, ...rest: any[]): [string, ...any[]] => {
   return [id, ...rest];
 };
 
-export const create_knowledge_success_message = (
-  name: string,
-): React.ReactElement => {
-  return (
-    <p>
-      Your knowledge base <strong className="font-medium">{name}</strong> has
-      been successfully created.
-    </p>
-  );
-};
+export const create_knowledge_success_message = (name: string): string =>
+  `Your knowledge base ${name} has been successfully created.`;
 
 export const create_endpoint_version_success_message = (
   endpointName: string,
-): React.ReactElement => {
-  return (
-    <p>
-      New version of endpoint{' '}
-      <strong className="font-medium">{endpointName}</strong> has been
-      successfully created.
-    </p>
-  );
-};
+): string =>
+  `New version of endpoint ${endpointName} has been successfully created.`;
 
-export const create_endpoint_success_message = (
-  endpointName: string,
-): React.ReactElement => {
-  return (
-    <p>
-      Your endpoint <strong className="font-medium">{endpointName}</strong> has
-      been successfully created.
-    </p>
-  );
-};
+export const create_endpoint_success_message = (endpointName: string): string =>
+  `Your endpoint ${endpointName} has been successfully created.`;
 
 export const create_assistant_version_success_message = (
   assistantName: string,
-): React.ReactElement => {
-  return (
-    <p>
-      New version of assistant{' '}
-      <strong className="font-medium">{assistantName}</strong> has been
-      successfully created.
-    </p>
-  );
-};
+): string =>
+  `New version of assistant ${assistantName} has been successfully created.`;
 
 export const create_assistant_success_message = (
   assistantName: string,
-): React.ReactElement => {
-  return (
-    <p>
-      Your assistant <strong className="font-medium">{assistantName}</strong>{' '}
-      has been successfully created.
-    </p>
-  );
-};
+): string => `Your assistant ${assistantName} has been successfully created.`;


### PR DESCRIPTION
## Description

Wires a new `openai-compatible` integration that points the OpenAI SDK at a user-supplied base URL, with chat + streaming + tool-calls + credential verification (via `/v1/models`). This unlocks self-hosted or third-party LLM servers that expose the OpenAI Chat Completions API — vLLM, Ollama, LM Studio, Text Generation Inference, and similar.

Includes:
- Backend caller package `api/integration-api/internal/caller/openai_compatible/` (chat, streaming, tool-calls, token/TTFT metrics, `/v1/models` verifier).
- Factory registration in `api/integration-api/internal/caller/caller.go` for `GetLargeLanguageCaller` and `GetVerifier`.
- UI provider metadata in both `ui/src/providers/provider.development.json` and `ui/src/providers/provider.production.json` with `Base URL` + `API Key` configuration fields.
- Model catalog at `ui/src/providers/openai-compatible/text-models.json` and inclusion in `TEXT_CUSTOM_MODEL_PROVIDERS` so users can type any model id the server exposes (e.g. `meta-llama/Llama-3.1-8B-Instruct`).

Also fixes the `[object Object]` success toast on endpoint and knowledge-base creation by returning plain strings from the message helpers in `ui/src/utils/messages.tsx`. The toast renderer calls `t.message.toString()`, which produced `[object Object]` whenever a helper returned a React element.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

Fixes #

## Checklist

### General

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [x] My changes do not introduce any security vulnerabilities
- [x] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

- Credential verification uses `GET /v1/models` rather than a fixed-model chat completion, since many OpenAI-compatible servers do not accept names like `gpt-4o`. All major compatible backends (vLLM, Ollama, LM Studio, TGI) expose the models endpoint.
- Only the `text` capability is enabled for this provider. Embeddings/reranking were intentionally left out of the factory — vLLM deployments sometimes serve embedding models, so that can be wired in a follow-up if needed.
- Backend unit tests live at `api/integration-api/internal/caller/openai_compatible/llm_test.go` (history construction, base-URL validation, optional API key handling). Verified end-to-end against a local vLLM instance: create endpoint, test call, and streaming all succeed.
- The toast fix is small and orthogonal but was hit during manual testing, so it's bundled here rather than split into a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible LLM integration with configurable base URL and API key, credential verification, sync and streaming chat completions with usage/metrics; UI registers the provider and treats it as a custom text-model option.

* **UI**
  * Added a customizable “custom-model” configuration and updated provider lists for dev/prod.

* **Tests**
  * Added unit tests for message history mapping and client/credential validation.

* **Refactor**
  * Success-message helpers now return plain text strings instead of JSX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->