### PR TITLE
chore(security): bump go to 1.25.11

### DIFF
--- a/.github/workflows/docker-publish-base.yml
+++ b/.github/workflows/docker-publish-base.yml
@@ -85,9 +85,9 @@ jobs:
 
   # ── Shared login step (reused via composite would be ideal, but keeping it inline) ──
 
-  # ── rapidaai/rapida-golang:1.25.8-bookworm (heavy — ONNX, RNNoise, Azure Speech SDK) ──
+  # ── rapidaai/rapida-golang:1.25.11-bookworm (heavy — ONNX, RNNoise, Azure Speech SDK) ──
   push-golang-bookworm:
-    name: Push rapida-golang:1.25.8-bookworm
+    name: Push rapida-golang:1.25.11-bookworm
     needs: changes
     if: needs.changes.outputs.golang-bookworm == 'true'
     runs-on: ubuntu-latest
@@ -108,13 +108,13 @@ jobs:
           file: ./docker/base/rapida-golang-bookworm.Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.8-bookworm
+          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.11-bookworm
           cache-from: type=gha,scope=rapida-golang-bookworm
           cache-to: type=gha,scope=rapida-golang-bookworm,mode=max
 
-  # ── rapidaai/rapida-golang:1.25.8-alpine ──────────────────────────────────
+  # ── rapidaai/rapida-golang:1.25.11-alpine ──────────────────────────────────
   push-golang-alpine:
-    name: Push rapida-golang:1.25.8-alpine
+    name: Push rapida-golang:1.25.11-alpine
     needs: changes
     if: needs.changes.outputs.golang-alpine == 'true'
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
           file: ./docker/base/rapida-golang-alpine.Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.8-alpine
+          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.11-alpine
           cache-from: type=gha,scope=rapida-golang-alpine
           cache-to: type=gha,scope=rapida-golang-alpine,mode=max
 
@@ -267,8 +267,8 @@ jobs:
             echo ""
             echo "| Image | Result |"
             echo "|-------|--------|"
-            echo "| \`rapidaai/rapida-golang:1.25.8-bookworm\` | ${{ needs.push-golang-bookworm.result }} |"
-            echo "| \`rapidaai/rapida-golang:1.25.8-alpine\`   | ${{ needs.push-golang-alpine.result }} |"
+            echo "| \`rapidaai/rapida-golang:1.25.11-bookworm\` | ${{ needs.push-golang-bookworm.result }} |"
+            echo "| \`rapidaai/rapida-golang:1.25.11-alpine\`   | ${{ needs.push-golang-alpine.result }} |"
             echo "| \`rapidaai/rapida-alpine:3.21\`            | ${{ needs.push-alpine.result }} |"
             echo "| \`rapidaai/rapida-debian:bookworm-slim\`   | ${{ needs.push-debian-slim.result }} |"
             echo "| \`rapidaai/rapida-node:22-alpine\`         | ${{ needs.push-node-alpine.result }} |"

--- a/.github/workflows/push-base-images.yml
+++ b/.github/workflows/push-base-images.yml
@@ -85,9 +85,9 @@ jobs:
 
   # ── Shared login step (reused via composite would be ideal, but keeping it inline) ──
 
-  # ── rapidaai/rapida-golang:1.25.10-bookworm (heavy — ONNX, RNNoise, Azure Speech SDK) ──
+  # ── rapidaai/rapida-golang:1.25.11-bookworm (heavy — ONNX, RNNoise, Azure Speech SDK) ──
   push-golang-bookworm:
-    name: Push rapida-golang:1.25.10-bookworm
+    name: Push rapida-golang:1.25.11-bookworm
     needs: changes
     if: needs.changes.outputs.golang-bookworm == 'true'
     runs-on: ubuntu-latest
@@ -108,13 +108,13 @@ jobs:
           file: ./docker/base/rapida-golang-bookworm.Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.10-bookworm
+          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.11-bookworm
           cache-from: type=gha,scope=rapida-golang-bookworm
           cache-to: type=gha,scope=rapida-golang-bookworm,mode=max
 
-  # ── rapidaai/rapida-golang:1.25.10-alpine ──────────────────────────────────
+  # ── rapidaai/rapida-golang:1.25.11-alpine ──────────────────────────────────
   push-golang-alpine:
-    name: Push rapida-golang:1.25.10-alpine
+    name: Push rapida-golang:1.25.11-alpine
     needs: changes
     if: needs.changes.outputs.golang-alpine == 'true'
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
           file: ./docker/base/rapida-golang-alpine.Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.10-alpine
+          tags: ${{ env.REGISTRY }}/rapida-golang:1.25.11-alpine
           cache-from: type=gha,scope=rapida-golang-alpine
           cache-to: type=gha,scope=rapida-golang-alpine,mode=max
 
@@ -267,8 +267,8 @@ jobs:
             echo ""
             echo "| Image | Result |"
             echo "|-------|--------|"
-            echo "| \`rapidaai/rapida-golang:1.25.10-bookworm\` | ${{ needs.push-golang-bookworm.result }} |"
-            echo "| \`rapidaai/rapida-golang:1.25.10-alpine\`   | ${{ needs.push-golang-alpine.result }} |"
+            echo "| \`rapidaai/rapida-golang:1.25.11-bookworm\` | ${{ needs.push-golang-bookworm.result }} |"
+            echo "| \`rapidaai/rapida-golang:1.25.11-alpine\`   | ${{ needs.push-golang-alpine.result }} |"
             echo "| \`rapidaai/rapida-alpine:3.21\`            | ${{ needs.push-alpine.result }} |"
             echo "| \`rapidaai/rapida-debian:bookworm-slim\`   | ${{ needs.push-debian-slim.result }} |"
             echo "| \`rapidaai/rapida-node:22-alpine\`         | ${{ needs.push-node-alpine.result }} |"

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ help:
 	@echo "  make build-all-safe            - Build all services sequentially (low-memory)"
 	@echo "  make build-all-fast            - Build all services in parallel"
 	@echo "  make push-base-images          - Build + push all rapida-* base images (run when versions change)"
-	@echo "  make push-rapida-golang-bookworm - Rebuild + push rapidaai/rapida-golang:1.25.10-bookworm"
-	@echo "  make push-rapida-golang-alpine   - Rebuild + push rapidaai/rapida-golang:1.25.10-alpine"
+	@echo "  make push-rapida-golang-bookworm - Rebuild + push rapidaai/rapida-golang:1.25.11-bookworm"
+	@echo "  make push-rapida-golang-alpine   - Rebuild + push rapidaai/rapida-golang:1.25.11-alpine"
 	@echo "  make push-rapida-alpine          - Rebuild + push rapidaai/rapida-alpine:3.21"
 	@echo "  make push-rapida-debian-slim     - Rebuild + push rapidaai/rapida-debian:bookworm-slim"
 	@echo "  make push-rapida-node-alpine     - Rebuild + push rapidaai/rapida-node:22-alpine"
@@ -390,16 +390,16 @@ down: down-all
 # ============================================================================
 
 push-rapida-golang-bookworm:
-	@echo "Building rapidaai/rapida-golang:1.25.10-bookworm..."
-	DOCKER_BUILDKIT=1 docker build -f docker/base/rapida-golang-bookworm.Dockerfile -t rapidaai/rapida-golang:1.25.10-bookworm .
-	docker push rapidaai/rapida-golang:1.25.10-bookworm
-	@echo "✓ rapidaai/rapida-golang:1.25.10-bookworm pushed"
+	@echo "Building rapidaai/rapida-golang:1.25.11-bookworm..."
+	DOCKER_BUILDKIT=1 docker build -f docker/base/rapida-golang-bookworm.Dockerfile -t rapidaai/rapida-golang:1.25.11-bookworm .
+	docker push rapidaai/rapida-golang:1.25.11-bookworm
+	@echo "✓ rapidaai/rapida-golang:1.25.11-bookworm pushed"
 
 push-rapida-golang-alpine:
-	@echo "Building rapidaai/rapida-golang:1.25.10-alpine..."
-	DOCKER_BUILDKIT=1 docker build -f docker/base/rapida-golang-alpine.Dockerfile -t rapidaai/rapida-golang:1.25.10-alpine .
-	docker push rapidaai/rapida-golang:1.25.10-alpine
-	@echo "✓ rapidaai/rapida-golang:1.25.10-alpine pushed"
+	@echo "Building rapidaai/rapida-golang:1.25.11-alpine..."
+	DOCKER_BUILDKIT=1 docker build -f docker/base/rapida-golang-alpine.Dockerfile -t rapidaai/rapida-golang:1.25.11-alpine .
+	docker push rapidaai/rapida-golang:1.25.11-alpine
+	@echo "✓ rapidaai/rapida-golang:1.25.11-alpine pushed"
 
 push-rapida-alpine:
 	@echo "Building rapidaai/rapida-alpine:3.21..."

--- a/docker/assistant-api/Dockerfile
+++ b/docker/assistant-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # ---- Build stage ----
-FROM rapidaai/rapida-golang:1.25.10-bookworm AS builder
+FROM rapidaai/rapida-golang:1.25.11-bookworm AS builder
 
 WORKDIR /app
 

--- a/docker/base/rapida-golang-alpine.Dockerfile
+++ b/docker/base/rapida-golang-alpine.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-# rapidaai/rapida-golang:1.25.10-alpine
-# Extends golang:1.25.10-alpine — pinned base for all Go service builder stages.
-# Published to: docker.io/rapidaai/rapida-golang:1.25.10-alpine
+# rapidaai/rapida-golang:1.25.11-alpine
+# Extends golang:1.25.11-alpine — pinned base for all Go service builder stages.
+# Published to: docker.io/rapidaai/rapida-golang:1.25.11-alpine
 # Rebuild + push only when Go version changes: make push-rapida-golang-alpine
-FROM golang:1.25.10-alpine
+FROM golang:1.25.11-alpine

--- a/docker/base/rapida-golang-bookworm.Dockerfile
+++ b/docker/base/rapida-golang-bookworm.Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
-# rapidaai/rapida-golang:1.25.10-bookworm
-# Extends golang:1.25.10-bookworm with C libraries required by assistant-api.
-# Published to: docker.io/rapidaai/rapida-golang:1.25.10-bookworm
+# rapidaai/rapida-golang:1.25.11-bookworm
+# Extends golang:1.25.11-bookworm with C libraries required by assistant-api.
+# Published to: docker.io/rapidaai/rapida-golang:1.25.11-bookworm
 # Rebuild + push only when SDK versions change: make push-rapida-golang-bookworm
-FROM golang:1.25.10-bookworm AS base
+FROM golang:1.25.11-bookworm AS base
 
 WORKDIR /app
 

--- a/docker/endpoint-api/Dockerfile
+++ b/docker/endpoint-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM rapidaai/rapida-golang:1.25.10-alpine AS builder
+FROM rapidaai/rapida-golang:1.25.11-alpine AS builder
 
 WORKDIR /app
 

--- a/docker/integration-api/Dockerfile
+++ b/docker/integration-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM rapidaai/rapida-golang:1.25.10-alpine AS builder
+FROM rapidaai/rapida-golang:1.25.11-alpine AS builder
 
 WORKDIR /app
 

--- a/docker/web-api/Dockerfile
+++ b/docker/web-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM rapidaai/rapida-golang:1.25.10-alpine AS builder
+FROM rapidaai/rapida-golang:1.25.11-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rapidaai
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/vonage/vonage-go-sdk => github.com/iamprashant/vonage-go-sdk v0.0.0-20251001095859-c473c1750cbd
 


### PR DESCRIPTION
## Description
  - Bump project Go version to 1.25.11
  - Align Docker base images, service Dockerfiles, Makefile targets, and base-image workflows to Go 1.25.11
  - Leave SDK modules unchanged

  ## Why
  Fixes Go standard library vulnerability findings:
  - GO-2026-5039 in `net/textproto`
  - GO-2026-5037 in `crypto/x509`

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain and Docker base images from version 1.25.10 to 1.25.11 across all application containers and build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->