### PR TITLE
fix: bound webhook timeout and stringify webhook ids

### DIFF
--- a/api/assistant-api/internal/observability/collectors/webhook/collector.go
+++ b/api/assistant-api/internal/observability/collectors/webhook/collector.go
@@ -37,6 +37,9 @@ const (
 	WebhookOptionRetryStatusCodesKey = "retry_status_codes"
 	WebhookOptionMaxRetryCountKey    = "max_retry_count"
 	WebhookOptionTimeoutSecondsKey   = "timeout_seconds"
+
+	defaultWebhookTimeoutSeconds uint32 = 60
+	minWebhookTimeoutSeconds     uint32 = 1
 )
 
 type Config struct {
@@ -59,7 +62,7 @@ type Collector struct {
 }
 
 func New(_ context.Context, config Config) observability.Collector {
-	if config.Auth == nil || config.AssistantConfigurationService == nil || config.HTTPLogService == nil {
+	if !validator.NonNil(config.Auth) || !validator.NonNil(config.AssistantConfigurationService) || !validator.NonNil(config.HTTPLogService) {
 		return observability.NoopCollector{}
 	}
 	return &Collector{
@@ -184,48 +187,41 @@ func (c *Collector) send(ctx context.Context, scope observability.Scope, webhook
 	}
 
 	webhookTimeoutSeconds, err := webhookOptions.GetUint32(WebhookOptionTimeoutSecondsKey)
-	if err != nil {
-		webhookTimeoutSeconds = 0
+	if err != nil || !validator.Between(int(webhookTimeoutSeconds), int(minWebhookTimeoutSeconds), int(defaultWebhookTimeoutSeconds)) {
+		webhookTimeoutSeconds = defaultWebhookTimeoutSeconds
 	}
 	webhookRetryStatusCodes := webhookOptions.GetStringSlice(WebhookOptionRetryStatusCodesKey)
 
 	webhookHTTPClient := rest.NewRestClientWithConfig(webhookHTTPURL, webhookHTTPHeaders, webhookTimeoutSeconds)
-	webhookAssistantID := uint64(0)
 	var webhookConversationID *uint64
 	switch typedScope := scope.(type) {
 	case observability.MessageScope:
-		webhookAssistantID = typedScope.AssistantScopeID()
 		scopeConversationID := typedScope.ConversationScopeID()
 		webhookConversationID = &scopeConversationID
 		if !validator.NotBlank(webhookContextID) {
 			webhookContextID = typedScope.ContextID()
 		}
 	case observability.ConversationScope:
-		webhookAssistantID = typedScope.AssistantScopeID()
 		scopeConversationID := typedScope.ConversationScopeID()
 		webhookConversationID = &scopeConversationID
 		if !validator.NotBlank(webhookContextID) {
 			webhookContextID = typedScope.ContextID()
 		}
 	case observability.AssistantScope:
-		webhookAssistantID = typedScope.AssistantScopeID()
 		if !validator.NotBlank(webhookContextID) {
 			webhookContextID = typedScope.ContextID()
 		}
 	}
-	if webhookAssistantID == 0 {
-		webhookAssistantID = c.assistantID
-	}
 	webhookRequestBody := map[string]interface{}{
 		"assistant": map[string]interface{}{
-			"id": webhookAssistantID,
+			"id": fmt.Sprintf("%d", c.assistantID),
 		},
 		"data":  webhookPayload,
 		"event": webhookEventName,
 	}
 	if webhookConversationID != nil && *webhookConversationID != 0 {
 		webhookRequestBody["conversation"] = map[string]interface{}{
-			"id": *webhookConversationID,
+			"id": fmt.Sprintf("%d", *webhookConversationID),
 		}
 	}
 
@@ -291,7 +287,7 @@ func (c *Collector) send(ctx context.Context, scope observability.Scope, webhook
 			webhookConfiguration.Id,
 			webhookEventName,
 			webhookContextID,
-			webhookAssistantID,
+			c.assistantID,
 			webhookConversationID,
 			webhookHTTPURL,
 			webhookHTTPMethod,

--- a/api/assistant-api/internal/observability/collectors/webhook/collector_test.go
+++ b/api/assistant-api/internal/observability/collectors/webhook/collector_test.go
@@ -75,11 +75,11 @@ func TestCollector_SendsWebhookEventPayload(t *testing.T) {
 		t.Fatalf("CollectWebhook returned error: %v", err)
 	}
 	assistantPayload, ok := got["assistant"].(map[string]interface{})
-	if !ok || assistantPayload["id"] != float64(10) {
+	if !ok || assistantPayload["id"] != "10" {
 		t.Fatalf("unexpected assistant payload: %+v", got)
 	}
 	conversationPayload, ok := got["conversation"].(map[string]interface{})
-	if !ok || conversationPayload["id"] != float64(20) {
+	if !ok || conversationPayload["id"] != "20" {
 		t.Fatalf("unexpected conversation payload: %+v", got)
 	}
 	dataPayload, ok := got["data"].(map[string]interface{})
@@ -108,6 +108,13 @@ func TestCollector_SendsWebhookEventPayload(t *testing.T) {
 	if requestLogCall.status != type_enums.RECORD_COMPLETE || requestLogCall.responseStatus != http.StatusNoContent {
 		t.Fatalf("unexpected request log status: %+v", requestLogCall)
 	}
+	var requestSnapshot map[string]interface{}
+	if err := json.Unmarshal(requestLogCall.requestPayload, &requestSnapshot); err != nil {
+		t.Fatalf("failed to decode request snapshot: %v", err)
+	}
+	if requestSnapshot["timeout_ms"] != float64(defaultWebhookTimeoutSeconds*1000) {
+		t.Fatalf("timeout_ms = %v, want %d", requestSnapshot["timeout_ms"], defaultWebhookTimeoutSeconds*1000)
+	}
 }
 
 func TestNew_DoesNotLoadWebhooks(t *testing.T) {
@@ -135,6 +142,53 @@ func TestNew_DoesNotLoadWebhooks(t *testing.T) {
 	}
 	if configurationService.getAllCalls != 0 {
 		t.Fatalf("New should not load webhooks, got %d calls", configurationService.getAllCalls)
+	}
+}
+
+func TestCollector_DefaultsTooLargeTimeoutSeconds(t *testing.T) {
+	httpLogService := &recordingHTTPLogService{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	organizationID := uint64(30)
+	projectID := uint64(40)
+	auth := &types.ServiceScope{
+		OrganizationId: &organizationID,
+		ProjectId:      &projectID,
+	}
+	configurationService := &recordingAssistantConfigurationService{
+		configurations: []*internal_assistant_entity.AssistantConfiguration{
+			testWebhook(1, []string{observability.CallRinging.String()}, map[string]interface{}{
+				WebhookOptionHTTPURLKey:        server.URL,
+				WebhookOptionTimeoutSecondsKey: uint32(defaultWebhookTimeoutSeconds + 1),
+			}),
+		},
+	}
+	collector := New(context.Background(), Config{
+		Logger:                        testLogger(t),
+		Auth:                          auth,
+		AssistantID:                   10,
+		AssistantConfigurationService: configurationService,
+		HTTPLogService:                httpLogService,
+	})
+
+	err := collector.Collect(context.Background(), observability.AssistantScope{AssistantID: 10}, observability.Context{Auth: auth}, observability.RecordWebhook{
+		Event: observability.CallRinging,
+	})
+	if err != nil {
+		t.Fatalf("CollectWebhook returned error: %v", err)
+	}
+	if len(httpLogService.calls) != 1 {
+		t.Fatalf("expected one request log call, got %d", len(httpLogService.calls))
+	}
+	var requestSnapshot map[string]interface{}
+	if err := json.Unmarshal(httpLogService.calls[0].requestPayload, &requestSnapshot); err != nil {
+		t.Fatalf("failed to decode request snapshot: %v", err)
+	}
+	if requestSnapshot["timeout_ms"] != float64(defaultWebhookTimeoutSeconds*1000) {
+		t.Fatalf("timeout_ms = %v, want %d", requestSnapshot["timeout_ms"], defaultWebhookTimeoutSeconds*1000)
 	}
 }
 
@@ -286,6 +340,7 @@ type webhookHTTPLogCall struct {
 	conversationID *uint64
 	responseStatus int64
 	status         type_enums.RecordState
+	requestPayload []byte
 }
 
 type recordingHTTPLogService struct {
@@ -329,7 +384,7 @@ func (s *recordingHTTPLogService) CreateLog(
 	_ uint32,
 	status type_enums.RecordState,
 	_ *string,
-	_ []byte,
+	requestPayload []byte,
 	_ []byte,
 ) (*internal_assistant_entity.AssistantHTTPLog, error) {
 	s.calls = append(s.calls, webhookHTTPLogCall{
@@ -341,6 +396,7 @@ func (s *recordingHTTPLogService) CreateLog(
 		conversationID: conversationID,
 		responseStatus: responseStatus,
 		status:         status,
+		requestPayload: requestPayload,
 	})
 	return &internal_assistant_entity.AssistantHTTPLog{}, nil
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook requests now use a consistent assistant ID and avoid mixing in scope-derived values.
  * Conversation and context IDs are applied more predictably based on the event type and available context.
  * Invalid or overly large webhook timeout values now safely fall back to a supported default.
  * Webhook logging now records the request snapshot with the expected timeout value for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->