### PR TITLE
fix: persist recordings before finalizing session

### DIFF
--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	adapter_lifecycle "github.com/rapidaai/api/assistant-api/internal/adapters/lifecycle"
@@ -2584,25 +2585,30 @@ func (h requestorDispatchHandler) HandleFinalizeAuthentication(ctx context.Conte
 	h.r.OnPacket(ctx, internal_type.FinalizeSessionRuntimePacket{ContextID: p.ContextID})
 }
 func (h requestorDispatchHandler) HandleFinalizeSessionRuntime(ctx context.Context, p internal_type.FinalizeSessionRuntimePacket) {
-	if h.r.outputNormalizer != nil {
+	var closeGroup sync.WaitGroup
+	if outputNormalizer := h.r.outputNormalizer; outputNormalizer != nil {
+		closeGroup.Add(1)
 		utils.Go(ctx, func() {
-			h.r.outputNormalizer.Close(ctx)
+			defer closeGroup.Done()
+			outputNormalizer.Close(ctx)
 			h.r.outputNormalizer = nil
 		})
 	}
-
 	//
-	if h.r.inputNormalizer != nil {
+	if inputNormalizer := h.r.inputNormalizer; inputNormalizer != nil {
+		closeGroup.Add(1)
 		utils.Go(ctx, func() {
-			h.r.inputNormalizer.Close(ctx)
+			defer closeGroup.Done()
+			inputNormalizer.Close(ctx)
 			h.r.inputNormalizer = nil
 		})
 	}
-
 	//
-	if h.r.conversationRecordingExecutor != nil {
+	if conversationRecordingExecutor := h.r.conversationRecordingExecutor; conversationRecordingExecutor != nil {
+		closeGroup.Add(1)
 		utils.Go(ctx, func() {
-			if err := h.r.conversationRecordingExecutor.Close(ctx); err != nil {
+			defer closeGroup.Done()
+			if err := conversationRecordingExecutor.Close(ctx); err != nil {
 				h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
 					ContextID: p.ContextID,
 					Scope:     internal_type.ObservabilityRecordScopeConversation,
@@ -2619,11 +2625,11 @@ func (h requestorDispatchHandler) HandleFinalizeSessionRuntime(ctx context.Conte
 						},
 					},
 				})
-				return
 			}
+			h.r.conversationRecordingExecutor = nil
 		})
 	}
-	// analysis -> webhooks -> finalize conversation
+	closeGroup.Wait()
 	h.r.OnPacket(ctx,
 		internal_type.ExecuteAnalysisPacket{
 			ContextID:      p.ContextID,

--- a/api/assistant-api/internal/adapters/internal/requestor.go
+++ b/api/assistant-api/internal/adapters/internal/requestor.go
@@ -50,6 +50,7 @@ const (
 	LLMGenerating      = adapter_lifecycle.LLMGenerating
 	LLMGenerated       = adapter_lifecycle.LLMGenerated
 	dbWriteTimeout     = 5 * time.Second
+	recordingTimeout   = 3*storages.FileWriteTimeout + dbWriteTimeout
 	connectDeadline    = 30 * time.Second
 	disconnectDeadline = 30 * time.Second
 )

--- a/api/assistant-api/internal/adapters/internal/state.go
+++ b/api/assistant-api/internal/adapters/internal/state.go
@@ -284,6 +284,7 @@ func (deb *genericRequestor) onAddMessage(_ context.Context, msg internal_type.M
 		_, err := deb.conversationService.CreateConversationMessage(dbCtx, deb.Auth(), deb.GetSource(), deb.Assistant().Id, deb.Assistant().AssistantProviderId, deb.Conversation().Id,
 			fmt.Sprintf("%s-%s", msg.Role(), msg.ContextId()), msg.Role(), msg.Content())
 		if err != nil {
+			deb.logger.Debugf("error while persisting conversation recording %+v", err)
 		}
 	})
 	return nil
@@ -291,29 +292,11 @@ func (deb *genericRequestor) onAddMessage(_ context.Context, msg internal_type.M
 
 func (gr *genericRequestor) CreateConversationRecording(_ context.Context, user, assistant, conversation []byte) error {
 	utils.Go(context.Background(), func() {
-		dbCtx, cancel := context.WithTimeout(context.Background(), dbWriteTimeout)
+		dbCtx, cancel := context.WithTimeout(context.Background(), recordingTimeout)
 		defer cancel()
-		if _, err := gr.conversationService.CreateConversationRecording(dbCtx, gr.auth, gr.assistant.Id, gr.assistantConversation.Id, user, assistant, conversation); err != nil {
-			gr.OnPacket(context.Background(), internal_type.ObservabilityLogRecordPacket{
-				ContextID: gr.GetID(),
-				Scope:     internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.RecordLog{
-					Level:   observability.LevelError,
-					Message: "conversation recording persistence failed",
-					Attributes: observability.Attributes{
-						"component":             observability.ComponentRecording.String(),
-						"operation":             "persist_recording",
-						"context_id":            gr.GetID(),
-						"assistant_id":          fmt.Sprintf("%d", gr.assistant.Id),
-						"conversation_id":       fmt.Sprintf("%d", gr.assistantConversation.Id),
-						"user_audio_bytes":      fmt.Sprintf("%d", len(user)),
-						"assistant_audio_bytes": fmt.Sprintf("%d", len(assistant)),
-						"mixed_audio_bytes":     fmt.Sprintf("%d", len(conversation)),
-						"error":                 err.Error(),
-						"error_type":            fmt.Sprintf("%T", err),
-					},
-				},
-			})
+		_, err := gr.conversationService.CreateConversationRecording(dbCtx, gr.auth, gr.assistant.Id, gr.assistantConversation.Id, user, assistant, conversation)
+		if err != nil {
+			gr.logger.Debugf("error while persisting conversation recording %+v", err)
 		}
 	})
 	return nil

--- a/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
@@ -584,14 +584,13 @@ func (endOfSpeech *livekitEndOfSpeech) Close(ctx context.Context) error {
 	endOfSpeech.mu.Unlock()
 
 	if endOfSpeech.onPacket != nil {
-		packets := []internal_type.Packet{}
 		if !eosStartedAt.IsZero() {
-			packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
+			endOfSpeech.onPacket(ctx, internal_type.ObservabilityUsageRecordPacket{
 				Scope:  internal_type.ObservabilityRecordScopeConversation,
 				Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
 			})
 		}
-		packets = append(packets, internal_type.ObservabilityEventRecordPacket{
+		endOfSpeech.onPacket(ctx, internal_type.ObservabilityEventRecordPacket{
 			Scope: internal_type.ObservabilityRecordScopeConversation,
 			Record: observability.RecordEvent{
 				Component: observability.ComponentEOS,
@@ -602,10 +601,9 @@ func (endOfSpeech *livekitEndOfSpeech) Close(ctx context.Context) error {
 				OccurredAt: time.Now(),
 			},
 		})
-		_ = endOfSpeech.onPacket(ctx, packets...)
 	}
-	close(endOfSpeech.stopCh)
 
+	close(endOfSpeech.stopCh)
 	endOfSpeech.predictorMu.Lock()
 	if predictor, ok := endOfSpeech.predictor.(interface{ Destroy() }); ok {
 		predictor.Destroy()

--- a/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
@@ -512,12 +512,23 @@ func (conversationService *assistantConversationService) CreateConversationRecor
 	assistantKey := conversationService.ObjectKey(s3Prefix, assistantConversationId, fmt.Sprintf("assistant-%d.wav", recordingId))
 	conversationKey := conversationService.ObjectKey(s3Prefix, assistantConversationId, fmt.Sprintf("conversation-%d.wav", recordingId))
 
-	// we know the file path so no need to wait for it
-	utils.Go(context.Background(), func() {
-		conversationService.storage.Store(ctx, userKey, user)
-		conversationService.storage.Store(ctx, assistantKey, assistant)
-		conversationService.storage.Store(ctx, conversationKey, conversation)
-	})
+	recordings := []struct {
+		label string
+		key   string
+		data  []byte
+	}{
+		{label: "user", key: userKey, data: user},
+		{label: "assistant", key: assistantKey, data: assistant},
+		{label: "conversation", key: conversationKey, data: conversation},
+	}
+	for _, recording := range recordings {
+		result := conversationService.storage.Store(ctx, recording.key, recording.data)
+		if result.Error != nil {
+			conversationService.logger.Benchmark("conversationService.CreateConversationRecording", time.Since(start))
+			conversationService.logger.Errorf("error while storing %s conversation recording %s: %v", recording.label, recording.key, result.Error)
+			return nil, fmt.Errorf("store %s recording: %w", recording.label, result.Error)
+		}
+	}
 
 	conversationRecording := &internal_conversation_entity.AssistantConversationRecording{
 		Audited: gorm_models.Audited{


### PR DESCRIPTION
## Description

  Fixes a race where call recordings could be missed when a conversation finalized
  quickly, especially when no analysis or webhook executors were configured.

  Previously, recorder shutdown could run async while finalization continued. If
  analysis/webhook were absent, the session could reach cancellation before the
  recording completion path had time to persist the WAV files.

  ## Changes

  - Wait for runtime shutdown tasks in `HandleFinalizeSessionRuntime` before enqueueing
  analysis/webhook/finalize packets.
  - Ensure recorder close completes before final conversation finalization proceeds.
  - Use a longer recording persistence timeout based on storage write timeout.
  - Store recording WAV files before creating the conversation recording DB row.
  - Preserve logging for recording persistence failures.

  ## Testing

  ```sh
  go test ./api/assistant-api/internal/audio/recorder/...
  env GOCACHE=/private/tmp/voice-ai-gocache go test ./api/assistant-api/internal/
  adapters/internal ./api/assistant-api/internal/adapters/router
  env GOCACHE=/private/tmp/voice-ai-gocache go test ./api/assistant-api/internal/
  services/assistant

