### PR TITLE
feat(sip): add granular call and transfer lifecycle webhook events

### DIFF
--- a/api/assistant-api/sip/infra/pipeline.go
+++ b/api/assistant-api/sip/infra/pipeline.go
@@ -44,6 +44,48 @@ type SessionEstablishedPipeline struct {
 
 func (p SessionEstablishedPipeline) CallID() string { return p.ID }
 
+// CallCreatedPipeline is emitted when SIP session identity is created and
+// registered, before ringing/answer lifecycle transitions.
+type CallCreatedPipeline struct {
+	ID      string
+	Session *Session
+	FromURI string
+	ToURI   string
+}
+
+func (p CallCreatedPipeline) CallID() string { return p.ID }
+
+// CallRingingPipeline is emitted when an inbound call reaches ringing state
+// (180 Ringing), before conversation startup.
+type CallRingingPipeline struct {
+	ID      string
+	Session *Session
+	FromURI string
+	ToURI   string
+}
+
+func (p CallRingingPipeline) CallID() string { return p.ID }
+
+// CallAnsweredPipeline is emitted when an inbound call is answered
+// (200 OK / connected), before conversation startup.
+type CallAnsweredPipeline struct {
+	ID      string
+	Session *Session
+	FromURI string
+	ToURI   string
+}
+
+func (p CallAnsweredPipeline) CallID() string { return p.ID }
+
+// CallMediaStartedPipeline represents confirmed media flow start.
+// Emit only when RTP/media start can be signaled reliably.
+type CallMediaStartedPipeline struct {
+	ID      string
+	Session *Session
+}
+
+func (p CallMediaStartedPipeline) CallID() string { return p.ID }
+
 // =============================================================================
 // Signal pipeline — BYE, CANCEL, transfer (preempts everything)
 // =============================================================================
@@ -66,8 +108,10 @@ func (p CancelReceivedPipeline) CallID() string { return p.ID }
 type TransferInitiatedPipeline struct {
 	ID                 string
 	Session            *Session
+	TransferID         string
 	TargetURI          string
 	Targets            []string
+	RoutingMode        string
 	Config             *Config
 	PostTransferAction string
 	OnAttempt          func(target string, attempt int, total int)
@@ -84,17 +128,101 @@ type TransferConnectedPipeline struct {
 	ID              string
 	InboundSession  *Session
 	OutboundSession *Session
+	TargetURI       string
+	Attempt         int
+	TotalAttempts   int
+	TransferID      string
+	RoutingMode     string
 }
 
 func (p TransferConnectedPipeline) CallID() string { return p.ID }
 
 type TransferFailedPipeline struct {
-	ID     string
-	Error  error
-	Reason string
+	ID          string
+	Session     *Session
+	TransferID  string
+	RoutingMode string
+	Error       error
+	Reason      string
 }
 
 func (p TransferFailedPipeline) CallID() string { return p.ID }
+
+type TransferAttemptStartedPipeline struct {
+	ID        string
+	Session   *Session
+	TransferID string
+	TargetURI string
+	Attempt   int
+	Total     int
+	RoutingMode string
+}
+
+func (p TransferAttemptStartedPipeline) CallID() string { return p.ID }
+
+// TransferRequestedPipeline is emitted when transfer routing starts, before
+// target attempts begin.
+type TransferRequestedPipeline struct {
+	ID                 string
+	Session            *Session
+	TransferID         string
+	Targets            []string
+	RoutingMode        string
+	PostTransferAction string
+}
+
+func (p TransferRequestedPipeline) CallID() string { return p.ID }
+
+// TransferTargetRingingPipeline is emitted when a transfer target is known to
+// be ringing from an outbound progress signal.
+type TransferTargetRingingPipeline struct {
+	ID          string
+	Session     *Session
+	TransferID  string
+	TargetURI   string
+	Attempt     int
+	Total       int
+	RoutingMode string
+}
+
+func (p TransferTargetRingingPipeline) CallID() string { return p.ID }
+
+// TransferAttemptEndedPipeline is emitted once per attempted transfer target
+// with terminal state (connected/no_answer/busy/rejected/failed/cancelled).
+type TransferAttemptEndedPipeline struct {
+	ID             string
+	Session        *Session
+	TransferID     string
+	AttemptID      string
+	TargetURI      string
+	OutboundCallID string
+	Attempt        int
+	Total          int
+	RoutingMode    string
+	State          string
+	Reason         string
+	AnsweredBy     string
+	Metadata       map[string]interface{}
+}
+
+func (p TransferAttemptEndedPipeline) CallID() string { return p.ID }
+
+// TransferCancelledPipeline is emitted when pending transfer targets are
+// cancelled (for example answered_by_other in parallel routing).
+type TransferCancelledPipeline struct {
+	ID          string
+	Session     *Session
+	TransferID  string
+	TargetURI   string
+	Attempt     int
+	Total       int
+	RoutingMode string
+	Reason      string
+	AnsweredBy  string
+	Metadata    map[string]interface{}
+}
+
+func (p TransferCancelledPipeline) CallID() string { return p.ID }
 
 type CallEndedPipeline struct {
 	ID       string

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -175,6 +175,9 @@ type Server struct {
 
 	// Event callbacks
 	onInvite func(session *Session, fromURI, toURI string) error
+	onCreated func(session *Session, fromURI, toURI string)
+	onRinging func(session *Session, fromURI, toURI string)
+	onAnswered func(session *Session, fromURI, toURI string)
 	onBye    func(session *Session) error
 	onCancel func(session *Session) error
 	onError  func(session *Session, err error)
@@ -523,6 +526,27 @@ func (s *Server) SetOnInvite(fn func(session *Session, fromURI, toURI string) er
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onInvite = fn
+}
+
+// SetOnCreated sets the callback when a call session is created/registered.
+func (s *Server) SetOnCreated(fn func(session *Session, fromURI, toURI string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onCreated = fn
+}
+
+// SetOnRinging sets the callback when a call reaches ringing state.
+func (s *Server) SetOnRinging(fn func(session *Session, fromURI, toURI string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onRinging = fn
+}
+
+// SetOnAnswered sets the callback when a call is answered/connected.
+func (s *Server) SetOnAnswered(fn func(session *Session, fromURI, toURI string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onAnswered = fn
 }
 
 // SetOnBye sets the callback for BYE requests

--- a/api/assistant-api/sip/infra/server_inbound.go
+++ b/api/assistant-api/sip/infra/server_inbound.go
@@ -141,9 +141,17 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 	for k, v := range resolvedExtra {
 		session.SetMetadata(k, v)
 	}
+	session.SetMetadata(MetadataCallFromURI, fromURI)
+	session.SetMetadata(MetadataCallToURI, toURI)
 
 	// Register session and lifecycle hooks.
 	s.registerSession(session, callID)
+	s.mu.RLock()
+	onCreated := s.onCreated
+	s.mu.RUnlock()
+	if onCreated != nil {
+		onCreated(session, fromURI, toURI)
+	}
 
 	if s.isInviteCancelled(callID) {
 		s.terminatePendingInvite(callID, 487)
@@ -174,6 +182,12 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 		}
 	}
 	s.setCallState(session, CallStateRinging, "inbound_invite_ringing")
+	s.mu.RLock()
+	onRinging := s.onRinging
+	s.mu.RUnlock()
+	if onRinging != nil {
+		onRinging(session, fromURI, toURI)
+	}
 
 	s.logger.Debugw("Parsed remote SDP",
 		"call_id", callID,
@@ -185,6 +199,7 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 	rtpPort, err := s.rtpAllocator.Allocate()
 	if err != nil {
 		s.logger.Errorw("No RTP ports available", "error", err, "call_id", callID)
+		s.notifyError(session, err)
 		s.removeSession(callID)
 		s.sendResponse(tx, req, 503) // Service Unavailable
 		return
@@ -205,6 +220,7 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 	if err != nil {
 		s.rtpAllocator.Release(rtpPort)
 		s.logger.Errorw("Failed to create RTP handler", "error", err, "call_id", callID)
+		s.notifyError(session, err)
 		s.removeSession(callID)
 		s.sendResponse(tx, req, 500)
 		return
@@ -227,6 +243,8 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 
 	// Start RTP processing
 	rtpHandler.Start()
+	// NOTE: do not emit call.media.started here. Local RTP startup does not
+	// guarantee that real media packets have started flowing yet.
 
 	// Generate SDP for response — advertise the negotiated codec only.
 	// Using NegotiatedSDPConfig ensures we confirm the codec we agreed upon,
@@ -257,6 +275,12 @@ func (s *Server) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
 	}
 	s.clearPendingInvite(callID)
 	s.setCallState(session, CallStateConnected, "inbound_invite_answered")
+	s.mu.RLock()
+	onAnswered := s.onAnswered
+	s.mu.RUnlock()
+	if onAnswered != nil {
+		onAnswered(session, fromURI, toURI)
+	}
 
 	s.logger.Infow("SIP call answered",
 		"call_id", callID,

--- a/api/assistant-api/sip/infra/types.go
+++ b/api/assistant-api/sip/infra/types.go
@@ -301,6 +301,12 @@ const (
 	// outbound (B-leg) call created for the transfer.
 	MetadataBridgeTransferOutboundCallID = "bridge_transfer_outbound_call_id"
 
+	// MetadataCallFromURI stores the raw SIP From URI for lifecycle events.
+	MetadataCallFromURI = "call_from_uri"
+
+	// MetadataCallToURI stores the raw SIP To URI for lifecycle events.
+	MetadataCallToURI = "call_to_uri"
+
 	// PostTransferActionEndCall ends the inbound caller's session when the
 	// operator (transfer target) hangs up.
 	PostTransferActionEndCall = "end_call"

--- a/api/assistant-api/sip/pipeline/dispatcher.go
+++ b/api/assistant-api/sip/pipeline/dispatcher.go
@@ -49,6 +49,7 @@ type Dispatcher struct {
 	onCallStart          OnCallStartFunc
 	onCallEnd            OnCallEndFunc
 	onCreateObserver     OnCreateObserverFunc
+	onLifecycleWebhook   OnLifecycleWebhookFunc
 }
 
 type DIDResolverFunc func(did string) (assistantID uint64, auth types.SimplePrinciple, err error)
@@ -90,6 +91,7 @@ type OnCallStartFunc func(ctx context.Context, session *sip_infra.Session, setup
 type OnCallEndFunc func(callID string)
 
 type OnCreateObserverFunc func(ctx context.Context, setup *CallSetupResult, auth types.SimplePrinciple) *observe.ConversationObserver
+type OnLifecycleWebhookFunc func(ctx context.Context, eventType string, session *sip_infra.Session, payload map[string]interface{})
 
 type DispatcherConfig struct {
 	Logger               commons.Logger
@@ -103,6 +105,7 @@ type DispatcherConfig struct {
 	OnCallStart          OnCallStartFunc
 	OnCallEnd            OnCallEndFunc
 	OnCreateObserver     OnCreateObserverFunc
+	OnLifecycleWebhook   OnLifecycleWebhookFunc
 }
 
 // TransferServer is the minimal SIP infra surface required by transfer orchestration.
@@ -128,6 +131,7 @@ func NewDispatcher(cfg *DispatcherConfig) *Dispatcher {
 		onCallStart:          cfg.OnCallStart,
 		onCallEnd:            cfg.OnCallEnd,
 		onCreateObserver:     cfg.OnCreateObserver,
+		onLifecycleWebhook:   cfg.OnLifecycleWebhook,
 		signalCh:             make(chan callEnvelope, signalChSize),
 		setupCh:              make(chan callEnvelope, setupChSize),
 		mediaCh:              make(chan callEnvelope, mediaChSize),
@@ -147,10 +151,19 @@ func (d *Dispatcher) OnPipeline(ctx context.Context, stages ...sip_infra.Pipelin
 	for _, s := range stages {
 		e := callEnvelope{ctx: ctx, p: s}
 		switch s.(type) {
-		case sip_infra.ByeReceivedPipeline,
+		case sip_infra.CallCreatedPipeline,
+			sip_infra.CallRingingPipeline,
+			sip_infra.CallAnsweredPipeline,
+			sip_infra.CallMediaStartedPipeline,
+			sip_infra.ByeReceivedPipeline,
 			sip_infra.CancelReceivedPipeline,
+			sip_infra.TransferRequestedPipeline,
 			sip_infra.TransferInitiatedPipeline,
+			sip_infra.TransferAttemptStartedPipeline,
+			sip_infra.TransferTargetRingingPipeline,
 			sip_infra.TransferConnectedPipeline,
+			sip_infra.TransferAttemptEndedPipeline,
+			sip_infra.TransferCancelledPipeline,
 			sip_infra.TransferFailedPipeline,
 			sip_infra.CallEndedPipeline,
 			sip_infra.CallFailedPipeline:
@@ -193,16 +206,34 @@ func (d *Dispatcher) drain(ch chan callEnvelope) {
 
 func (d *Dispatcher) dispatch(ctx context.Context, p sip_infra.Pipeline) {
 	switch v := p.(type) {
+	case sip_infra.CallCreatedPipeline:
+		d.handleCallCreated(ctx, v)
+	case sip_infra.CallRingingPipeline:
+		d.handleCallRinging(ctx, v)
+	case sip_infra.CallAnsweredPipeline:
+		d.handleCallAnswered(ctx, v)
+	case sip_infra.CallMediaStartedPipeline:
+		d.handleCallMediaStarted(ctx, v)
 	case sip_infra.SessionEstablishedPipeline:
 		d.handleSessionEstablished(ctx, v)
 	case sip_infra.ByeReceivedPipeline:
 		d.handleByeReceived(ctx, v)
 	case sip_infra.CancelReceivedPipeline:
 		d.handleCancelReceived(ctx, v)
+	case sip_infra.TransferRequestedPipeline:
+		d.handleTransferRequested(ctx, v)
 	case sip_infra.TransferInitiatedPipeline:
 		d.handleTransferInitiated(ctx, v)
+	case sip_infra.TransferAttemptStartedPipeline:
+		d.handleTransferAttemptStarted(ctx, v)
+	case sip_infra.TransferTargetRingingPipeline:
+		d.handleTransferTargetRinging(ctx, v)
 	case sip_infra.TransferConnectedPipeline:
 		d.handleTransferConnected(ctx, v)
+	case sip_infra.TransferAttemptEndedPipeline:
+		d.handleTransferAttemptEnded(ctx, v)
+	case sip_infra.TransferCancelledPipeline:
+		d.handleTransferCancelled(ctx, v)
 	case sip_infra.TransferFailedPipeline:
 		d.handleTransferFailed(ctx, v)
 	case sip_infra.CallEndedPipeline:

--- a/api/assistant-api/sip/pipeline/signal.go
+++ b/api/assistant-api/sip/pipeline/signal.go
@@ -29,6 +29,8 @@ const (
 	reasonMediaError    = "media_error"
 	reasonInternalError = "internal_error"
 	reasonUnknown       = "unknown"
+	// maxExtensionLength is the maximum digit length treated as a SIP extension.
+	maxExtensionLength = 6
 )
 
 var sipCodePattern = regexp.MustCompile(`\b([1-6][0-9]{2})\b`)
@@ -219,7 +221,7 @@ func targetExtensionFromURI(uri string) string {
 			return ""
 		}
 	}
-	if len(user) > 0 && len(user) <= 6 {
+	if len(user) > 0 && len(user) <= maxExtensionLength {
 		return user
 	}
 	return ""

--- a/api/assistant-api/sip/pipeline/signal.go
+++ b/api/assistant-api/sip/pipeline/signal.go
@@ -8,23 +8,295 @@ package sip_pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/emiago/sipgo"
 	obs "github.com/rapidaai/api/assistant-api/internal/observe"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 )
+
+const (
+	reasonNoAnswer      = "no_answer"
+	reasonBusy          = "busy"
+	reasonRejected      = "rejected"
+	reasonCancelled     = "cancelled"
+	reasonAnsweredOther = "answered_by_other"
+	reasonSIPError      = "sip_error"
+	reasonMediaError    = "media_error"
+	reasonInternalError = "internal_error"
+	reasonUnknown       = "unknown"
+)
+
+var sipCodePattern = regexp.MustCompile(`\b([1-6][0-9]{2})\b`)
+
+func (d *Dispatcher) emitLifecycleWebhook(ctx context.Context, eventType string, session *sip_infra.Session, payload map[string]interface{}) {
+	if d.onLifecycleWebhook == nil {
+		return
+	}
+	go d.onLifecycleWebhook(ctx, eventType, session, payload)
+}
+
+func parseSIPCode(err error, fallback int) int {
+	if fallback > 0 {
+		return fallback
+	}
+	if err == nil {
+		return 0
+	}
+	var dialogErr *sipgo.ErrDialogResponse
+	if errors.As(err, &dialogErr) && dialogErr != nil && dialogErr.Res != nil {
+		return int(dialogErr.Res.StatusCode)
+	}
+	var sipErr *sip_infra.SIPError
+	if errors.As(err, &sipErr) && sipErr != nil {
+		if sipErr.Code > 0 {
+			return sipErr.Code
+		}
+		if sipErr.Err != nil {
+			return parseSIPCode(sipErr.Err, 0)
+		}
+	}
+	matches := sipCodePattern.FindStringSubmatch(err.Error())
+	if len(matches) == 2 {
+		if code, convErr := strconv.Atoi(matches[1]); convErr == nil {
+			return code
+		}
+	}
+	return 0
+}
+
+func classifyCallFailure(err error, sipCode int) (string, string) {
+	code := parseSIPCode(err, sipCode)
+	if code == 486 || code == 600 {
+		return "call.busy", reasonBusy
+	}
+	if code == 480 || code == 408 {
+		return "call.no_answer", reasonNoAnswer
+	}
+	if code == 603 || code == 403 {
+		return "call.rejected", reasonRejected
+	}
+
+	msg := ""
+	if err != nil {
+		msg = strings.ToLower(err.Error())
+	}
+	switch {
+	case strings.Contains(msg, "busy"):
+		return "call.busy", reasonBusy
+	case strings.Contains(msg, "decline") || strings.Contains(msg, "reject"):
+		return "call.rejected", reasonRejected
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline") || strings.Contains(msg, "no answer") || strings.Contains(msg, "unavailable"):
+		return "call.no_answer", reasonNoAnswer
+	case strings.Contains(msg, "rtp") || strings.Contains(msg, "media"):
+		return "call.failed", reasonMediaError
+	case strings.Contains(msg, "cancel"):
+		return "call.cancelled", reasonCancelled
+	case strings.Contains(msg, "sip"):
+		return "call.failed", reasonSIPError
+	case msg != "":
+		return "call.failed", reasonInternalError
+	default:
+		return "call.failed", reasonUnknown
+	}
+}
+
+func classifyTransferAttemptFailure(err error) (string, string) {
+	if err == nil {
+		return "failed", reasonUnknown
+	}
+	code := parseSIPCode(err, 0)
+	if code == 486 || code == 600 {
+		return "busy", reasonBusy
+	}
+	if code == 480 || code == 408 {
+		return "no_answer", reasonNoAnswer
+	}
+	if code == 603 || code == 403 {
+		return "rejected", reasonRejected
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "busy"):
+		return "busy", reasonBusy
+	case strings.Contains(msg, "decline") || strings.Contains(msg, "reject"):
+		return "rejected", reasonRejected
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline") || strings.Contains(msg, "no answer") || strings.Contains(msg, "unavailable"):
+		return "no_answer", reasonNoAnswer
+	case strings.Contains(msg, "cancel"):
+		return "cancelled", reasonCancelled
+	default:
+		return "failed", reasonSIPError
+	}
+}
+
+func sessionURIs(session *sip_infra.Session) (string, string) {
+	if session == nil {
+		return "", ""
+	}
+	var fromURI, toURI string
+	if from, ok := session.GetMetadata(sip_infra.MetadataCallFromURI); ok {
+		if s, ok := from.(string); ok {
+			fromURI = s
+		}
+	}
+	if to, ok := session.GetMetadata(sip_infra.MetadataCallToURI); ok {
+		if s, ok := to.(string); ok {
+			toURI = s
+		}
+	}
+	return fromURI, toURI
+}
+
+func transferDirection(session *sip_infra.Session) string {
+	if session == nil {
+		return ""
+	}
+	return string(session.GetInfo().Direction)
+}
+
+func transferCallPayload(session *sip_infra.Session, state, reason string) map[string]interface{} {
+	fromURI, toURI := sessionURIs(session)
+	payload := map[string]interface{}{
+		"provider":        "sip",
+		"call_id":         "",
+		"conversation_id": nil,
+		"assistant_id":    nil,
+		"project_id":      nil,
+		"organization_id": nil,
+		"direction":       transferDirection(session),
+		"from_uri":        fromURI,
+		"to_uri":          toURI,
+		"from_number":     sip_infra.ExtractDIDFromURI(fromURI),
+		"to_number":       sip_infra.ExtractDIDFromURI(toURI),
+		"session_id":      "",
+		"state":           state,
+		"reason":          reason,
+		"metadata":        map[string]interface{}{},
+	}
+	if session == nil {
+		return payload
+	}
+	payload["call_id"] = session.GetCallID()
+	payload["session_id"] = session.GetCallID()
+	if convID := session.GetConversationID(); convID > 0 {
+		payload["conversation_id"] = fmt.Sprintf("%d", convID)
+	}
+	if assistant := session.GetAssistant(); assistant != nil {
+		payload["assistant_id"] = fmt.Sprintf("%d", assistant.Id)
+	}
+	if auth := session.GetAuth(); auth != nil {
+		if pid := auth.GetCurrentProjectId(); pid != nil {
+			payload["project_id"] = fmt.Sprintf("%d", *pid)
+		}
+		if oid := auth.GetCurrentOrganizationId(); oid != nil {
+			payload["organization_id"] = fmt.Sprintf("%d", *oid)
+		}
+	}
+	return payload
+}
+
+func targetExtensionFromURI(uri string) string {
+	if uri == "" {
+		return ""
+	}
+	raw := strings.TrimPrefix(strings.TrimPrefix(uri, "sip:"), "sips:")
+	parts := strings.SplitN(raw, "@", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return ""
+	}
+	user := parts[0]
+	if idx := strings.IndexByte(user, ';'); idx >= 0 {
+		user = user[:idx]
+	}
+	user = strings.TrimPrefix(user, "+")
+	for _, ch := range user {
+		if ch < '0' || ch > '9' {
+			return ""
+		}
+	}
+	if len(user) > 0 && len(user) <= 6 {
+		return user
+	}
+	return ""
+}
+
+func transferEventPayload(session *sip_infra.Session, state, reason, transferID, routingMode string) map[string]interface{} {
+	if routingMode == "" {
+		routingMode = "unknown"
+	}
+	payload := transferCallPayload(session, state, reason)
+	payload["transfer_id"] = transferID
+	payload["attempt_id"] = nil
+	payload["outbound_call_id"] = nil
+	payload["routing_mode"] = routingMode
+	payload["target_uri"] = nil
+	payload["target_number"] = nil
+	payload["target_extension"] = nil
+	payload["target_user_id"] = nil
+	payload["attempt"] = nil
+	payload["total_attempts"] = nil
+	payload["answered_by"] = nil
+	return payload
+}
+
+func (d *Dispatcher) handleCallCreated(ctx context.Context, v sip_infra.CallCreatedPipeline) {
+	d.logger.Infow("Pipeline: CallCreated", "call_id", v.ID)
+	payload := transferCallPayload(v.Session, "created", "")
+	payload["from_uri"] = v.FromURI
+	payload["to_uri"] = v.ToURI
+	payload["from_number"] = sip_infra.ExtractDIDFromURI(v.FromURI)
+	payload["to_number"] = sip_infra.ExtractDIDFromURI(v.ToURI)
+	d.emitLifecycleWebhook(ctx, "call.created", v.Session, payload)
+}
+
+func (d *Dispatcher) handleCallRinging(ctx context.Context, v sip_infra.CallRingingPipeline) {
+	d.logger.Infow("Pipeline: CallRinging", "call_id", v.ID)
+	payload := transferCallPayload(v.Session, "ringing", "")
+	payload["from_uri"] = v.FromURI
+	payload["to_uri"] = v.ToURI
+	payload["from_number"] = sip_infra.ExtractDIDFromURI(v.FromURI)
+	payload["to_number"] = sip_infra.ExtractDIDFromURI(v.ToURI)
+	d.emitLifecycleWebhook(ctx, "call.ringing", v.Session, payload)
+}
+
+func (d *Dispatcher) handleCallAnswered(ctx context.Context, v sip_infra.CallAnsweredPipeline) {
+	d.logger.Infow("Pipeline: CallAnswered", "call_id", v.ID)
+	payload := transferCallPayload(v.Session, "answered", "")
+	payload["from_uri"] = v.FromURI
+	payload["to_uri"] = v.ToURI
+	payload["from_number"] = sip_infra.ExtractDIDFromURI(v.FromURI)
+	payload["to_number"] = sip_infra.ExtractDIDFromURI(v.ToURI)
+	d.emitLifecycleWebhook(ctx, "call.answered", v.Session, payload)
+}
+
+func (d *Dispatcher) handleCallMediaStarted(ctx context.Context, v sip_infra.CallMediaStartedPipeline) {
+	d.logger.Infow("Pipeline: CallMediaStarted", "call_id", v.ID)
+	payload := transferCallPayload(v.Session, "media_started", "")
+	d.emitLifecycleWebhook(ctx, "call.media.started", v.Session, payload)
+}
 
 func (d *Dispatcher) handleByeReceived(ctx context.Context, v sip_infra.ByeReceivedPipeline) {
 	d.logger.Infow("Pipeline: ByeReceived",
 		"call_id", v.ID,
 		"reason", v.Reason,
 		"direction", v.Session.GetInfo().Direction)
+	reason := v.Reason
+	if reason == "" {
+		reason = "remote_bye"
+	}
+	d.emitLifecycleWebhook(ctx, "call.ended", v.Session, transferCallPayload(v.Session, "ended", reason))
 }
 
 func (d *Dispatcher) handleCancelReceived(ctx context.Context, v sip_infra.CancelReceivedPipeline) {
 	d.logger.Infow("Pipeline: CancelReceived",
 		"call_id", v.ID,
 		"direction", v.Session.GetInfo().Direction)
+	d.emitLifecycleWebhook(ctx, "call.cancelled", v.Session, transferCallPayload(v.Session, "ended", "cancelled"))
 }
 
 func (d *Dispatcher) handleCallEnded(ctx context.Context, v sip_infra.CallEndedPipeline) {
@@ -39,20 +311,49 @@ func (d *Dispatcher) handleCallEnded(ctx context.Context, v sip_infra.CallEndedP
 // failures (outbound call rejected, setup error) that occur before the main
 // SessionEstablished pipeline creates its own observer.
 func (d *Dispatcher) handleCallFailed(ctx context.Context, v sip_infra.CallFailedPipeline) {
-	reason := "call_failed"
-	if v.Error != nil {
-		reason = v.Error.Error()
-	}
-
 	d.logger.Warnw("Pipeline: CallFailed",
 		"call_id", v.ID,
 		"error", fmt.Sprintf("%v", v.Error),
 		"sip_code", v.SIPCode)
 
 	// Emit failure metric via observer if session has enough context
+	sipCode := parseSIPCode(v.Error, v.SIPCode)
 	if v.Session == nil {
+		eventType, normalizedReason := classifyCallFailure(v.Error, sipCode)
+		meta := map[string]interface{}{}
+		if sipCode > 0 {
+			meta["sip_code"] = fmt.Sprintf("%d", sipCode)
+		}
+		d.emitLifecycleWebhook(ctx, eventType, nil, map[string]interface{}{
+			"provider":        "sip",
+			"call_id":         v.ID,
+			"conversation_id": nil,
+			"assistant_id":    nil,
+			"project_id":      nil,
+			"organization_id": nil,
+			"direction":       "",
+			"from_uri":        "",
+			"to_uri":          "",
+			"from_number":     "",
+			"to_number":       "",
+			"session_id":      v.ID,
+			"state":           "failed",
+			"reason":          normalizedReason,
+			"metadata":        meta,
+		})
 		return
 	}
+	eventType, normalizedReason := classifyCallFailure(v.Error, sipCode)
+	callFailedPayload := transferCallPayload(v.Session, "failed", normalizedReason)
+	if sipCode > 0 {
+		meta := callFailedPayload["metadata"].(map[string]interface{})
+		meta["sip_code"] = fmt.Sprintf("%d", sipCode)
+	}
+	if v.Error != nil {
+		meta := callFailedPayload["metadata"].(map[string]interface{})
+		meta["error"] = v.Error.Error()
+	}
+	d.emitLifecycleWebhook(ctx, eventType, v.Session, callFailedPayload)
 	auth := v.Session.GetAuth()
 	convID := v.Session.GetConversationID()
 	if auth == nil || convID == 0 {
@@ -81,18 +382,136 @@ func (d *Dispatcher) handleCallFailed(ctx context.Context, v sip_infra.CallFaile
 			eventData := map[string]string{
 				obs.DataType:      obs.EventCallFailed,
 				obs.DataProvider:  "sip",
-				obs.DataReason:    reason,
+				obs.DataReason:    normalizedReason,
 				obs.DataDirection: string(v.Session.GetInfo().Direction),
 			}
-			if v.SIPCode > 0 {
-				eventData["sip_code"] = fmt.Sprintf("%d", v.SIPCode)
+			if sipCode > 0 {
+				eventData["sip_code"] = fmt.Sprintf("%d", sipCode)
 			}
 			if v.Error != nil {
 				eventData[obs.DataError] = v.Error.Error()
 			}
-			observer.EmitMetric(ctx, obs.CallStatusMetric("FAILED", reason))
+			observer.EmitMetric(ctx, obs.CallStatusMetric("FAILED", normalizedReason))
 			observer.EmitEvent(ctx, obs.ComponentTelephony, eventData)
 			observer.Shutdown(ctx)
 		}
 	}
+}
+
+func (d *Dispatcher) handleTransferRequested(ctx context.Context, v sip_infra.TransferRequestedPipeline) {
+	routingMode := v.RoutingMode
+	if routingMode == "" {
+		routingMode = "unknown"
+	}
+	payload := transferEventPayload(v.Session, "requested", "", v.TransferID, routingMode)
+	payload["attempt"] = 0
+	payload["total_attempts"] = len(v.Targets)
+	payload["metadata"] = map[string]interface{}{
+		"post_transfer_action": v.PostTransferAction,
+	}
+	d.emitLifecycleWebhook(ctx, "transfer.requested", v.Session, payload)
+}
+
+func (d *Dispatcher) handleTransferAttemptStarted(ctx context.Context, v sip_infra.TransferAttemptStartedPipeline) {
+	payload := transferEventPayload(v.Session, "attempting", "", v.TransferID, v.RoutingMode)
+	payload["attempt_id"] = fmt.Sprintf("%s:%d", v.TransferID, v.Attempt)
+	payload["target_uri"] = v.TargetURI
+	payload["target_number"] = sip_infra.ExtractDIDFromURI(v.TargetURI)
+	payload["target_extension"] = targetExtensionFromURI(v.TargetURI)
+	payload["target_user_id"] = nil
+	payload["attempt"] = v.Attempt
+	payload["total_attempts"] = v.Total
+	d.emitLifecycleWebhook(ctx, "transfer.attempt.started", v.Session, payload)
+}
+
+func (d *Dispatcher) handleTransferTargetRinging(ctx context.Context, v sip_infra.TransferTargetRingingPipeline) {
+	payload := transferEventPayload(v.Session, "ringing", "", v.TransferID, v.RoutingMode)
+	payload["attempt_id"] = fmt.Sprintf("%s:%d", v.TransferID, v.Attempt)
+	payload["target_uri"] = v.TargetURI
+	payload["target_number"] = sip_infra.ExtractDIDFromURI(v.TargetURI)
+	payload["target_extension"] = targetExtensionFromURI(v.TargetURI)
+	payload["attempt"] = v.Attempt
+	payload["total_attempts"] = v.Total
+	d.emitLifecycleWebhook(ctx, "transfer.target.ringing", v.Session, payload)
+}
+
+func (d *Dispatcher) handleTransferConnected(ctx context.Context, v sip_infra.TransferConnectedPipeline) {
+	outboundInfo := v.OutboundSession.GetInfo()
+	d.logger.Infow("Pipeline: transfer_connected",
+		"call_id", v.ID,
+		"outbound_call_id", v.OutboundSession.GetCallID(),
+		"target_uri", outboundInfo.RemoteURI,
+		"codec", outboundInfo.Codec)
+	targetURI := v.TargetURI
+	if targetURI == "" {
+		targetURI = outboundInfo.RemoteURI
+	}
+	payload := transferEventPayload(v.InboundSession, "connected", "target_answered", v.TransferID, v.RoutingMode)
+	payload["outbound_call_id"] = v.OutboundSession.GetCallID()
+	payload["target_uri"] = targetURI
+	payload["target_number"] = sip_infra.ExtractDIDFromURI(targetURI)
+	payload["target_extension"] = targetExtensionFromURI(targetURI)
+	payload["target_user_id"] = nil
+	payload["attempt"] = v.Attempt
+	payload["total_attempts"] = v.TotalAttempts
+	if v.Attempt > 0 {
+		payload["attempt_id"] = fmt.Sprintf("%s:%d", v.TransferID, v.Attempt)
+	}
+	d.emitLifecycleWebhook(ctx, "transfer.connected", v.InboundSession, payload)
+}
+
+func (d *Dispatcher) handleTransferAttemptEnded(ctx context.Context, v sip_infra.TransferAttemptEndedPipeline) {
+	payload := transferEventPayload(v.Session, v.State, v.Reason, v.TransferID, v.RoutingMode)
+	payload["attempt_id"] = v.AttemptID
+	payload["outbound_call_id"] = v.OutboundCallID
+	payload["target_uri"] = v.TargetURI
+	payload["target_number"] = sip_infra.ExtractDIDFromURI(v.TargetURI)
+	payload["target_extension"] = targetExtensionFromURI(v.TargetURI)
+	payload["attempt"] = v.Attempt
+	payload["total_attempts"] = v.Total
+	payload["answered_by"] = v.AnsweredBy
+	if v.Metadata != nil {
+		payload["metadata"] = v.Metadata
+	}
+	d.emitLifecycleWebhook(ctx, "transfer.attempt.ended", v.Session, payload)
+}
+
+func (d *Dispatcher) handleTransferCancelled(ctx context.Context, v sip_infra.TransferCancelledPipeline) {
+	payload := transferEventPayload(v.Session, "cancelled", v.Reason, v.TransferID, v.RoutingMode)
+	if v.TransferID != "" && v.Attempt > 0 {
+		payload["attempt_id"] = fmt.Sprintf("%s:%d", v.TransferID, v.Attempt)
+	}
+	payload["target_uri"] = v.TargetURI
+	payload["target_number"] = sip_infra.ExtractDIDFromURI(v.TargetURI)
+	payload["target_extension"] = targetExtensionFromURI(v.TargetURI)
+	payload["attempt"] = v.Attempt
+	payload["total_attempts"] = v.Total
+	payload["answered_by"] = v.AnsweredBy
+	if v.Metadata != nil {
+		payload["metadata"] = v.Metadata
+	}
+	d.emitLifecycleWebhook(ctx, "transfer.cancelled", v.Session, payload)
+}
+
+func (d *Dispatcher) handleTransferFailed(ctx context.Context, v sip_infra.TransferFailedPipeline) {
+	// Categorize the failure for structured alerting
+	category := categorizeTransferError(v.Reason, v.Error)
+	d.logger.Warnw("Pipeline: transfer_failed",
+		"call_id", v.ID,
+		"reason", v.Reason,
+		"category", category,
+		"error", v.Error)
+	reason := strings.TrimSpace(v.Reason)
+	if reason == "" && v.Error != nil {
+		reason = v.Error.Error()
+	}
+	payload := transferEventPayload(v.Session, "failed", reason, v.TransferID, v.RoutingMode)
+	payload["outbound_call_id"] = nil
+	payload["target_uri"] = nil
+	payload["target_number"] = nil
+	payload["target_extension"] = nil
+	payload["target_user_id"] = nil
+	payload["attempt"] = nil
+	payload["total_attempts"] = nil
+	d.emitLifecycleWebhook(ctx, "transfer.failed", v.Session, payload)
 }

--- a/api/assistant-api/sip/pipeline/signal_lifecycle_test.go
+++ b/api/assistant-api/sip/pipeline/signal_lifecycle_test.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package sip_pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/types"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+)
+
+type lifecycleEventCapture struct {
+	eventType string
+	session   *sip_infra.Session
+	payload   map[string]interface{}
+}
+
+func newLifecycleTestDispatcher(t *testing.T, ch chan lifecycleEventCapture) *Dispatcher {
+	t.Helper()
+	logger, err := commons.NewApplicationLogger(
+		commons.EnableConsole(false),
+		commons.EnableFile(false),
+		commons.Level("error"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	return NewDispatcher(&DispatcherConfig{
+		Logger: logger,
+		OnLifecycleWebhook: func(ctx context.Context, eventType string, session *sip_infra.Session, payload map[string]interface{}) {
+			ch <- lifecycleEventCapture{
+				eventType: eventType,
+				session:   session,
+				payload:   payload,
+			}
+		},
+	})
+}
+
+func newLifecycleTestSession(t *testing.T, callID string) *sip_infra.Session {
+	t.Helper()
+	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
+		Config: &sip_infra.Config{
+			Server:            "127.0.0.1",
+			Port:              5060,
+			RTPPortRangeStart: 10000,
+			RTPPortRangeEnd:   10100,
+		},
+		Direction: sip_infra.CallDirectionInbound,
+		CallID:    callID,
+	})
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	session.SetMetadata(sip_infra.MetadataCallFromURI, "sip:+15551234567@pbx.example.com")
+	session.SetMetadata(sip_infra.MetadataCallToURI, "sip:+18005550100@pbx.example.com")
+	session.SetConversationID(42)
+
+	projectID := uint64(1001)
+	organizationID := uint64(2002)
+	session.SetAuth(&types.ProjectScope{
+		ProjectId:      &projectID,
+		OrganizationId: &organizationID,
+		Status:         type_enums.RECORD_ACTIVE.String(),
+	})
+
+	assistant := &internal_assistant_entity.Assistant{}
+	assistant.Id = 77
+	session.SetAssistant(assistant)
+	return session
+}
+
+func waitLifecycleEvent(t *testing.T, ch <-chan lifecycleEventCapture) lifecycleEventCapture {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		return evt
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for lifecycle event")
+		return lifecycleEventCapture{}
+	}
+}
+
+func TestDispatch_CallRinging_EmitsLifecycleWebhook(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-ring-1")
+
+	d.dispatch(context.Background(), sip_infra.CallRingingPipeline{
+		ID:      "call-ring-1",
+		Session: session,
+		FromURI: "sip:+15551234567@pbx.example.com",
+		ToURI:   "sip:+18005550100@pbx.example.com",
+	})
+
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "call.ringing" {
+		t.Fatalf("expected event type call.ringing, got %s", evt.eventType)
+	}
+	if got := evt.payload["call_id"]; got != "call-ring-1" {
+		t.Fatalf("expected call_id call-ring-1, got %v", got)
+	}
+	if got := evt.payload["state"]; got != "ringing" {
+		t.Fatalf("expected state ringing, got %v", got)
+	}
+	if got := evt.payload["assistant_id"]; got != "77" {
+		t.Fatalf("expected assistant_id 77, got %v", got)
+	}
+}
+
+func TestDispatch_CallCreated_EmitsLifecycleWebhook(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-created-1")
+
+	d.dispatch(context.Background(), sip_infra.CallCreatedPipeline{
+		ID:      "call-created-1",
+		Session: session,
+		FromURI: "sip:+15551234567@pbx.example.com",
+		ToURI:   "sip:+18005550100@pbx.example.com",
+	})
+
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "call.created" {
+		t.Fatalf("expected event type call.created, got %s", evt.eventType)
+	}
+	if got := evt.payload["state"]; got != "created" {
+		t.Fatalf("expected state created, got %v", got)
+	}
+}
+
+func TestDispatch_TransferAttemptStarted_EmitsAttemptPayload(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-transfer-1")
+
+	d.dispatch(context.Background(), sip_infra.TransferAttemptStartedPipeline{
+		ID:          "call-transfer-1",
+		Session:     session,
+		TransferID:  "transfer:call-transfer-1",
+		TargetURI:   "sip:101@pbx.example.com",
+		Attempt:     1,
+		Total:       3,
+		RoutingMode: "sequential",
+	})
+
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "transfer.attempt.started" {
+		t.Fatalf("expected event type transfer.attempt.started, got %s", evt.eventType)
+	}
+	if got := evt.payload["target_uri"]; got != "sip:101@pbx.example.com" {
+		t.Fatalf("expected target_uri sip:101@pbx.example.com, got %v", got)
+	}
+	if got := evt.payload["attempt"]; got != 1 {
+		t.Fatalf("expected attempt 1, got %v", got)
+	}
+	if got := evt.payload["total_attempts"]; got != 3 {
+		t.Fatalf("expected total 3, got %v", got)
+	}
+	if got := evt.payload["state"]; got != "attempting" {
+		t.Fatalf("expected state attempting, got %v", got)
+	}
+}
+
+func TestDispatch_CallFailedWithoutSession_MapsNoAnswer(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+
+	d.dispatch(context.Background(), sip_infra.CallFailedPipeline{
+		ID:      "call-failed-no-answer",
+		Session: nil,
+		Error:   context.DeadlineExceeded,
+		SIPCode: 408,
+	})
+
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "call.no_answer" {
+		t.Fatalf("expected event type call.no_answer, got %s", evt.eventType)
+	}
+	if got := evt.payload["reason"]; got != reasonNoAnswer {
+		t.Fatalf("expected reason no_answer, got %v", got)
+	}
+}
+
+func TestDispatch_CallFailedWithoutSession_MapsBusyAndRejected(t *testing.T) {
+	tcs := []struct {
+		name      string
+		err       error
+		sipCode   int
+		eventType string
+		reason    string
+	}{
+		{
+			name:      "busy",
+			err:       errors.New("486 Busy Here"),
+			sipCode:   486,
+			eventType: "call.busy",
+			reason:    reasonBusy,
+		},
+		{
+			name:      "rejected",
+			err:       errors.New("603 Decline"),
+			sipCode:   603,
+			eventType: "call.rejected",
+			reason:    reasonRejected,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan lifecycleEventCapture, 1)
+			d := newLifecycleTestDispatcher(t, ch)
+			d.dispatch(context.Background(), sip_infra.CallFailedPipeline{
+				ID:      "call-failed-" + tc.name,
+				Session: nil,
+				Error:   tc.err,
+				SIPCode: tc.sipCode,
+			})
+			evt := waitLifecycleEvent(t, ch)
+			if evt.eventType != tc.eventType {
+				t.Fatalf("expected event type %s, got %s", tc.eventType, evt.eventType)
+			}
+			if got := evt.payload["reason"]; got != tc.reason {
+				t.Fatalf("expected reason %s, got %v", tc.reason, got)
+			}
+		})
+	}
+}
+
+func TestDispatch_TransferRequested_MapsPayload(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-transfer-requested")
+
+	d.dispatch(context.Background(), sip_infra.TransferRequestedPipeline{
+		ID:                 "call-transfer-requested",
+		Session:            session,
+		TransferID:         "transfer:call-transfer-requested",
+		Targets:            []string{"sip:101@pbx.example.com", "sip:102@pbx.example.com"},
+		RoutingMode:        "sequential",
+		PostTransferAction: "resume_ai",
+	})
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "transfer.requested" {
+		t.Fatalf("expected transfer.requested, got %s", evt.eventType)
+	}
+	if got := evt.payload["transfer_id"]; got != "transfer:call-transfer-requested" {
+		t.Fatalf("expected transfer id, got %v", got)
+	}
+	if got := evt.payload["total_attempts"]; got != 2 {
+		t.Fatalf("expected total attempts 2, got %v", got)
+	}
+}
+
+func TestDispatch_TransferAttemptEnded_MapsTerminalState(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-transfer-ended")
+
+	d.dispatch(context.Background(), sip_infra.TransferAttemptEndedPipeline{
+		ID:          "call-transfer-ended",
+		Session:     session,
+		TransferID:  "transfer:call-transfer-ended",
+		AttemptID:   "transfer:call-transfer-ended:1",
+		TargetURI:   "sip:101@pbx.example.com",
+		Attempt:     1,
+		Total:       3,
+		RoutingMode: "sequential",
+		State:       "busy",
+		Reason:      reasonBusy,
+	})
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "transfer.attempt.ended" {
+		t.Fatalf("expected transfer.attempt.ended, got %s", evt.eventType)
+	}
+	if got := evt.payload["state"]; got != "busy" {
+		t.Fatalf("expected state busy, got %v", got)
+	}
+	if got := evt.payload["reason"]; got != reasonBusy {
+		t.Fatalf("expected reason busy, got %v", got)
+	}
+}
+
+func TestDispatch_TransferCancelled_AnsweredByOther(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+	session := newLifecycleTestSession(t, "call-transfer-cancel")
+
+	d.dispatch(context.Background(), sip_infra.TransferCancelledPipeline{
+		ID:          "call-transfer-cancel",
+		Session:     session,
+		TransferID:  "transfer:call-transfer-cancel",
+		TargetURI:   "sip:102@pbx.example.com",
+		Attempt:     2,
+		Total:       3,
+		RoutingMode: "parallel",
+		Reason:      reasonAnsweredOther,
+		AnsweredBy:  "sip:101@pbx.example.com",
+	})
+	evt := waitLifecycleEvent(t, ch)
+	if evt.eventType != "transfer.cancelled" {
+		t.Fatalf("expected transfer.cancelled, got %s", evt.eventType)
+	}
+	if got := evt.payload["reason"]; got != reasonAnsweredOther {
+		t.Fatalf("expected reason answered_by_other, got %v", got)
+	}
+	if got := evt.payload["answered_by"]; got != "sip:101@pbx.example.com" {
+		t.Fatalf("expected answered_by to be set, got %v", got)
+	}
+}
+
+func TestDispatch_CallFailedWithoutSession_EmitsMinimalFailurePayload(t *testing.T) {
+	ch := make(chan lifecycleEventCapture, 1)
+	d := newLifecycleTestDispatcher(t, ch)
+
+	d.dispatch(context.Background(), sip_infra.CallFailedPipeline{
+		ID:      "call-failed-unknown",
+		Session: nil,
+		Error:   errors.New("unclassified"),
+	})
+
+	evt := waitLifecycleEvent(t, ch)
+	if got := evt.payload["call_id"]; got != "call-failed-unknown" {
+		t.Fatalf("expected call_id call-failed-unknown, got %v", got)
+	}
+	if got := evt.payload["state"]; got != "failed" {
+		t.Fatalf("expected state failed, got %v", got)
+	}
+	if got := evt.payload["reason"]; got == nil || got == "" {
+		t.Fatalf("expected non-empty normalized failure reason")
+	}
+}

--- a/api/assistant-api/sip/pipeline/transfer.go
+++ b/api/assistant-api/sip/pipeline/transfer.go
@@ -16,10 +16,34 @@ import (
 )
 
 func (d *Dispatcher) handleTransferInitiated(ctx context.Context, v sip_infra.TransferInitiatedPipeline) {
+	if v.RoutingMode == "" {
+		v.RoutingMode = "sequential"
+	}
+	if v.TransferID == "" {
+		v.TransferID = fmt.Sprintf("transfer:%s", v.ID)
+	}
+	targets := v.Targets
+	if len(targets) == 0 && v.TargetURI != "" {
+		targets = []string{v.TargetURI}
+	}
+	d.OnPipeline(ctx, sip_infra.TransferRequestedPipeline{
+		ID:                 v.ID,
+		Session:            v.Session,
+		TransferID:         v.TransferID,
+		Targets:            targets,
+		RoutingMode:        v.RoutingMode,
+		PostTransferAction: v.PostTransferAction,
+	})
 	go d.executeTransfer(ctx, v)
 }
 
 func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferInitiatedPipeline) {
+	if v.RoutingMode == "" {
+		v.RoutingMode = "sequential"
+	}
+	if v.TransferID == "" {
+		v.TransferID = fmt.Sprintf("transfer:%s", v.ID)
+	}
 	d.logger.Infow("Pipeline: transfer_initiated",
 		"call_id", v.ID, "target", v.TargetURI)
 
@@ -30,6 +54,14 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		if v.OnFailed != nil {
 			v.OnFailed()
 		}
+		d.OnPipeline(ctx, sip_infra.TransferFailedPipeline{
+			ID:          v.ID,
+			Session:     v.Session,
+			TransferID:  v.TransferID,
+			RoutingMode: v.RoutingMode,
+			Error:       fmt.Errorf("sip server unavailable"),
+			Reason:      "server_nil",
+		})
 		return
 	}
 
@@ -62,6 +94,17 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		if v.OnAttempt != nil {
 			v.OnAttempt(target, attempt, len(targets))
 		}
+		d.OnPipeline(ctx, sip_infra.TransferAttemptStartedPipeline{
+			ID:          v.ID,
+			Session:     v.Session,
+			TransferID:  v.TransferID,
+			TargetURI:   target,
+			Attempt:     attempt,
+			Total:       len(targets),
+			RoutingMode: v.RoutingMode,
+		})
+		// TODO: emit TransferTargetRingingPipeline when bridge dialing exposes
+		// a reliable per-target ringing callback from SIP 180/183 progress.
 
 		// Each target gets its own BridgeCallTimeout. The overall budget is
 		// bounded by the inbound session context — if the caller hangs up
@@ -72,6 +115,19 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		if err == nil {
 			outboundSession = session
 			connectedTarget = target
+			d.OnPipeline(ctx, sip_infra.TransferAttemptEndedPipeline{
+				ID:             v.ID,
+				Session:        v.Session,
+				TransferID:     v.TransferID,
+				AttemptID:      fmt.Sprintf("%s:%d", v.TransferID, attempt),
+				TargetURI:      target,
+				OutboundCallID: session.GetCallID(),
+				Attempt:        attempt,
+				Total:          len(targets),
+				RoutingMode:    v.RoutingMode,
+				State:          "connected",
+				Reason:         "connected",
+			})
 			break
 		}
 
@@ -88,6 +144,34 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 				"error":   err.Error(),
 			},
 		})
+		attemptState, attemptReason := classifyTransferAttemptFailure(err)
+		d.OnPipeline(ctx, sip_infra.TransferAttemptEndedPipeline{
+			ID:          v.ID,
+			Session:     v.Session,
+			TransferID:  v.TransferID,
+			AttemptID:   fmt.Sprintf("%s:%d", v.TransferID, attempt),
+			TargetURI:   target,
+			Attempt:     attempt,
+			Total:       len(targets),
+			RoutingMode: v.RoutingMode,
+			State:       attemptState,
+			Reason:      attemptReason,
+			Metadata: map[string]interface{}{
+				"error": err.Error(),
+			},
+		})
+		if attemptState == "cancelled" {
+			d.OnPipeline(ctx, sip_infra.TransferCancelledPipeline{
+				ID:          v.ID,
+				Session:     v.Session,
+				TransferID:  v.TransferID,
+				TargetURI:   target,
+				Attempt:     attempt,
+				Total:       len(targets),
+				RoutingMode: v.RoutingMode,
+				Reason:      attemptReason,
+			})
+		}
 
 		// Caller hung up or session ended — stop trying further targets.
 		if v.Session.Context().Err() != nil {
@@ -103,9 +187,12 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 			v.OnFailed()
 		}
 		d.OnPipeline(ctx, sip_infra.TransferFailedPipeline{
-			ID:     v.ID,
-			Error:  fmt.Errorf("all %d transfer targets failed", len(targets)),
-			Reason: "outbound_failed",
+			ID:          v.ID,
+			Session:     v.Session,
+			TransferID:  v.TransferID,
+			RoutingMode: v.RoutingMode,
+			Error:       fmt.Errorf("all %d transfer targets failed", len(targets)),
+			Reason:      "outbound_failed",
 		})
 		return
 	}
@@ -131,7 +218,32 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		ID:              v.ID,
 		InboundSession:  v.Session,
 		OutboundSession: outboundSession,
+		TargetURI:       connectedTarget,
+		Attempt:         indexOfTarget(targets, connectedTarget) + 1,
+		TotalAttempts:   len(targets),
+		TransferID:      v.TransferID,
+		RoutingMode:     v.RoutingMode,
 	})
+	connectedIndex := indexOfTarget(targets, connectedTarget)
+	for i, target := range targets {
+		if target == connectedTarget {
+			continue
+		}
+		if v.RoutingMode != "parallel" && connectedIndex >= 0 && i < connectedIndex {
+			continue
+		}
+		d.OnPipeline(ctx, sip_infra.TransferCancelledPipeline{
+			ID:          v.ID,
+			Session:     v.Session,
+			TransferID:  v.TransferID,
+			TargetURI:   target,
+			Attempt:     i + 1,
+			Total:       len(targets),
+			RoutingMode: v.RoutingMode,
+			Reason:      reasonAnsweredOther,
+			AnsweredBy:  connectedTarget,
+		})
+	}
 
 	// Track bridge duration from the moment the transfer target answered
 	bridgeStart := time.Now()
@@ -181,23 +293,13 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 	}
 }
 
-func (d *Dispatcher) handleTransferConnected(ctx context.Context, v sip_infra.TransferConnectedPipeline) {
-	outboundInfo := v.OutboundSession.GetInfo()
-	d.logger.Infow("Pipeline: transfer_connected",
-		"call_id", v.ID,
-		"outbound_call_id", v.OutboundSession.GetCallID(),
-		"target_uri", outboundInfo.RemoteURI,
-		"codec", outboundInfo.Codec)
-}
-
-func (d *Dispatcher) handleTransferFailed(ctx context.Context, v sip_infra.TransferFailedPipeline) {
-	// Categorize the failure for structured alerting
-	category := categorizeTransferError(v.Reason, v.Error)
-	d.logger.Warnw("Pipeline: transfer_failed",
-		"call_id", v.ID,
-		"reason", v.Reason,
-		"category", category,
-		"error", v.Error)
+func indexOfTarget(targets []string, target string) int {
+	for i, t := range targets {
+		if t == target {
+			return i
+		}
+	}
+	return -1
 }
 
 // categorizeTransferError maps raw transfer failure reasons into high-level
@@ -213,13 +315,21 @@ func categorizeTransferError(reason string, err error) string {
 		return "setup"
 	case reason == "outbound_failed":
 		if err != nil {
-			errMsg := err.Error()
+			errMsg := strings.ToLower(err.Error())
 			if strings.Contains(errMsg, "timeout") || strings.Contains(errMsg, "deadline") {
 				return "network"
 			}
-			if strings.Contains(errMsg, "486") || strings.Contains(errMsg, "603") ||
-				strings.Contains(errMsg, "busy") || strings.Contains(errMsg, "declined") {
+			if strings.Contains(errMsg, "486") || strings.Contains(errMsg, "600") ||
+				strings.Contains(errMsg, "busy") {
 				return "rejected"
+			}
+			if strings.Contains(errMsg, "603") || strings.Contains(errMsg, "403") ||
+				strings.Contains(errMsg, "declined") || strings.Contains(errMsg, "rejected") {
+				return "rejected"
+			}
+			if strings.Contains(errMsg, "480") || strings.Contains(errMsg, "408") ||
+				strings.Contains(errMsg, "no answer") || strings.Contains(errMsg, "unavailable") {
+				return "network"
 			}
 		}
 		return "network"

--- a/api/assistant-api/sip/pipeline/transfer.go
+++ b/api/assistant-api/sip/pipeline/transfer.go
@@ -85,6 +85,8 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 
 	var outboundSession *sip_infra.Session
 	var connectedTarget string
+	connectedIndex := -1
+	var lastErr error
 	for i, target := range targets {
 		attempt := i + 1
 		d.logger.Infow("Pipeline: transfer_attempt",
@@ -115,6 +117,7 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		if err == nil {
 			outboundSession = session
 			connectedTarget = target
+			connectedIndex = i
 			d.OnPipeline(ctx, sip_infra.TransferAttemptEndedPipeline{
 				ID:             v.ID,
 				Session:        v.Session,
@@ -134,6 +137,7 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		d.logger.Warnw("Pipeline: transfer_target_failed",
 			"call_id", v.ID, "target", target,
 			"attempt", attempt, "error", err)
+		lastErr = err
 
 		d.OnPipeline(ctx, sip_infra.EventEmittedPipeline{
 			ID:    v.ID,
@@ -191,7 +195,7 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 			Session:     v.Session,
 			TransferID:  v.TransferID,
 			RoutingMode: v.RoutingMode,
-			Error:       fmt.Errorf("all %d transfer targets failed", len(targets)),
+			Error:       transferFailedError(len(targets), lastErr),
 			Reason:      "outbound_failed",
 		})
 		return
@@ -219,14 +223,13 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 		InboundSession:  v.Session,
 		OutboundSession: outboundSession,
 		TargetURI:       connectedTarget,
-		Attempt:         indexOfTarget(targets, connectedTarget) + 1,
+		Attempt:         connectedIndex + 1,
 		TotalAttempts:   len(targets),
 		TransferID:      v.TransferID,
 		RoutingMode:     v.RoutingMode,
 	})
-	connectedIndex := indexOfTarget(targets, connectedTarget)
 	for i, target := range targets {
-		if target == connectedTarget {
+		if i == connectedIndex {
 			continue
 		}
 		if v.RoutingMode != "parallel" && connectedIndex >= 0 && i < connectedIndex {
@@ -293,13 +296,11 @@ func (d *Dispatcher) executeTransfer(ctx context.Context, v sip_infra.TransferIn
 	}
 }
 
-func indexOfTarget(targets []string, target string) int {
-	for i, t := range targets {
-		if t == target {
-			return i
-		}
+func transferFailedError(total int, lastErr error) error {
+	if lastErr == nil {
+		return fmt.Errorf("all %d transfer targets failed", total)
 	}
-	return -1
+	return fmt.Errorf("all %d transfer targets failed: %w", total, lastErr)
 }
 
 // categorizeTransferError maps raw transfer failure reasons into high-level

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -57,6 +57,7 @@ type SIPEngine struct {
 	storage    storages.Storage
 
 	assistantConversationService internal_services.AssistantConversationService
+	assistantHTTPLogService      internal_services.AssistantHTTPLogService
 	assistantService             internal_services.AssistantService
 	deploymentService            internal_services.AssistantDeploymentService
 	vaultClient                  web_client.VaultClient
@@ -85,6 +86,7 @@ func NewSIPEngine(config *config.AssistantConfig, logger commons.Logger,
 		redis:                        redis,
 		opensearch:                   opensearch,
 		assistantConversationService: internal_assistant_service.NewAssistantConversationService(logger, postgres, storage_files.NewStorage(config.AssetStoreConfig, logger)),
+		assistantHTTPLogService:      internal_assistant_service.NewAssistantHTTPLogService(logger, postgres, storage_files.NewStorage(config.AssetStoreConfig, logger)),
 		assistantService:             internal_assistant_service.NewAssistantService(config, logger, postgres, opensearch),
 		deploymentService:            internal_assistant_service.NewAssistantDeploymentService(config, logger, postgres),
 		storage:                      storage_files.NewStorage(config.AssetStoreConfig, logger),
@@ -141,6 +143,9 @@ func (m *SIPEngine) Connect(ctx context.Context) error {
 		m.vaultConfigResolver, // Fetch SIP config from vault
 	)
 	server.SetOnInvite(m.onInvite)
+	server.SetOnCreated(m.onCreated)
+	server.SetOnRinging(m.onRinging)
+	server.SetOnAnswered(m.onAnswered)
 	server.SetOnBye(m.onBye)
 	server.SetOnCancel(m.onCancel)
 	server.SetOnError(m.onError)
@@ -167,6 +172,7 @@ func (m *SIPEngine) Connect(ctx context.Context) error {
 		OnCallStart:          m.pipelineCallStart,
 		OnCallEnd:            m.pipelineCallEnd,
 		OnCreateObserver:     m.createObserver,
+		OnLifecycleWebhook:   m.publishSIPLifecycleWebhook,
 	})
 	m.dispatcher.Start(m.ctx)
 
@@ -225,7 +231,7 @@ func (m *SIPEngine) assistantMiddleware(ctx *sip_infra.SIPRequestContext, next f
 	}
 
 	assistant, err := m.assistantService.Get(m.ctx, auth, assistantID, utils.GetVersionDefinition("latest"),
-		&internal_services.GetAssistantOption{InjectPhoneDeployment: true})
+		&internal_services.GetAssistantOption{InjectPhoneDeployment: true, InjectWebhook: true})
 	if err != nil {
 		m.logger.Error("SIP: assistant not found", "call_id", ctx.CallID, "method", ctx.Method, "assistant_id", assistantID, "error", err)
 		return sip_infra.Reject(404, "Assistant not found"), nil
@@ -324,6 +330,33 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) 
 	return nil
 }
 
+func (m *SIPEngine) onCreated(session *sip_infra.Session, fromURI, toURI string) {
+	m.dispatcher.OnPipeline(m.ctx, sip_infra.CallCreatedPipeline{
+		ID:      session.GetInfo().CallID,
+		Session: session,
+		FromURI: fromURI,
+		ToURI:   toURI,
+	})
+}
+
+func (m *SIPEngine) onRinging(session *sip_infra.Session, fromURI, toURI string) {
+	m.dispatcher.OnPipeline(m.ctx, sip_infra.CallRingingPipeline{
+		ID:      session.GetInfo().CallID,
+		Session: session,
+		FromURI: fromURI,
+		ToURI:   toURI,
+	})
+}
+
+func (m *SIPEngine) onAnswered(session *sip_infra.Session, fromURI, toURI string) {
+	m.dispatcher.OnPipeline(m.ctx, sip_infra.CallAnsweredPipeline{
+		ID:      session.GetInfo().CallID,
+		Session: session,
+		FromURI: fromURI,
+		ToURI:   toURI,
+	})
+}
+
 func (m *SIPEngine) onBye(session *sip_infra.Session) error {
 	m.dispatcher.OnPipeline(m.ctx, sip_infra.ByeReceivedPipeline{
 		ID:      session.GetInfo().CallID,
@@ -343,6 +376,10 @@ func (m *SIPEngine) onCancel(session *sip_infra.Session) error {
 // onError handles SIP-level errors by emitting a CallFailedPipeline event.
 // The pipeline handler (signal.go) creates the observer and persists metrics.
 func (m *SIPEngine) onError(session *sip_infra.Session, callErr error) {
+	if session == nil {
+		m.logger.Warnw("SIP error without session", "error", callErr)
+		return
+	}
 	m.logger.Warnw("SIP error", "call_id", session.GetCallID(), "error", callErr)
 	m.dispatcher.OnPipeline(m.ctx, sip_infra.CallFailedPipeline{
 		ID:      session.GetCallID(),
@@ -648,7 +685,7 @@ func (m *SIPEngine) pipelineCallSetup(ctx context.Context, session *sip_infra.Se
 	if assistant == nil {
 		var err error
 		assistant, err = m.assistantService.Get(ctx, auth, assistantID, utils.GetVersionDefinition("latest"),
-			&internal_services.GetAssistantOption{InjectPhoneDeployment: true})
+			&internal_services.GetAssistantOption{InjectPhoneDeployment: true, InjectWebhook: true})
 		if err != nil {
 			return nil, fmt.Errorf("failed to load assistant %d: %w", assistantID, err)
 		}

--- a/api/assistant-api/sip/webhook_lifecycle.go
+++ b/api/assistant-api/sip/webhook_lifecycle.go
@@ -14,9 +14,9 @@ import (
 
 	internal_condition "github.com/rapidaai/api/assistant-api/internal/condition"
 	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	internal_services "github.com/rapidaai/api/assistant-api/internal/services"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	internal_webhook "github.com/rapidaai/api/assistant-api/internal/webhook"
-	internal_services "github.com/rapidaai/api/assistant-api/internal/services"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	gorm_generator "github.com/rapidaai/pkg/models/gorm/generators"
 	"github.com/rapidaai/pkg/types"
@@ -57,7 +57,7 @@ func (c *sipWebhookCallback) OnPacket(ctx context.Context, pkts ...internal_type
 			httpPkt.ResponsePayload,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("sip webhook callback: create http log (event=%s, context=%s): %w", httpPkt.SourceEvent, httpPkt.ContextID, err)
 		}
 	}
 	return nil
@@ -164,4 +164,3 @@ func allowSIPWebhookCondition(webhook *internal_assistant_entity.AssistantWebhoo
 	}
 	return allowed
 }
-

--- a/api/assistant-api/sip/webhook_lifecycle.go
+++ b/api/assistant-api/sip/webhook_lifecycle.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package assistant_sip
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	internal_condition "github.com/rapidaai/api/assistant-api/internal/condition"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
+	internal_webhook "github.com/rapidaai/api/assistant-api/internal/webhook"
+	internal_services "github.com/rapidaai/api/assistant-api/internal/services"
+	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
+	gorm_generator "github.com/rapidaai/pkg/models/gorm/generators"
+	"github.com/rapidaai/pkg/types"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+	"github.com/rapidaai/pkg/utils"
+)
+
+type sipWebhookCallback struct {
+	httpLogService internal_services.AssistantHTTPLogService
+	auth           types.SimplePrinciple
+	assistantID    uint64
+	conversationID *uint64
+}
+
+func (c *sipWebhookCallback) OnPacket(ctx context.Context, pkts ...internal_type.Packet) error {
+	for _, pkt := range pkts {
+		httpPkt, ok := pkt.(internal_type.HTTPLogCreatePacket)
+		if !ok {
+			continue
+		}
+		_, err := c.httpLogService.CreateLog(
+			ctx,
+			c.auth,
+			httpPkt.Source,
+			httpPkt.SourceRefID,
+			httpPkt.SourceEvent,
+			httpPkt.ContextID,
+			c.assistantID,
+			c.conversationID,
+			httpPkt.HTTPURL,
+			httpPkt.HTTPMethod,
+			httpPkt.ResponseStatus,
+			httpPkt.TimeTaken,
+			httpPkt.RetryCount,
+			httpPkt.Status,
+			httpPkt.ErrorMessage,
+			httpPkt.RequestPayload,
+			httpPkt.ResponsePayload,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *SIPEngine) publishSIPLifecycleWebhook(ctx context.Context, eventType string, session *sip_infra.Session, payload map[string]interface{}) {
+	if session == nil {
+		return
+	}
+
+	auth := session.GetAuth()
+	assistant := session.GetAssistant()
+	if auth == nil || assistant == nil {
+		return
+	}
+
+	if len(assistant.AssistantWebhooks) == 0 {
+		loaded, err := m.assistantService.Get(ctx, auth, assistant.Id, utils.GetVersionDefinition("latest"),
+			&internal_services.GetAssistantOption{InjectWebhook: true})
+		if err == nil && loaded != nil {
+			assistant = loaded
+			session.SetAssistant(loaded)
+		}
+	}
+	if len(assistant.AssistantWebhooks) == 0 {
+		return
+	}
+
+	data := payload
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	envelope := map[string]interface{}{
+		"id":        fmt.Sprintf("%d", gorm_generator.ID()),
+		"type":      eventType,
+		"timestamp": time.Now().UnixMilli(),
+		"data":      data,
+	}
+
+	var conversationID *uint64
+	if convID := session.GetConversationID(); convID > 0 {
+		conversationID = &convID
+	}
+	cb := &sipWebhookCallback{
+		httpLogService: m.assistantHTTPLogService,
+		auth:           auth,
+		assistantID:    assistant.Id,
+		conversationID: conversationID,
+	}
+
+	for _, webhook := range assistant.AssistantWebhooks {
+		if webhook == nil {
+			continue
+		}
+		if !slices.Contains(webhook.GetAssistantEvents(), eventType) {
+			continue
+		}
+		if !allowSIPWebhookCondition(webhook, string(session.GetInfo().Direction)) {
+			continue
+		}
+
+		exec, err := internal_webhook.NewExecutor(m.logger, ctx, webhook, cb, nil)
+		if err != nil {
+			m.logger.Warnw("SIP lifecycle webhook: executor creation failed",
+				"event", eventType,
+				"webhook_id", webhook.Id,
+				"error", err)
+			continue
+		}
+		err = exec.Execute(ctx, internal_type.ExecuteWebhookPacket{
+			ContextID: session.GetCallID(),
+			Event:     utils.AssistantWebhookEvent(eventType),
+			Arguments: envelope,
+		})
+		if err != nil {
+			m.logger.Warnw("SIP lifecycle webhook execution failed",
+				"event", eventType,
+				"webhook_id", webhook.Id,
+				"error", err)
+		}
+		_ = exec.Close(ctx)
+	}
+}
+
+func allowSIPWebhookCondition(webhook *internal_assistant_entity.AssistantWebhook, direction string) bool {
+	if webhook == nil {
+		return false
+	}
+	raw, err := webhook.GetOptions().GetString("webhook.condition")
+	if err != nil {
+		return true
+	}
+	parsed, parseErr := internal_condition.Parse(raw)
+	if parseErr != nil {
+		return false
+	}
+	allowed, evalErr := parsed.Run(
+		internal_condition.ConditionValue{RuleType: internal_condition.RuleTypeSource, Value: utils.PhoneCall.Get()},
+		internal_condition.ConditionValue{RuleType: internal_condition.RuleTypeMode, Value: type_enums.AudioMode.String()},
+		internal_condition.ConditionValue{RuleType: internal_condition.RuleTypeDirection, Value: direction},
+	)
+	if evalErr != nil {
+		return false
+	}
+	return allowed
+}
+

--- a/api/assistant-api/sip/webhook_lifecycle_test.go
+++ b/api/assistant-api/sip/webhook_lifecycle_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package assistant_sip
+
+import (
+	"testing"
+
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	gorm_model "github.com/rapidaai/pkg/models/gorm"
+)
+
+func TestAllowSIPWebhookCondition_NoCondition_Allows(t *testing.T) {
+	webhook := &internal_assistant_entity.AssistantWebhook{}
+	if !allowSIPWebhookCondition(webhook, "inbound") {
+		t.Fatal("expected webhook with no condition to be allowed")
+	}
+}
+
+func TestAllowSIPWebhookCondition_ValidDirectionCondition(t *testing.T) {
+	webhook := &internal_assistant_entity.AssistantWebhook{
+		AssistantWebhookOption: []*internal_assistant_entity.AssistantWebhookOption{
+			{
+				Metadata: gorm_model.Metadata{
+					Key:   "webhook.condition",
+					Value: `[{"key":"source","condition":"=","value":"phone"},{"key":"mode","condition":"=","value":"voice"},{"key":"direction","condition":"=","value":"inbound"}]`,
+				},
+			},
+		},
+	}
+	if !allowSIPWebhookCondition(webhook, "inbound") {
+		t.Fatal("expected inbound direction to satisfy webhook.condition")
+	}
+	if allowSIPWebhookCondition(webhook, "outbound") {
+		t.Fatal("expected outbound direction to fail webhook.condition")
+	}
+}
+
+func TestAllowSIPWebhookCondition_InvalidCondition_Blocks(t *testing.T) {
+	webhook := &internal_assistant_entity.AssistantWebhook{
+		AssistantWebhookOption: []*internal_assistant_entity.AssistantWebhookOption{
+			{
+				Metadata: gorm_model.Metadata{
+					Key:   "webhook.condition",
+					Value: `{invalid_json`,
+				},
+			},
+		},
+	}
+	if allowSIPWebhookCondition(webhook, "inbound") {
+		t.Fatal("expected invalid webhook.condition to be blocked")
+	}
+}

--- a/pkg/utils/rapida_event.go
+++ b/pkg/utils/rapida_event.go
@@ -17,6 +17,24 @@ const (
 	ConversationFailed AssistantWebhookEvent = "conversation.failed"
 	// Triggered when a conversation encounters an error.
 
+	// SIP/call lifecycle events (pre/during conversation).
+	CallCreated    AssistantWebhookEvent = "call.created"
+	CallRinging    AssistantWebhookEvent = "call.ringing"
+	CallAnswered   AssistantWebhookEvent = "call.answered"
+	CallMediaStarted AssistantWebhookEvent = "call.media.started"
+	CallNoAnswer   AssistantWebhookEvent = "call.no_answer"
+	CallBusy       AssistantWebhookEvent = "call.busy"
+	CallRejected   AssistantWebhookEvent = "call.rejected"
+	CallCancelled  AssistantWebhookEvent = "call.cancelled"
+	CallEnded      AssistantWebhookEvent = "call.ended"
+	CallFailed     AssistantWebhookEvent = "call.failed"
+	TransferRequested      AssistantWebhookEvent = "transfer.requested"
+	TransferAttemptStarted AssistantWebhookEvent = "transfer.attempt.started"
+	TransferTargetRinging  AssistantWebhookEvent = "transfer.target.ringing"
+	TransferConnected      AssistantWebhookEvent = "transfer.connected"
+	TransferAttemptEnded   AssistantWebhookEvent = "transfer.attempt.ended"
+	TransferCancelled      AssistantWebhookEvent = "transfer.cancelled"
+	TransferFailed         AssistantWebhookEvent = "transfer.failed"
 )
 
 func (r AssistantWebhookEvent) Get() string {

--- a/pkg/utils/rapida_event_test.go
+++ b/pkg/utils/rapida_event_test.go
@@ -16,6 +16,23 @@ func TestAssistantWebhookEvent_Get(t *testing.T) {
 		{ConversationResume, "conversation.resume"},
 		{ConversationCompleted, "conversation.completed"},
 		{ConversationFailed, "conversation.failed"},
+		{CallCreated, "call.created"},
+		{CallRinging, "call.ringing"},
+		{CallAnswered, "call.answered"},
+		{CallMediaStarted, "call.media.started"},
+		{CallNoAnswer, "call.no_answer"},
+		{CallBusy, "call.busy"},
+		{CallRejected, "call.rejected"},
+		{CallCancelled, "call.cancelled"},
+		{CallEnded, "call.ended"},
+		{CallFailed, "call.failed"},
+		{TransferRequested, "transfer.requested"},
+		{TransferAttemptStarted, "transfer.attempt.started"},
+		{TransferTargetRinging, "transfer.target.ringing"},
+		{TransferConnected, "transfer.connected"},
+		{TransferAttemptEnded, "transfer.attempt.ended"},
+		{TransferCancelled, "transfer.cancelled"},
+		{TransferFailed, "transfer.failed"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Adds granular SIP call and transfer lifecycle webhook events for CRM workflows, extending the existing SIP webhook pipeline without adding websockets or a new realtime server.

Highlights:
- Adds call lifecycle events: `call.created`, `call.no_answer`, `call.busy`, `call.rejected` (and preserves existing `call.ringing`, `call.answered`, `call.cancelled`, `call.ended`, `call.failed`)
- Adds transfer lifecycle events: `transfer.requested`, `transfer.attempt.ended`, `transfer.cancelled` (and preserves existing `transfer.attempt.started`, `transfer.connected`, `transfer.failed`)
- Defines `call.media.started` and `transfer.target.ringing` event types with wiring, but does not emit them yet without reliable low-level hooks
- Keeps webhook delivery async through existing executor path so failures do not block SIP call setup
- Adds/updates unit tests for event mapping and lifecycle behavior

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [x] Test update
- [ ] Security fix

## Related Issues

Fixes #125

## Checklist

### General

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [x] My changes do not introduce any security vulnerabilities
- [x] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

N/A

## Additional Notes

Go toolchain was not available in my execution environment, so I could not run `go test` locally in this session (`go` command not found).  
I added/updated tests in:
- `api/assistant-api/sip/pipeline/signal_lifecycle_test.go`
- `api/assistant-api/sip/webhook_lifecycle_test.go`
- `pkg/utils/rapida_event_test.go`

Changed files:
- `api/assistant-api/sip/infra/pipeline.go`
- `api/assistant-api/sip/infra/server.go`
- `api/assistant-api/sip/infra/server_inbound.go`
- `api/assistant-api/sip/infra/types.go`
- `api/assistant-api/sip/pipeline/dispatcher.go`
- `api/assistant-api/sip/pipeline/signal.go`
- `api/assistant-api/sip/pipeline/transfer.go`
- `api/assistant-api/sip/sip.go`
- `api/assistant-api/sip/webhook_lifecycle.go`
- `api/assistant-api/sip/pipeline/signal_lifecycle_test.go`
- `api/assistant-api/sip/webhook_lifecycle_test.go`
- `pkg/utils/rapida_event.go`
- `pkg/utils/rapida_event_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added call lifecycle events (created, ringing, answered, media started) and richer transfer lifecycle events (requested, attempt started, target ringing, connected, attempt ended, cancelled, failed)
  * Enabled assistant webhooks for SIP lifecycle events with conditional filtering

* **Improvements**
  * Standardized lifecycle webhook payloads and more precise error/classification for call and transfer failures

* **Tests**
  * Added unit tests validating lifecycle webhook emission and webhook condition handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rapidaai/voice-ai/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->