### PR TITLE
Fix: add visibility graph for latencies and update default cache key

### DIFF
--- a/api/assistant-api/api/assistant/get_all_assistant_http_log.go
+++ b/api/assistant-api/api/assistant/get_all_assistant_http_log.go
@@ -37,6 +37,7 @@ func (assistantApi *assistantGrpcApi) GetAllAssistantHTTPLog(ctx context.Context
 		req.GetOrder(),
 	)
 	if err != nil {
+		assistantApi.logger.Errorf("failed to get assistant HTTP logs: %v", err)
 		return exceptions.BadRequestError[protos.GetAllAssistantHTTPLogResponse]("Unable to get assistant HTTP logs.")
 	}
 

--- a/api/assistant-api/api/assistant/get_assistant_authentication.go
+++ b/api/assistant-api/api/assistant/get_assistant_authentication.go
@@ -30,16 +30,13 @@ func (assistantApi *assistantGrpcApi) GetAssistantAuthentication(
 		req.GetAssistantId(),
 	)
 	if err != nil {
+		assistantApi.logger.Errorf("failed to get assistant authentication: %v", err)
 		return utils.Error[protos.GetAssistantAuthenticationResponse](
 			err,
 			"Unable to get assistant authentication for the given assistant id.",
 		)
 	}
-
-	out := &protos.AssistantAuthentication{}
-	if authConfig == nil {
-		return utils.Success[protos.GetAssistantAuthenticationResponse, *protos.AssistantAuthentication](out)
-	}
+	var out *protos.AssistantAuthentication
 	if err = utils.Cast(authConfig, out); err != nil {
 		assistantApi.logger.Errorf("unable to cast assistant authentication %v", err)
 	}

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -215,9 +215,6 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 			internal_type.StopIdleTimeoutPacket{ContextID: p.ContextID},
 			internal_type.EndOfSpeechInterruptionPacket{ContextID: p.ContextID, Source: internal_type.InterruptionSourceWord},
 		)
-		// if err := h.callEndOfSpeech(ctx, p); err != nil {
-		// 	h.r.logger.Errorf("end of speech error: %v", err)
-		// }
 		if err := h.r.Transition(Interrupted); err != nil {
 			return
 		}
@@ -234,22 +231,24 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 		})
 
 	default:
-		if p.StartAt < 5 {
-			return
-		}
-		h.r.OnPacket(ctx,
-			internal_type.SpeechToTextInterruptPacket{ContextID: p.ContextID},
-			internal_type.EndOfSpeechInterruptionPacket{ContextID: p.ContextID, Source: internal_type.InterruptionSourceVad})
-
-		if err := h.r.Transition(Interrupt); err != nil {
-			return
-		}
-		utils.Go(ctx, func() {
-			h.r.Notify(ctx, &protos.ConversationInterruption{
-				Type: protos.ConversationInterruption_INTERRUPTION_TYPE_VAD,
-				Time: timestamppb.Now(),
+		switch p.Event {
+		case internal_type.InterruptionEventStart:
+			if p.StartAt < 5 {
+				return
+			}
+			if err := h.r.Transition(Interrupt); err != nil {
+				return
+			}
+			h.r.OnPacket(ctx, internal_type.EndOfSpeechInterruptionPacket{ContextID: p.ContextID, Source: internal_type.InterruptionSourceVad})
+			utils.Go(ctx, func() {
+				h.r.Notify(ctx, &protos.ConversationInterruption{
+					Type: protos.ConversationInterruption_INTERRUPTION_TYPE_VAD,
+					Time: timestamppb.Now(),
+				})
 			})
-		})
+		case internal_type.InterruptionEventEnd:
+			h.r.OnPacket(ctx, internal_type.SpeechToTextInterruptPacket{ContextID: p.ContextID})
+		}
 	}
 }
 

--- a/api/assistant-api/internal/audio/audio_utils.go
+++ b/api/assistant-api/internal/audio/audio_utils.go
@@ -6,12 +6,24 @@
 package internal_audio
 
 import (
+	"encoding/binary"
 	"math"
 
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/protos"
 	"github.com/zaf/g711"
 )
+
+// Linear16ToInt16 converts signed 16-bit little-endian PCM bytes to int16 samples.
+// If data length is odd, the trailing byte is ignored.
+func Linear16ToInt16(data []byte) []int16 {
+	numSamples := len(data) / 2
+	samples := make([]int16, numSamples)
+	for i := 0; i < numSamples; i++ {
+		samples[i] = int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
+	}
+	return samples
+}
 
 // BytesPerSample returns the number of bytes per audio sample for the given
 // audio format. Returns 0 for unsupported formats.

--- a/api/assistant-api/internal/audio/audio_utils_test.go
+++ b/api/assistant-api/internal/audio/audio_utils_test.go
@@ -6,11 +6,28 @@
 package internal_audio
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/rapidaai/protos"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLinear16ToInt16_ConvertsSamples(t *testing.T) {
+	data := make([]byte, 6)
+	binary.LittleEndian.PutUint16(data[0:2], 0x8000)
+	binary.LittleEndian.PutUint16(data[2:4], uint16(int16(0)))
+	binary.LittleEndian.PutUint16(data[4:6], uint16(int16(32767)))
+
+	got := Linear16ToInt16(data)
+	assert.Equal(t, []int16{-32768, 0, 32767}, got)
+}
+
+func TestLinear16ToInt16_OddLengthIgnoresTrailingByte(t *testing.T) {
+	data := []byte{0x01, 0x00, 0xFF}
+	got := Linear16ToInt16(data)
+	assert.Equal(t, []int16{1}, got)
+}
 
 // ---------------------------------------------------------------------------
 // BytesPerSample

--- a/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
@@ -15,6 +15,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 const (
@@ -444,6 +445,13 @@ func (eos *LivekitEOS) fire(ctx context.Context, seg SpeechSegment) {
 			Speech:    speech,
 			ContextID: seg.ContextID,
 			Speechs:   append([]internal_type.SpeechToTextPacket(nil), seg.Chunks...),
+		},
+		internal_type.UserMessageMetricPacket{
+			ContextID: seg.ContextID,
+			Metrics: []*protos.Metric{{
+				Name:  "eos_latency_ms",
+				Value: fmt.Sprintf("%d", triggerAt.Sub(seg.Timestamp).Milliseconds()),
+			}},
 		},
 		internal_type.ConversationEventPacket{
 			Name: "eos",

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
@@ -16,6 +16,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 const (
@@ -426,6 +427,13 @@ func (eos *PipecatEOS) fire(ctx context.Context, seg SpeechSegment) {
 			Speech:    seg.Text,
 			ContextID: seg.ContextID,
 			Speechs:   append([]internal_type.SpeechToTextPacket(nil), seg.Chunks...),
+		},
+		internal_type.UserMessageMetricPacket{
+			ContextID: seg.ContextID,
+			Metrics: []*protos.Metric{{
+				Name:  "eos_latency_ms",
+				Value: fmt.Sprintf("%d", triggerAt.Sub(seg.Timestamp).Milliseconds()),
+			}},
 		},
 		internal_type.ConversationEventPacket{
 			Name: "eos",

--- a/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech.go
@@ -15,6 +15,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 // SpeechSegment represents accumulated speech with metadata
@@ -320,6 +321,13 @@ func (eos *SilenceBasedEOS) fire(ctx context.Context, seg SpeechSegment) {
 			Speech:    seg.Text,
 			ContextID: seg.ContextID,
 			Speechs:   append([]internal_type.SpeechToTextPacket(nil), seg.Chunks...),
+		},
+		internal_type.UserMessageMetricPacket{
+			ContextID: seg.ContextID,
+			Metrics: []*protos.Metric{{
+				Name:  "eos_latency_ms",
+				Value: fmt.Sprintf("%d", triggerAt.Sub(seg.Timestamp).Milliseconds()),
+			}},
 		},
 		internal_type.ConversationEventPacket{
 			Name: "eos",

--- a/api/assistant-api/internal/services/assistant/authentication.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/authentication.impl.service.go
@@ -44,8 +44,7 @@ func (s *assistantAuthenticationService) Get(
 ) (*internal_assistant_entity.AssistantAuthentication, error) {
 	start := time.Now()
 	db := s.postgres.DB(ctx)
-
-	var out *internal_assistant_entity.AssistantAuthentication
+	var out internal_assistant_entity.AssistantAuthentication
 	tx := db.Preload("AssistantAuthenticationOption", "status = ?", type_enums.RECORD_ACTIVE).
 		Where("assistant_id = ? AND organization_id = ? AND project_id = ? AND status IN ?",
 			assistantId,
@@ -60,17 +59,12 @@ func (s *assistantAuthenticationService) Get(
 			Desc:   true,
 		}).
 		First(&out)
-	if tx.Error != nil {
-		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
-			s.logger.Benchmark("AssistantAuthenticationService.Get", time.Since(start))
-			return nil, nil
-		}
+	if tx.Error != nil && !errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 		s.logger.Benchmark("AssistantAuthenticationService.Get", time.Since(start))
 		return nil, tx.Error
 	}
-
 	s.logger.Benchmark("AssistantAuthenticationService.Get", time.Since(start))
-	return out, nil
+	return &out, nil
 }
 
 func (s *assistantAuthenticationService) Create(

--- a/api/assistant-api/internal/transformer/deepgram/stt.go
+++ b/api/assistant-api/internal/transformer/deepgram/stt.go
@@ -121,9 +121,7 @@ func (dg *deepgramSTT) Transform(ctx context.Context, in internal_type.Packet) e
 		return nil
 	case internal_type.SpeechToTextInterruptPacket:
 		dg.mu.Lock()
-		if dg.startedAt.IsZero() {
-			dg.startedAt = time.Now()
-		}
+		dg.startedAt = time.Now()
 		dg.mu.Unlock()
 		return nil
 	case internal_type.SpeechToTextAudioPacket:

--- a/api/assistant-api/internal/type/packet.go
+++ b/api/assistant-api/internal/type/packet.go
@@ -202,11 +202,19 @@ const (
 	InterruptionSourceVad  InterruptionSource = "vad"
 )
 
+type InterruptionEvent string
+
+const (
+	InterruptionEventStart InterruptionEvent = "start"
+	InterruptionEventEnd   InterruptionEvent = "end"
+)
+
 // InterruptionDetectedPacket signals that an interruption was detected (by VAD or word-level STT).
 // Dispatch handles this event by emitting InterruptTTSPacket and InterruptLLMPacket commands.
 type InterruptionDetectedPacket struct {
 	ContextID string
 	Source    InterruptionSource
+	Event     InterruptionEvent
 	StartAt   float64
 	EndAt     float64
 }

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
@@ -7,7 +7,6 @@ package internal_firered_vad
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -81,7 +81,10 @@ func NewFireRedVAD(
 		isTerminated:  false,
 	}
 
-	vad.startLifecycleManager(ctx)
+	go func() {
+		<-ctx.Done()
+		_ = vad.Close()
+	}()
 
 	if onPacket != nil {
 		_ = onPacket(ctx, internal_type.ConversationEventPacket{
@@ -114,7 +117,7 @@ func (v *FireRedVAD) Process(ctx context.Context, pkt internal_type.UserAudioRec
 	}
 
 	// Convert LINEAR16 bytes to int16 samples
-	samples := linear16ToInt16(pkt.Audio)
+	samples := internal_audio.Linear16ToInt16(pkt.Audio)
 
 	// Append to buffer
 	v.mu.Lock()
@@ -123,6 +126,8 @@ func (v *FireRedVAD) Process(ctx context.Context, pkt internal_type.UserAudioRec
 	// Process complete frames (400 samples each, 160-sample shift)
 	hasSpeech := false
 	var speechStartAt, speechEndAt float64
+	hasSpeechStart := false
+	hasSpeechEnd := false
 
 	for len(v.audioBuf) >= frameLenSample {
 		frame := v.audioBuf[:frameLenSample]
@@ -149,13 +154,24 @@ func (v *FireRedVAD) Process(ctx context.Context, pkt internal_type.UserAudioRec
 		result := v.postprocessor.ProcessFrame(prob)
 
 		if result.IsSpeechStart {
-			speechStartAt = float64(result.SpeechStartFrame-1) / float64(framesPerSecond)
-			if speechStartAt < 0 {
-				speechStartAt = 0
+			startAt := float64(result.SpeechStartFrame-1) / float64(framesPerSecond)
+			if startAt < 0 {
+				startAt = 0
 			}
+			if !hasSpeechStart || startAt < speechStartAt {
+				speechStartAt = startAt
+			}
+			hasSpeechStart = true
 		}
 		if result.IsSpeechEnd {
-			speechEndAt = float64(result.SpeechEndFrame-1) / float64(framesPerSecond)
+			endAt := float64(result.SpeechEndFrame-1) / float64(framesPerSecond)
+			if endAt < 0 {
+				endAt = 0
+			}
+			if !hasSpeechEnd || endAt > speechEndAt {
+				speechEndAt = endAt
+			}
+			hasSpeechEnd = true
 		}
 
 		// Only treat as speech when the postprocessor has confirmed onset
@@ -170,25 +186,20 @@ func (v *FireRedVAD) Process(ctx context.Context, pkt internal_type.UserAudioRec
 	}
 	v.mu.Unlock()
 
-	// Emit InterruptionDetectedPacket only on confirmed speech onset — this is the
-	// signal to interrupt assistant TTS/LLM. Speech end and sustained speech
-	// don't need interruption; the heartbeat handles EOS extension.
-	if speechStartAt > 0 {
-		v.notifyActivity(ctx, speechStartAt, speechEndAt)
-	}
-
 	// Emit a heartbeat while in confirmed speech so the EOS silence
 	// timer keeps extending during sustained speech.
 	if hasSpeech && v.onPacket != nil {
 		_ = v.onPacket(ctx,
 			internal_type.VadSpeechActivityPacket{},
-			// internal_type.ConversationEventPacket{
-			// 	Name: "vad",
-			// 	Data: map[string]string{
-			// 		"type": "heartbeat",
-			// 	},
-			// },
 		)
+	}
+
+	// Emit explicit interruption lifecycle events from VAD transitions.
+	if hasSpeechStart {
+		v.notifyInterruption(ctx, internal_type.InterruptionEventStart, speechStartAt)
+	}
+	if hasSpeechEnd {
+		v.notifyInterruption(ctx, internal_type.InterruptionEventEnd, speechEndAt)
 	}
 
 	return nil
@@ -241,46 +252,30 @@ func resolvePostprocessorConfig(options utils.Option) PostprocessorConfig {
 	return cfg
 }
 
-func (v *FireRedVAD) startLifecycleManager(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		v.Close()
-	}()
-}
-
 func (v *FireRedVAD) isActive() bool {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	return !v.isTerminated && v.detector != nil
 }
 
-// linear16ToInt16 converts signed 16-bit little-endian PCM bytes to int16 samples.
-func linear16ToInt16(data []byte) []int16 {
-	numSamples := len(data) / 2
-	samples := make([]int16, numSamples)
-	for i := 0; i < numSamples; i++ {
-		samples[i] = int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
-	}
-	return samples
-}
-
-func (v *FireRedVAD) notifyActivity(ctx context.Context, startAt, endAt float64) {
+func (v *FireRedVAD) notifyInterruption(ctx context.Context, event internal_type.InterruptionEvent, at float64) {
 	if v.onPacket == nil {
 		return
 	}
-
 	v.onPacket(ctx,
 		internal_type.InterruptionDetectedPacket{
 			Source:  internal_type.InterruptionSourceVad,
-			StartAt: startAt,
-			EndAt:   endAt,
+			Event:   event,
+			StartAt: at,
+			EndAt:   at,
 		},
 		internal_type.ConversationEventPacket{
 			Name: "vad",
 			Data: map[string]string{
 				"type":     "detected",
-				"start_at": fmt.Sprintf("%f", startAt),
-				"end_at":   fmt.Sprintf("%f", endAt),
+				"event":    string(event),
+				"start_at": fmt.Sprintf("%f", at),
+				"end_at":   fmt.Sprintf("%f", at),
 			},
 		},
 	)

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_test.go
@@ -251,3 +251,41 @@ func TestFireRedVAD_Process_80msChunk(t *testing.T) {
 	err := vad.Process(context.Background(), generateSilence(1280))
 	require.NoError(t, err)
 }
+
+func TestFireRedVAD_Process_PartialFrameCarry_NoDrop(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newFireRedOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(128))
+	require.NoError(t, err)
+	assert.Equal(t, 128, len(vad.audioBuf))
+
+	err = vad.Process(context.Background(), generateSilence(200))
+	require.NoError(t, err)
+	assert.Equal(t, 328, len(vad.audioBuf))
+
+	err = vad.Process(context.Background(), generateSilence(100))
+	require.NoError(t, err)
+	// 428 total samples buffered -> one frame processed, shift by 160 samples -> 268 retained.
+	assert.Equal(t, 268, len(vad.audioBuf))
+}
+
+func TestFireRedVAD_NotifyInterruption_SetsEvent(t *testing.T) {
+	var got internal_type.InterruptionDetectedPacket
+	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
+		for _, p := range pkts {
+			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
+				got = ip
+			}
+		}
+		return nil
+	}
+
+	v := &FireRedVAD{onPacket: callback}
+	v.notifyInterruption(context.Background(), internal_type.InterruptionEventEnd, 1.75)
+
+	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
+	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
+	assert.Equal(t, 1.75, got.StartAt)
+	assert.Equal(t, 1.75, got.EndAt)
+}

--- a/api/assistant-api/internal/vad/internal/silero_vad/detector.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/detector.go
@@ -75,8 +75,10 @@ func (c DetectorConfig) validate() error {
 // Segment contains timing information of a detected speech segment.
 type Segment struct {
 	// SpeechStartAt is the relative timestamp in seconds where speech begins.
+	// -1 means no speech-start event in this segment entry.
 	SpeechStartAt float64
 	// SpeechEndAt is the relative timestamp in seconds where speech ends.
+	// -1 means no speech-end event in this segment entry.
 	SpeechEndAt float64
 }
 
@@ -106,6 +108,8 @@ type Detector struct {
 	state [stateLen]float32
 	// Trailing samples from the previous window for temporal context
 	ctx [contextLen]float32
+	// Pending samples (< window size) carried across Detect calls
+	pending []float32
 
 	// Speech segmentation state
 	currSample int
@@ -216,8 +220,18 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 		windowSize = 256
 	}
 
-	// Small chunks are normal at stream boundaries — skip silently
-	if len(pcm) < windowSize {
+	// Merge pending remainder from previous call with current audio.
+	input := pcm
+	if len(sd.pending) > 0 {
+		merged := make([]float32, len(sd.pending)+len(pcm))
+		copy(merged, sd.pending)
+		copy(merged[len(sd.pending):], pcm)
+		input = merged
+	}
+
+	// Small chunks are normal at stream boundaries — carry forward.
+	if len(input) < windowSize {
+		sd.pending = append(sd.pending[:0], input...)
 		return nil, nil
 	}
 
@@ -225,8 +239,10 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 	speechPadSamples := sd.cfg.SpeechPadMs * sd.cfg.SampleRate / 1000
 
 	var segments []Segment
-	for i := 0; i < len(pcm)-windowSize; i += windowSize {
-		speechProb, err := sd.infer(pcm[i : i+windowSize])
+	fullWindows := len(input) / windowSize
+	for w := 0; w < fullWindows; w++ {
+		i := w * windowSize
+		speechProb, err := sd.infer(input[i : i+windowSize])
 		if err != nil {
 			return nil, fmt.Errorf("infer failed: %w", err)
 		}
@@ -245,7 +261,10 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 			if speechStartAt < 0 {
 				speechStartAt = 0
 			}
-			segments = append(segments, Segment{SpeechStartAt: speechStartAt})
+			segments = append(segments, Segment{
+				SpeechStartAt: speechStartAt,
+				SpeechEndAt:   -1,
+			})
 		}
 
 		// Speech offset (with hysteresis)
@@ -263,13 +282,25 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 			sd.tempEnd = 0
 			sd.triggered = false
 
-			// Speech started in a previous Detect() call — the onset was
-			// already reported. Just close the state without erroring.
+			// Speech started in a previous Detect() call — no start event in
+			// this call, but emit an end marker so callers can emit Event=end.
 			if len(segments) == 0 {
+				segments = append(segments, Segment{
+					SpeechStartAt: -1,
+					SpeechEndAt:   speechEndAt,
+				})
 				continue
 			}
 			segments[len(segments)-1].SpeechEndAt = speechEndAt
 		}
+	}
+
+	// Preserve tail remainder for the next Detect() call.
+	remainderStart := fullWindows * windowSize
+	if remainderStart < len(input) {
+		sd.pending = append(sd.pending[:0], input[remainderStart:]...)
+	} else {
+		sd.pending = sd.pending[:0]
 	}
 
 	return segments, nil
@@ -291,6 +322,7 @@ func (sd *Detector) Reset() {
 	for i := range sd.ctx {
 		sd.ctx[i] = 0
 	}
+	sd.pending = sd.pending[:0]
 }
 
 // Destroy releases all ONNX Runtime resources. Safe to call on a nil

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
@@ -7,15 +7,15 @@ package internal_silero_vad
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
 
+	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
+	internal_audio_resampler "github.com/rapidaai/api/assistant-api/internal/audio/resampler"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -59,6 +59,8 @@ type SileroVAD struct {
 
 	// Silero detector (CGO-backed, requires careful lifecycle management)
 	detector *Detector
+	// Shared audio converter for LINEAR16 -> float32 conversion
+	converter internal_type.AudioConverter
 
 	// Thread-safety for CGO resource protection
 	mu           sync.RWMutex
@@ -86,16 +88,24 @@ func NewSileroVAD(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create silero detector: %w", err)
 	}
+	converter, err := internal_audio_resampler.GetConverter(logger)
+	if err != nil {
+		detector.Destroy()
+		return nil, fmt.Errorf("failed to create audio converter: %w", err)
+	}
 
 	svad := &SileroVAD{
 		logger:       logger,
 		onPacket:     onPacket,
 		detector:     detector,
+		converter:    converter,
 		isTerminated: false,
 	}
 
-	// Start lifecycle manager for automatic cleanup
-	svad.startLifecycleManager(ctx)
+	go func() {
+		<-ctx.Done()
+		_ = svad.Close()
+	}()
 
 	if onPacket != nil {
 		_ = onPacket(ctx, internal_type.ConversationEventPacket{
@@ -131,8 +141,11 @@ func (s *SileroVAD) Process(ctx context.Context, pkt internal_type.UserAudioRece
 		return nil
 	}
 
-	// Convert LINEAR16 bytes to float32 samples
-	samples := linear16ToFloat32(pkt.Audio)
+	// Convert LINEAR16 bytes to float32 samples via shared audio converter.
+	samples, err := s.converter.ConvertToFloat32Samples(pkt.Audio, internal_audio.RAPIDA_INTERNAL_AUDIO_CONFIG)
+	if err != nil {
+		return fmt.Errorf("failed to convert audio to float32: %w", err)
+	}
 
 	// Perform detection with CGO safety
 	segments, isSpeaking, err := s.detectSafely(samples)
@@ -140,10 +153,18 @@ func (s *SileroVAD) Process(ctx context.Context, pkt internal_type.UserAudioRece
 		return err
 	}
 
-	// Emit InterruptionDetectedPacket only on confirmed speech onset — this is the
-	// signal to interrupt assistant TTS/LLM.
-	if hasSpeechStart(segments) {
-		s.notifyActivity(ctx, segments)
+	hasSpeechStart := false
+	hasSpeechEnd := false
+	var speechStartAt, speechEndAt float64
+	for _, seg := range segments {
+		if seg.SpeechStartAt >= 0 && (!hasSpeechStart || seg.SpeechStartAt < speechStartAt) {
+			speechStartAt = seg.SpeechStartAt
+			hasSpeechStart = true
+		}
+		if seg.SpeechEndAt >= 0 && (!hasSpeechEnd || seg.SpeechEndAt > speechEndAt) {
+			speechEndAt = seg.SpeechEndAt
+			hasSpeechEnd = true
+		}
 	}
 
 	// Emit a heartbeat while the user is actively speaking so the EOS
@@ -151,13 +172,15 @@ func (s *SileroVAD) Process(ctx context.Context, pkt internal_type.UserAudioRece
 	if isSpeaking && s.onPacket != nil {
 		_ = s.onPacket(ctx,
 			internal_type.VadSpeechActivityPacket{},
-		// internal_type.ConversationEventPacket{
-		// 	Name: "vad",
-		// 	Data: map[string]string{
-		// 		"type": "heartbeat",
-		// 	},
-		// }
 		)
+	}
+
+	// Emit explicit interruption lifecycle events from VAD transitions.
+	if hasSpeechStart {
+		s.notifyInterruption(ctx, internal_type.InterruptionEventStart, speechStartAt, len(segments))
+	}
+	if hasSpeechEnd {
+		s.notifyInterruption(ctx, internal_type.InterruptionEventEnd, speechEndAt, len(segments))
 	}
 
 	return nil
@@ -251,29 +274,6 @@ func resolveSpeechPadMs(options utils.Option) int {
 	return defaultSpeechPadMs
 }
 
-// -----------------------------------------------------------------------------
-// Private Helper Methods - Lifecycle
-// -----------------------------------------------------------------------------
-
-// hasSpeechStart returns true if any segment contains a speech onset.
-func hasSpeechStart(segments []Segment) bool {
-	for _, seg := range segments {
-		if seg.SpeechStartAt > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// startLifecycleManager spawns a goroutine that closes the VAD
-// when the context is cancelled.
-func (s *SileroVAD) startLifecycleManager(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		s.Close()
-	}()
-}
-
 // isActive checks if the VAD is still operational.
 // Thread-safe.
 func (s *SileroVAD) isActive() bool {
@@ -285,19 +285,6 @@ func (s *SileroVAD) isActive() bool {
 // -----------------------------------------------------------------------------
 // Private Helper Methods - Audio Processing
 // -----------------------------------------------------------------------------
-
-// linear16ToFloat32 converts signed 16-bit little-endian PCM bytes to
-// float32 samples in the range [-1.0, 1.0]. This is the only conversion
-// needed since input is always 16 kHz LINEAR16 mono.
-func linear16ToFloat32(data []byte) []float32 {
-	numSamples := len(data) / 2
-	samples := make([]float32, numSamples)
-	for i := 0; i < numSamples; i++ {
-		sample := int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
-		samples[i] = float32(sample) / 32768.0
-	}
-	return samples
-}
 
 // detectSafely performs voice activity detection with CGO resource protection.
 // Holds the write lock for the duration of the CGO call: Detector
@@ -319,37 +306,24 @@ func (s *SileroVAD) detectSafely(samples []float32) ([]Segment, bool, error) {
 	return segments, s.detector.triggered, nil
 }
 
-// notifyActivity calculates speech boundaries and invokes the callback.
-func (s *SileroVAD) notifyActivity(ctx context.Context, segments []Segment) {
-	minStart := math.MaxFloat64
-	maxEnd := -math.MaxFloat64
-
-	for _, seg := range segments {
-		start := float64(seg.SpeechStartAt)
-		end := float64(seg.SpeechEndAt)
-
-		if start < minStart {
-			minStart = start
-		}
-		if end > maxEnd {
-			maxEnd = end
-		}
-	}
-
+// notifyInterruption emits a VAD interruption lifecycle event packet.
+func (s *SileroVAD) notifyInterruption(ctx context.Context, event internal_type.InterruptionEvent, at float64, segmentCount int) {
 	if s.onPacket != nil {
-		s.onPacket(ctx,
+		_ = s.onPacket(ctx,
 			internal_type.InterruptionDetectedPacket{
 				Source:  internal_type.InterruptionSourceVad,
-				StartAt: minStart,
-				EndAt:   maxEnd,
+				Event:   event,
+				StartAt: at,
+				EndAt:   at,
 			},
 			internal_type.ConversationEventPacket{
 				Name: "vad",
 				Data: map[string]string{
 					"type":          "detected",
-					"start_at":      fmt.Sprintf("%f", minStart),
-					"end_at":        fmt.Sprintf("%f", maxEnd),
-					"segment_count": fmt.Sprintf("%d", len(segments)),
+					"event":         string(event),
+					"start_at":      fmt.Sprintf("%f", at),
+					"end_at":        fmt.Sprintf("%f", at),
+					"segment_count": fmt.Sprintf("%d", segmentCount),
 				},
 			},
 		)

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad_test.go
@@ -270,3 +270,67 @@ func TestSileroVAD_StatefulProcessing(t *testing.T) {
 
 	assert.GreaterOrEqual(t, calls, 0)
 }
+
+func TestSileroVAD_Process_ExactWindow_512Samples(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newSileroOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(512))
+	require.NoError(t, err)
+	assert.Equal(t, 512, vad.detector.currSample, "exact 512-sample chunk should process one full window")
+}
+
+func TestSileroVAD_Process_ExactMultiple_1024Samples(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newSileroOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(1024))
+	require.NoError(t, err)
+	assert.Equal(t, 1024, vad.detector.currSample, "exact 1024-sample chunk should process two full windows")
+}
+
+func TestSileroVAD_Process_CrossCallWindowCarry(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newSileroOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(320))
+	require.NoError(t, err)
+	assert.Equal(t, 0, vad.detector.currSample, "320 samples alone should not process a full 512-sample window")
+
+	err = vad.Process(context.Background(), generateSilence(192))
+	require.NoError(t, err)
+	assert.Equal(t, 512, vad.detector.currSample, "320+192 samples across calls should process one full window")
+}
+
+func TestSileroVAD_Process_RemainderCarry(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newSileroOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(1600))
+	require.NoError(t, err)
+	assert.Equal(t, 1536, vad.detector.currSample, "1600 samples should process three windows and carry 64")
+
+	err = vad.Process(context.Background(), generateSilence(448))
+	require.NoError(t, err)
+	assert.Equal(t, 2048, vad.detector.currSample, "64 carry + 448 samples should process one more window")
+}
+
+func TestSileroVAD_NotifyInterruption_SetsEvent(t *testing.T) {
+	var got internal_type.InterruptionDetectedPacket
+	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
+		for _, p := range pkts {
+			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
+				got = ip
+			}
+		}
+		return nil
+	}
+
+	s := &SileroVAD{onPacket: callback}
+	s.notifyInterruption(context.Background(), internal_type.InterruptionEventEnd, 2.75, 1)
+
+	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
+	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
+	assert.Equal(t, 2.75, got.StartAt)
+	assert.Equal(t, 2.75, got.EndAt)
+}

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
@@ -7,12 +7,11 @@ package internal_ten_vad
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
+	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -61,6 +60,7 @@ type TenVAD struct {
 	currSample int
 	triggered  bool
 	tempEnd    int
+	pending    []int16
 
 	// Configuration
 	hopSize              int
@@ -132,21 +132,25 @@ func (t *TenVAD) Process(ctx context.Context, pkt internal_type.UserAudioReceive
 	}
 
 	// Convert bytes to int16 samples
-	samples := bytesToInt16(pkt.Audio)
-	if len(samples) < t.hopSize {
-		return nil
-	}
-
+	samples := internal_audio.Linear16ToInt16(pkt.Audio)
 	// Process frame-by-frame under lock
 	segments, err := t.processFrames(samples)
 	if err != nil {
 		return err
 	}
 
-	// Emit InterruptionDetectedPacket only on confirmed speech onset — this is the
-	// signal to interrupt assistant TTS/LLM.
-	if hasSpeechStart(segments) {
-		t.notifyActivity(ctx, segments)
+	hasSpeechStart := false
+	hasSpeechEnd := false
+	var speechStartAt, speechEndAt float64
+	for _, seg := range segments {
+		if seg.startAt >= 0 && (!hasSpeechStart || seg.startAt < speechStartAt) {
+			speechStartAt = seg.startAt
+			hasSpeechStart = true
+		}
+		if seg.endAt >= 0 && (!hasSpeechEnd || seg.endAt > speechEndAt) {
+			speechEndAt = seg.endAt
+			hasSpeechEnd = true
+		}
 	}
 
 	// Emit a heartbeat while the user is actively speaking so the EOS
@@ -157,13 +161,15 @@ func (t *TenVAD) Process(ctx context.Context, pkt internal_type.UserAudioReceive
 	if isSpeaking && t.onPacket != nil {
 		_ = t.onPacket(ctx,
 			internal_type.VadSpeechActivityPacket{},
-			// internal_type.ConversationEventPacket{
-			// 	Name: "vad",
-			// 	Data: map[string]string{
-			// 		"type": "heartbeat",
-			// 	},
-			// },
 		)
+	}
+
+	// Emit explicit interruption lifecycle events from VAD transitions.
+	if hasSpeechStart {
+		t.notifyInterruption(ctx, internal_type.InterruptionEventStart, speechStartAt, len(segments))
+	}
+	if hasSpeechEnd {
+		t.notifyInterruption(ctx, internal_type.InterruptionEventEnd, speechEndAt, len(segments))
 	}
 
 	return nil
@@ -187,16 +193,6 @@ func (t *TenVAD) Close() error {
 	return nil
 }
 
-// hasSpeechStart returns true if any segment contains a speech onset.
-func hasSpeechStart(segments []segment) bool {
-	for _, seg := range segments {
-		if seg.startAt > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // -----------------------------------------------------------------------------
 // Private Methods
 // -----------------------------------------------------------------------------
@@ -209,6 +205,7 @@ func (t *TenVAD) isActive() bool {
 
 // segment represents a detected speech region.
 type segment struct {
+	// startAt/endAt use -1 as "unset" sentinel so valid timestamp 0 is preserved.
 	startAt float64
 	endAt   float64
 }
@@ -228,10 +225,30 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 	minSilenceSamples := t.minSilenceDurationMs * sampleRate / 1000
 	speechPadSamples := t.speechPadMs * sampleRate / 1000
 
+	input := samples
+	if len(t.pending) > 0 {
+		combined := make([]int16, 0, len(t.pending)+len(samples))
+		combined = append(combined, t.pending...)
+		combined = append(combined, samples...)
+		input = combined
+	}
+
+	fullSamples := (len(input) / t.hopSize) * t.hopSize
+	if fullSamples == 0 {
+		t.pending = append(t.pending[:0], input...)
+		return nil, nil
+	}
+
+	if fullSamples < len(input) {
+		t.pending = append(t.pending[:0], input[fullSamples:]...)
+	} else {
+		t.pending = t.pending[:0]
+	}
+
 	var segments []segment
 
-	for i := 0; i <= len(samples)-t.hopSize; i += t.hopSize {
-		frame := samples[i : i+t.hopSize]
+	for i := 0; i < fullSamples; i += t.hopSize {
+		frame := input[i : i+t.hopSize]
 
 		probability, _, err := t.detector.Process(frame)
 		if err != nil {
@@ -252,7 +269,7 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 			if speechStartAt < 0 {
 				speechStartAt = 0
 			}
-			segments = append(segments, segment{startAt: speechStartAt})
+			segments = append(segments, segment{startAt: speechStartAt, endAt: -1})
 		}
 
 		// Speech offset (with hysteresis)
@@ -271,6 +288,7 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 
 			// Speech started in a previous call — onset already reported
 			if len(segments) == 0 {
+				segments = append(segments, segment{startAt: -1, endAt: speechEndAt})
 				continue
 			}
 			segments[len(segments)-1].endAt = speechEndAt
@@ -280,47 +298,27 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 	return segments, nil
 }
 
-func (t *TenVAD) notifyActivity(ctx context.Context, segments []segment) {
-	minStart := math.MaxFloat64
-	maxEnd := -math.MaxFloat64
-
-	for _, seg := range segments {
-		if seg.startAt < minStart {
-			minStart = seg.startAt
-		}
-		if seg.endAt > maxEnd {
-			maxEnd = seg.endAt
-		}
-	}
-
+func (t *TenVAD) notifyInterruption(ctx context.Context, event internal_type.InterruptionEvent, at float64, segmentCount int) {
 	if t.onPacket != nil {
-		t.onPacket(ctx,
+		_ = t.onPacket(ctx,
 			internal_type.InterruptionDetectedPacket{
 				Source:  internal_type.InterruptionSourceVad,
-				StartAt: minStart,
-				EndAt:   maxEnd,
+				Event:   event,
+				StartAt: at,
+				EndAt:   at,
 			},
 			internal_type.ConversationEventPacket{
 				Name: "vad",
 				Data: map[string]string{
 					"type":          "detected",
-					"start_at":      fmt.Sprintf("%f", minStart),
-					"end_at":        fmt.Sprintf("%f", maxEnd),
-					"segment_count": fmt.Sprintf("%d", len(segments)),
+					"event":         string(event),
+					"start_at":      fmt.Sprintf("%f", at),
+					"end_at":        fmt.Sprintf("%f", at),
+					"segment_count": fmt.Sprintf("%d", segmentCount),
 				},
 			},
 		)
 	}
-}
-
-// bytesToInt16 converts signed 16-bit little-endian PCM bytes to int16 samples.
-func bytesToInt16(data []byte) []int16 {
-	numSamples := len(data) / 2
-	samples := make([]int16, numSamples)
-	for i := 0; i < numSamples; i++ {
-		samples[i] = int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
-	}
-	return samples
 }
 
 func resolveThreshold(options utils.Option) float64 {

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_test.go
@@ -241,3 +241,38 @@ func TestTenVAD_Process_80msChunk(t *testing.T) {
 	err := vad.Process(context.Background(), generateSilence(1280))
 	require.NoError(t, err)
 }
+
+func TestTenVAD_Process_PartialFrameCarry_NoDrop(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	vad := newTenVADOrSkip(t, 0.5, callback)
+
+	err := vad.Process(context.Background(), generateSilence(128))
+	require.NoError(t, err)
+	assert.Equal(t, 0, vad.currSample)
+	assert.Equal(t, 128, len(vad.pending))
+
+	err = vad.Process(context.Background(), generateSilence(200))
+	require.NoError(t, err)
+	assert.Equal(t, 256, vad.currSample)
+	assert.Equal(t, 72, len(vad.pending))
+}
+
+func TestTenVAD_NotifyInterruption_SetsEvent(t *testing.T) {
+	var got internal_type.InterruptionDetectedPacket
+	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
+		for _, p := range pkts {
+			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
+				got = ip
+			}
+		}
+		return nil
+	}
+
+	v := &TenVAD{onPacket: callback}
+	v.notifyInterruption(context.Background(), internal_type.InterruptionEventEnd, 3.25, 1)
+
+	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
+	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
+	assert.Equal(t, 3.25, got.StartAt)
+	assert.Equal(t, 3.25, got.EndAt)
+}

--- a/ui/src/app/components/base/modal/conversation-telemetry-modal/index.test.ts
+++ b/ui/src/app/components/base/modal/conversation-telemetry-modal/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildLatencySeries,
   buildTelemetryCriteriaInputs,
   matchesTelemetryFilters,
   splitStructuredTelemetryCriteria,
@@ -127,5 +128,60 @@ describe('conversation telemetry structured criteria helpers', () => {
         },
       ),
     ).toBe(true);
+  });
+
+  it('builds latency series with stt/tts/llm/eos metrics merged by context', () => {
+    const series = buildLatencySeries([
+      {
+        timestampMs: 2000,
+        contextId: 'ctx-1',
+        conversationId: 'conv-1',
+        metrics: [
+          { name: 'stt_latency_ms', value: '10' },
+          { name: 'tts_latency_ms', value: '20' },
+        ],
+      },
+      {
+        timestampMs: 1900,
+        contextId: 'ctx-1',
+        conversationId: 'conv-1',
+        metrics: [
+          { name: 'llm_latency_ms', value: '30' },
+          { name: 'eos_latency_ms', value: '40' },
+        ],
+      },
+      {
+        timestampMs: 2100,
+        contextId: 'ctx-2',
+        conversationId: 'conv-1',
+        metrics: [{ name: 'stt_latency_ms', value: '5' }],
+      },
+      {
+        timestampMs: 2200,
+        contextId: 'ctx-3',
+        conversationId: 'conv-1',
+        metrics: [{ name: 'agent_total_token', value: '100' }],
+      },
+    ]);
+
+    expect(series).toHaveLength(2);
+
+    expect(series[0]).toMatchObject({
+      contextId: 'ctx-1',
+      conversationId: 'conv-1',
+      stt_latency_ms: 10,
+      tts_latency_ms: 20,
+      llm_latency_ms: 30,
+      eos_latency_ms: 40,
+      sequence: 1,
+      timestampMs: 1900,
+    });
+
+    expect(series[1]).toMatchObject({
+      contextId: 'ctx-2',
+      conversationId: 'conv-1',
+      stt_latency_ms: 5,
+      sequence: 2,
+    });
   });
 });

--- a/ui/src/app/components/base/modal/conversation-telemetry-modal/index.tsx
+++ b/ui/src/app/components/base/modal/conversation-telemetry-modal/index.tsx
@@ -33,6 +33,15 @@ import {
   Dropdown,
   MultiSelect,
 } from '@carbon/react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  YAxis,
+} from 'recharts';
 import { TableToolbarFilter } from '@/app/components/carbon/table-toolbar-filter';
 import { ChevronRight } from '@carbon/icons-react';
 import { TextInput } from '@/app/components/carbon/form';
@@ -80,6 +89,28 @@ type TelemetryRow =
   | { kind: 'event'; ts: Date; key: string; record: TelemetryEvent }
   | { kind: 'metric'; ts: Date; key: string; record: TelemetryMetric };
 
+type LatencyMetricName =
+  | 'stt_latency_ms'
+  | 'tts_latency_ms'
+  | 'llm_latency_ms'
+  | 'eos_latency_ms';
+
+export type LatencyMetricDocument = {
+  timestampMs: number;
+  contextId: string;
+  conversationId: string;
+  metrics: Array<{ name: string; value: string }>;
+};
+
+export type LatencySeriesPoint = {
+  key: string;
+  sequence: number;
+  timestampMs: number;
+  timeLabel: string;
+  contextId: string;
+  conversationId: string;
+} & Partial<Record<LatencyMetricName, number>>;
+
 // ─── Color map ───────────────────────────────────────────────────────────────
 
 const EVENT_TAG_TYPE: Record<string, string> = {
@@ -120,6 +151,36 @@ const METRIC_SCOPE_OPTIONS = ['message', 'conversation'].map(id => ({
   id,
   label: id.charAt(0) + id.slice(1),
 }));
+
+const LATENCY_METRIC_META: Record<
+  LatencyMetricName,
+  { label: string; shortLabel: string; color: string; gradientId: string }
+> = {
+  stt_latency_ms: {
+    label: 'STT Latency',
+    shortLabel: 'STT',
+    color: '#f59e0b',
+    gradientId: 'telemetryLatencySttGradient',
+  },
+  tts_latency_ms: {
+    label: 'TTS Latency',
+    shortLabel: 'TTS',
+    color: 'var(--cds-interactive, #1e40af)',
+    gradientId: 'telemetryLatencyTtsGradient',
+  },
+  llm_latency_ms: {
+    label: 'LLM Latency',
+    shortLabel: 'LLM',
+    color: '#10b981',
+    gradientId: 'telemetryLatencyLlmGradient',
+  },
+  eos_latency_ms: {
+    label: 'EOS Latency',
+    shortLabel: 'EOS',
+    color: 'var(--cds-support-info, #0ea5e9)',
+    gradientId: 'telemetryLatencyEosGradient',
+  },
+};
 
 const normalizeComponentType = (nameKey: string): string =>
   nameKey === 'sip' ? 'telephony' : nameKey;
@@ -226,6 +287,68 @@ function formatDateTime(d: Date): string {
   );
 }
 
+const isLatencyMetricName = (name: string): name is LatencyMetricName =>
+  name === 'stt_latency_ms' ||
+  name === 'tts_latency_ms' ||
+  name === 'llm_latency_ms' ||
+  name === 'eos_latency_ms';
+
+export const buildLatencySeries = (
+  documents: LatencyMetricDocument[],
+): LatencySeriesPoint[] => {
+  const merged = new Map<string, LatencySeriesPoint>();
+
+  documents.forEach(document => {
+    const contextKey = document.contextId || `ts-${document.timestampMs}`;
+    const key = `${document.conversationId || 'unknown'}::${contextKey}`;
+    const existing = merged.get(key);
+    const point: LatencySeriesPoint =
+      existing ??
+      ({
+        key,
+        sequence: 0,
+        timestampMs: document.timestampMs,
+        timeLabel: formatDateTime(new Date(document.timestampMs)),
+        contextId: document.contextId,
+        conversationId: document.conversationId,
+      } as LatencySeriesPoint);
+
+    const hasExisting = !!existing;
+    let hasLatencyValue = false;
+
+    document.metrics.forEach(metric => {
+      if (!isLatencyMetricName(metric.name)) return;
+      const parsed = Number(metric.value);
+      if (!Number.isFinite(parsed)) return;
+      point[metric.name] = parsed;
+      hasLatencyValue = true;
+    });
+
+    if (!hasExisting && !hasLatencyValue) return;
+
+    if (document.timestampMs < point.timestampMs) {
+      point.timestampMs = document.timestampMs;
+      point.timeLabel = formatDateTime(new Date(document.timestampMs));
+    }
+
+    if (!point.contextId && document.contextId) {
+      point.contextId = document.contextId;
+    }
+    if (!point.conversationId && document.conversationId) {
+      point.conversationId = document.conversationId;
+    }
+
+    merged.set(key, point);
+  });
+
+  return Array.from(merged.values())
+    .sort((a, b) => a.timestampMs - b.timestampMs)
+    .map((point, index) => ({
+      ...point,
+      sequence: index + 1,
+    }));
+};
+
 function eventToJson(event: TelemetryEvent): object {
   const data = Object.fromEntries(
     event.getDataMap().toArray() as [string, string][],
@@ -311,14 +434,17 @@ export function ConversationTelemetryDialog(
   const [appliedEventDataType, setAppliedEventDataType] = useState('');
   const [appliedMetricScope, setAppliedMetricScope] = useState('');
   const [structuredError, setStructuredError] = useState('');
-  const activeTabKind: 'event' | 'metric' =
-    selectedTab === 0 ? 'event' : 'metric';
+  const activeTabKind: 'event' | 'metric' | 'latency' =
+    selectedTab === 0 ? 'event' : selectedTab === 1 ? 'metric' : 'latency';
   const hasSearchQuery = searchText.trim() !== '';
   const hasLocalFilters =
     activeTabKind === 'event'
       ? appliedEventNames.length > 0 || appliedEventDataType !== ''
-      : appliedMetricScope !== '';
-  const shouldFetchAllRows = hasSearchQuery || hasLocalFilters;
+      : activeTabKind === 'metric'
+        ? appliedMetricScope !== ''
+        : false;
+  const shouldFetchAllRows =
+    activeTabKind === 'latency' || hasSearchQuery || hasLocalFilters;
   const requestPage = shouldFetchAllRows ? 1 : page;
   const requestPageSize = shouldFetchAllRows ? 100 : pageSize;
 
@@ -582,7 +708,24 @@ export function ConversationTelemetryDialog(
       );
     });
 
-  const filteredRows = getFilteredRows(activeTabKind);
+  const filteredRows =
+    activeTabKind === 'latency' ? [] : getFilteredRows(activeTabKind);
+  const latencySeries = buildLatencySeries(
+    rows
+      .filter(
+        (row): row is Extract<TelemetryRow, { kind: 'metric' }> =>
+          row.kind === 'metric',
+      )
+      .map(row => ({
+        timestampMs: row.ts.getTime(),
+        contextId: row.record.getContextid(),
+        conversationId: row.record.getAssistantconversationid(),
+        metrics: row.record.getMetricsList().map(metric => ({
+          name: metric.getName(),
+          value: metric.getValue(),
+        })),
+      })),
+  );
 
   useEffect(() => {
     if (!shouldFetchAllRows) return;
@@ -598,6 +741,199 @@ export function ConversationTelemetryDialog(
   }, [selectedTab]);
 
   const totalItems = shouldFetchAllRows ? filteredRows.length : totalItem;
+  const latencyMetricNames = Object.keys(
+    LATENCY_METRIC_META,
+  ) as LatencyMetricName[];
+  const avgLatencyByMetric = latencyMetricNames.reduce(
+    (acc, metricName) => {
+      const values = latencySeries
+        .map(point => point[metricName])
+        .filter(
+          (value): value is number =>
+            typeof value === 'number' && Number.isFinite(value),
+        );
+      acc[metricName] =
+        values.length > 0
+          ? Math.round(
+              values.reduce((sum, current) => sum + current, 0) / values.length,
+            )
+          : 0;
+      return acc;
+    },
+    {} as Record<LatencyMetricName, number>,
+  );
+  const renderLatencyChart = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-16">
+          <Loading withOverlay={false} small />
+        </div>
+      );
+    }
+
+    if (latencySeries.length === 0) {
+      return (
+        <div className="flex items-center justify-center py-16 text-gray-400 dark:text-gray-500 text-sm">
+          No latency metrics found
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-1 min-h-0 flex-col">
+        <div className="flex flex-wrap items-center gap-6 px-4 pt-3 pb-2">
+          {latencyMetricNames.map(metricName => (
+            <div key={metricName}>
+              <p className="text-[10px] text-gray-400 uppercase">
+                {LATENCY_METRIC_META[metricName].shortLabel}
+              </p>
+              <p className="text-xl font-light tabular-nums">
+                {avgLatencyByMetric[metricName]}{' '}
+                <span className="text-xs text-gray-500">ms</span>
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="flex-1 min-h-0 px-2">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={latencySeries}
+              margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                strokeOpacity={0.25}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={42}
+                tick={{ fontSize: 11, fill: '#9ca3af' }}
+              />
+              <defs>
+                {latencyMetricNames.map(metricName => (
+                  <linearGradient
+                    key={LATENCY_METRIC_META[metricName].gradientId}
+                    id={LATENCY_METRIC_META[metricName].gradientId}
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="0%"
+                      stopColor={LATENCY_METRIC_META[metricName].color}
+                      stopOpacity={0.18}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor={LATENCY_METRIC_META[metricName].color}
+                      stopOpacity={0.02}
+                    />
+                  </linearGradient>
+                ))}
+              </defs>
+              {latencyMetricNames.map(metricName => (
+                <Area
+                  key={metricName}
+                  type="monotone"
+                  dataKey={metricName}
+                  stroke={LATENCY_METRIC_META[metricName].color}
+                  strokeWidth={0}
+                  fill={`url(#${LATENCY_METRIC_META[metricName].gradientId})`}
+                  dot={false}
+                  connectNulls
+                />
+              ))}
+              {latencyMetricNames.map(metricName => (
+                <Line
+                  key={`${metricName}-line`}
+                  type="monotone"
+                  dataKey={metricName}
+                  stroke={LATENCY_METRIC_META[metricName].color}
+                  strokeWidth={2}
+                  dot={{
+                    r: 2,
+                    fill: LATENCY_METRIC_META[metricName].color,
+                    strokeWidth: 0,
+                  }}
+                  activeDot={{ r: 3 }}
+                  connectNulls
+                />
+              ))}
+              <RechartsTooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const point = payload[0]?.payload as
+                    | LatencySeriesPoint
+                    | undefined;
+                  const visiblePayload = Array.from(
+                    payload.reduce(
+                      (acc, item) => acc.set(String(item.dataKey), item),
+                      new Map<string, (typeof payload)[number]>(),
+                    ),
+                  )
+                    .map(([, item]) => item)
+                    .filter(item => Number.isFinite(Number(item?.value)));
+                  if (visiblePayload.length === 0) return null;
+
+                  return (
+                    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-lg px-3 py-2 text-sm min-w-[180px]">
+                      <p className="text-gray-400 text-xs mb-1.5">
+                        {point?.contextId
+                          ? `${point.timeLabel} • ${point.contextId}`
+                          : point?.timeLabel || ''}
+                      </p>
+                      {visiblePayload.map(item => {
+                        const metricName = item.dataKey as LatencyMetricName;
+                        const meta = LATENCY_METRIC_META[metricName];
+                        return (
+                          <div
+                            key={String(item.dataKey)}
+                            className="flex items-center gap-2"
+                          >
+                            <div
+                              className="w-2 h-2"
+                              style={{
+                                backgroundColor: item.color || meta?.color,
+                              }}
+                            />
+                            <span className="text-gray-600 dark:text-gray-300 uppercase text-xs">
+                              {meta?.shortLabel || String(item.dataKey)}
+                            </span>
+                            <span className="ml-auto font-semibold tabular-nums">
+                              {Number(item.value)} ms
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="flex flex-wrap justify-center gap-4 px-4 pb-3 text-xs">
+          {latencyMetricNames.map(metricName => (
+            <div
+              key={`${metricName}-legend`}
+              className="flex items-center gap-1.5"
+            >
+              <div
+                className="w-3 h-0.5"
+                style={{
+                  backgroundColor: LATENCY_METRIC_META[metricName].color,
+                }}
+              />
+              {LATENCY_METRIC_META[metricName].shortLabel}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
   const renderTelemetryTable = (kind: 'event' | 'metric') => {
     const isActiveTab = activeTabKind === kind;
     const isEventTab = kind === 'event';
@@ -877,7 +1213,7 @@ export function ConversationTelemetryDialog(
       />
       <ModalBody className="!p-0 !overflow-hidden !flex !flex-col">
         <Tabs
-          tabs={['Events', 'Metrics']}
+          tabs={['Events', 'Metrics', 'Latency']}
           selectedIndex={selectedTab}
           onChange={setSelectedTab}
           contained
@@ -890,6 +1226,9 @@ export function ConversationTelemetryDialog(
           </div>
           <div className="flex flex-1 min-h-0 flex-col">
             {renderTelemetryTable('metric')}
+          </div>
+          <div className="flex flex-1 min-h-0 flex-col">
+            {renderLatencyChart()}
           </div>
         </Tabs>
       </ModalBody>

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/index.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/index.tsx
@@ -161,13 +161,10 @@ const ConfigureAssistantAuthentication: FC<{ assistantId: string }> = ({
   });
 
   const [loading, setLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState('');
   const [authentication, setAuthentication] = useState<AssistantAuthentication | null>(null);
 
   const load = () => {
     setLoading(true);
-    setErrorMessage('');
-
     const request = new GetAssistantAuthenticationRequest();
     request.setAssistantid(assistantId);
 
@@ -183,13 +180,12 @@ const ConfigureAssistantAuthentication: FC<{ assistantId: string }> = ({
           return;
         }
         const data = response.getData();
-        setAuthentication(data || null);
+        if (data) {
+          setAuthentication(data);
+        }
         setLoading(false);
       })
       .catch(() => {
-        setErrorMessage(
-          'Unable to load assistant authentication. Please try again.',
-        );
         setAuthentication(null);
         setLoading(false);
       });
@@ -279,9 +275,6 @@ const ConfigureAssistantAuthentication: FC<{ assistantId: string }> = ({
       </TableToolbar>
 
       <TableSection>
-        {errorMessage && (
-          <Notification kind="error" title="Error" subtitle={errorMessage} />
-        )}
         {authentication ? (
           <Table>
             <TableHead>

--- a/ui/src/providers/azure-foundry/text-models.json
+++ b/ui/src/providers/azure-foundry/text-models.json
@@ -126,7 +126,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -311,7 +311,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -496,7 +496,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -681,7 +681,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -866,7 +866,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",

--- a/ui/src/providers/openai/text-models.json
+++ b/ui/src/providers/openai/text-models.json
@@ -1207,7 +1207,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -1861,7 +1861,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -2103,7 +2103,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -2345,7 +2345,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -2587,7 +2587,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -2833,7 +2833,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -3075,7 +3075,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -3317,7 +3317,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -3559,7 +3559,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -3801,7 +3801,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -3995,7 +3995,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -4193,7 +4193,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -4391,7 +4391,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -4589,7 +4589,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -4787,7 +4787,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",
@@ -4981,7 +4981,7 @@
           "type": "select",
           "advanced": true,
           "required": false,
-          "default": "assistant_id",
+          "default": "conversation_id",
           "choices": [
             {
               "label": "Assistant ID",

--- a/ui/src/styles/generated/tailwindcss.css
+++ b/ui/src/styles/generated/tailwindcss.css
@@ -2566,6 +2566,9 @@
   .h-\[140px\] {
     height: 140px;
   }
+  .h-\[180px\] {
+    height: 180px;
+  }
   .h-\[200px\] {
     height: 200px;
   }
@@ -3003,6 +3006,9 @@
   }
   .min-w-\[160px\] {
     min-width: 160px;
+  }
+  .min-w-\[180px\] {
+    min-width: 180px;
   }
   .min-w-\[240px\] {
     min-width: 240px;


### PR DESCRIPTION
## Description

  - Added EOS latency to supported latency metrics and chart series in:
      - src/app/components/base/modal/conversation-telemetry-modal/index.tsx
  - Added/updated unit test coverage for latency aggregation including EOS:
      - src/app/components/base/modal/conversation-telemetry-modal/index.test.ts

  Behavior now

  - Latency tab plots 4 lines:
      - stt_latency_ms
      - tts_latency_ms
      - llm_latency_ms
      - eos_latency_ms


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-of-speech latency metrics are now emitted by speech detectors; telemetry modal adds a “Latency” tab with multi-series latency charts.

* **Improvements**
  * More accurate and consistent interruption detection and speech-segmentation handling across detectors; improved audio frame buffering for reliability.

* **Tests**
  * Added unit tests covering latency series aggregation, VAD windowing/carryover, and interruption events.

* **Chores**
  * Default model prompt cache key changed from assistant_id to conversation_id for OpenAI and Azure providers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rapidaai/voice-ai/pull/115)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->