### PR TITLE
feat(sip): separate registration identity from caller ID

### DIFF
--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -67,6 +67,14 @@ type Config struct {
 	Realm    string `json:"sip_realm" mapstructure:"sip_realm"`
 	Domain   string `json:"sip_domain,omitempty" mapstructure:"sip_domain"`
 
+	// AuthUsername is the Digest auth identity; falls back to Username.
+	AuthUsername string `json:"sip_auth_username,omitempty" mapstructure:"sip_auth_username"`
+	// AORUser is the REGISTER/Contact identity; falls back to Username.
+	AORUser string `json:"sip_aor_user,omitempty" mapstructure:"sip_aor_user"`
+	// OutboundProxy overrides the outbound request target.
+	OutboundProxy string `json:"sip_outbound_proxy,omitempty" mapstructure:"sip_outbound_proxy"`
+
+	// CallerID is the outbound From user only — never used for REGISTER.
 	CallerID      string            `json:"sip_caller_id,omitempty" mapstructure:"sip_caller_id"`
 	CustomHeaders map[string]string `json:"sip_headers,omitempty" mapstructure:"sip_headers"`
 
@@ -158,6 +166,9 @@ func (c *Config) toCore() *internal_core.Config {
 		Password:               c.Password,
 		Realm:                  c.Realm,
 		Domain:                 c.Domain,
+		AuthUsername:           c.AuthUsername,
+		AORUser:                c.AORUser,
+		OutboundProxy:          c.OutboundProxy,
 		CallerID:               c.CallerID,
 		CustomHeaders:          c.CustomHeaders,
 		Port:                   c.Port,
@@ -186,6 +197,9 @@ func configFromCore(c *internal_core.Config) Config {
 		Password:               c.Password,
 		Realm:                  c.Realm,
 		Domain:                 c.Domain,
+		AuthUsername:           c.AuthUsername,
+		AORUser:                c.AORUser,
+		OutboundProxy:          c.OutboundProxy,
 		CallerID:               c.CallerID,
 		CustomHeaders:          c.CustomHeaders,
 		Port:                   c.Port,

--- a/api/assistant-api/sip/internal/core/outbound_config.go
+++ b/api/assistant-api/sip/internal/core/outbound_config.go
@@ -18,15 +18,17 @@ func (c *Config) ToOutboundConfig() OutboundConfig {
 	}
 
 	return OutboundConfig{
-		Mode:            OutboundModeTrunkTermination,
-		Address:         c.Server,
+		Mode: OutboundModeTrunkTermination,
+		// Route via the outbound proxy when one is configured; otherwise the
+		// registrar host doubles as the termination target.
+		Address:         c.GetOutboundTarget(),
 		Port:            c.Port,
 		Transport:       c.GetTransport(),
 		Domain:          c.Domain,
 		RingingTimeout:  c.InviteTimeout,
 		MaxCallDuration: c.SessionTimeout,
 		Auth: SIPAuthConfig{
-			Username: c.Username,
+			Username: c.GetAuthUsername(),
 			Password: c.Password,
 			Realm:    c.Realm,
 		},

--- a/api/assistant-api/sip/internal/core/register.go
+++ b/api/assistant-api/sip/internal/core/register.go
@@ -281,9 +281,14 @@ func (rc *RegistrationClient) sendRegisterWithMinExpires(
 
 	// To/From: the AOR (Address of Record) being registered.
 	// Per RFC 3261 §10.2, To and From are identical for REGISTER.
+	//
+	// The AOR user is the registration identity the registrar knows (AORUser, or
+	// the SIP username when unset) — never the DID and never the caller ID.
+	// Registrars that key accounts by username reject a DID-based AOR with 404.
+	aorUser := registrationAORUser(cfg, reg)
 	aor := sip.Uri{
 		Scheme: scheme,
-		User:   normalizeUser(reg.DID),
+		User:   aorUser,
 		Host:   domain,
 	}
 
@@ -305,7 +310,7 @@ func (rc *RegistrationClient) sendRegisterWithMinExpires(
 	contactHdr := &sip.ContactHeader{
 		Address: sip.Uri{
 			Scheme: scheme,
-			User:   normalizeUser(reg.DID),
+			User:   aorUser,
 			Host:   externalIP,
 			Port:   rc.listenConfig.Port,
 		},
@@ -347,7 +352,7 @@ func (rc *RegistrationClient) sendRegisterWithMinExpires(
 			"status", resp.StatusCode)
 
 		resp, err = rc.client.DoDigestAuth(reqCtx, req, resp, sipgo.DigestAuth{
-			Username: cfg.Username,
+			Username: cfg.GetAuthUsername(),
 			Password: cfg.Password,
 		})
 		if err != nil {
@@ -476,8 +481,30 @@ func contextWithTimeout(parent context.Context, timeout time.Duration) (context.
 
 // normalizeUser strips the "+" prefix from a DID for the SIP URI user part.
 // Some registrars reject "+" in the userinfo field.
+// normalizeUser strips the leading "+" from an E.164 DID so it can be used as a
+// SIP URI user part. Only apply this to phone numbers — alphanumeric SIP account
+// names must be sent verbatim.
 func normalizeUser(did string) string {
 	return strings.TrimPrefix(did, "+")
+}
+
+// registrationAORUser resolves the user part for the REGISTER AOR and Contact.
+//
+// Precedence:
+//  1. Config.AORUser  — explicit registration identity
+//  2. Config.Username — the SIP account name (the common case)
+//  3. Registration.DID — legacy fallback for credentials saved before the AOR and
+//     DID fields were separated, so existing deployments keep registering.
+//
+// Only the DID path is number-normalized; an account name is never rewritten.
+func registrationAORUser(cfg *Config, reg *Registration) string {
+	if aorUser := cfg.GetAORUser(); aorUser != "" {
+		return aorUser
+	}
+	if validator.NonNil(reg) {
+		return normalizeUser(strings.TrimSpace(reg.DID))
+	}
+	return ""
 }
 
 func (rc *RegistrationClient) markRenewalFailed(

--- a/api/assistant-api/sip/internal/core/sip_identity_test.go
+++ b/api/assistant-api/sip/internal/core/sip_identity_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package core
+
+import "testing"
+
+// The registration identity (AOR), the Digest auth identity, and the outbound
+// caller ID are three different things. Mixing them is what made a
+// username-keyed registrar answer REGISTER with 404, so each resolver is
+// pinned here.
+
+func TestGetAuthUsernameFallsBackToUsername(t *testing.T) {
+	tests := []struct {
+		name         string
+		username     string
+		authUsername string
+		want         string
+	}{
+		{name: "falls back to sip username", username: "sip7f2a91", want: "sip7f2a91"},
+		{name: "prefers explicit auth username", username: "sip7f2a91", authUsername: "auth-user", want: "auth-user"},
+		{name: "ignores blank auth username", username: "sip7f2a91", authUsername: "   ", want: "sip7f2a91"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Username: tt.username, AuthUsername: tt.authUsername}
+			if got := cfg.GetAuthUsername(); got != tt.want {
+				t.Fatalf("GetAuthUsername() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAORUserFallsBackToUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		aorUser  string
+		want     string
+	}{
+		{name: "falls back to sip username", username: "sip7f2a91", want: "sip7f2a91"},
+		{name: "prefers explicit aor user", username: "sip7f2a91", aorUser: "1044", want: "1044"},
+		{name: "ignores blank aor user", username: "sip7f2a91", aorUser: "  ", want: "sip7f2a91"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Username: tt.username, AORUser: tt.aorUser}
+			if got := cfg.GetAORUser(); got != tt.want {
+				t.Fatalf("GetAORUser() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A caller ID is outbound presentation only. It must never leak into the AOR,
+// otherwise REGISTER goes out as the phone number instead of the account.
+func TestRegistrationAORUserIgnoresCallerID(t *testing.T) {
+	cfg := &Config{Username: "sip7f2a91", CallerID: "+15551234567"}
+	reg := &Registration{DID: "+15551234567"}
+
+	if got := registrationAORUser(cfg, reg); got != "sip7f2a91" {
+		t.Fatalf("registrationAORUser() = %q, want the SIP username", got)
+	}
+}
+
+// Credentials saved before the split have no username; those deployments must
+// keep registering off the DID rather than breaking on upgrade.
+func TestRegistrationAORUserLegacyDIDFallback(t *testing.T) {
+	cfg := &Config{}
+	reg := &Registration{DID: "+15551234567"}
+
+	if got := registrationAORUser(cfg, reg); got != "15551234567" {
+		t.Fatalf("registrationAORUser() = %q, want the normalized DID", got)
+	}
+}
+
+// Alphanumeric account names are not phone numbers and must survive verbatim.
+func TestRegistrationAORUserDoesNotNormalizeAlphanumeric(t *testing.T) {
+	cfg := &Config{Username: "+abc-user"}
+
+	if got := registrationAORUser(cfg, &Registration{DID: "+15551234567"}); got != "+abc-user" {
+		t.Fatalf("registrationAORUser() = %q, want the username unchanged", got)
+	}
+}
+
+func TestGetOutboundTargetPrefersProxy(t *testing.T) {
+	cfg := &Config{Server: "at1.provider.com"}
+	if got := cfg.GetOutboundTarget(); got != "at1.provider.com" {
+		t.Fatalf("GetOutboundTarget() = %q, want the server", got)
+	}
+
+	cfg.OutboundProxy = "sbc.provider.com"
+	if got := cfg.GetOutboundTarget(); got != "sbc.provider.com" {
+		t.Fatalf("GetOutboundTarget() = %q, want the outbound proxy", got)
+	}
+}
+
+// Outbound auth uses the Digest identity, and routing honours the proxy.
+func TestToOutboundConfigUsesAuthIdentityAndProxy(t *testing.T) {
+	cfg := &Config{
+		Server:        "at1.provider.com",
+		Username:      "sip7f2a91",
+		AuthUsername:  "auth-user",
+		OutboundProxy: "sbc.provider.com",
+		Port:          5060,
+		Transport:     TransportUDP,
+	}
+
+	outbound := cfg.ToOutboundConfig()
+	if outbound.Auth.Username != "auth-user" {
+		t.Fatalf("outbound auth username = %q, want the Digest identity", outbound.Auth.Username)
+	}
+	if outbound.Address != "sbc.provider.com" {
+		t.Fatalf("outbound address = %q, want the outbound proxy", outbound.Address)
+	}
+}

--- a/api/assistant-api/sip/internal/core/types.go
+++ b/api/assistant-api/sip/internal/core/types.go
@@ -89,7 +89,20 @@ type Config struct {
 	Realm    string `json:"sip_realm" mapstructure:"sip_realm"`
 	Domain   string `json:"sip_domain,omitempty" mapstructure:"sip_domain"`
 
-	// CallerID overrides the From header user in outbound calls.
+	// AuthUsername is the Digest authentication username. Providers that issue a
+	// separate auth identity set this; otherwise Username is used.
+	AuthUsername string `json:"sip_auth_username,omitempty" mapstructure:"sip_auth_username"`
+
+	// AORUser is the Address-of-Record user placed in REGISTER To/From and in the
+	// Contact header. This is the registration identity the registrar knows — it is
+	// NOT the DID and NOT the caller ID. Falls back to Username when unset.
+	AORUser string `json:"sip_aor_user,omitempty" mapstructure:"sip_aor_user"`
+
+	// OutboundProxy routes outbound requests through an SBC/proxy instead of Server.
+	OutboundProxy string `json:"sip_outbound_proxy,omitempty" mapstructure:"sip_outbound_proxy"`
+
+	// CallerID overrides the From header user in outbound calls. Outbound only —
+	// it must never be used to build a REGISTER.
 	CallerID string `json:"sip_caller_id,omitempty" mapstructure:"sip_caller_id"`
 
 	// CustomHeaders are added to outbound INVITE requests.
@@ -115,6 +128,43 @@ type Config struct {
 // Validate validates the shared SIP network configuration.
 func (c *Config) Validate() error {
 	return c.ValidateRTP()
+}
+
+// GetAuthUsername returns the Digest authentication username, falling back to
+// the SIP username when the provider does not issue a separate auth identity.
+func (c *Config) GetAuthUsername() string {
+	if c == nil {
+		return ""
+	}
+	if authUsername := strings.TrimSpace(c.AuthUsername); authUsername != "" {
+		return authUsername
+	}
+	return strings.TrimSpace(c.Username)
+}
+
+// GetAORUser returns the Address-of-Record user used for REGISTER To/From and
+// Contact, falling back to the SIP username. Callers must not substitute a DID
+// or caller ID here — those identify the phone number, not the registration.
+func (c *Config) GetAORUser() string {
+	if c == nil {
+		return ""
+	}
+	if aorUser := strings.TrimSpace(c.AORUser); aorUser != "" {
+		return aorUser
+	}
+	return strings.TrimSpace(c.Username)
+}
+
+// GetOutboundTarget returns the host outbound requests are sent to: the outbound
+// proxy when configured, otherwise the registrar itself.
+func (c *Config) GetOutboundTarget() string {
+	if c == nil {
+		return ""
+	}
+	if proxy := strings.TrimSpace(c.OutboundProxy); proxy != "" {
+		return proxy
+	}
+	return strings.TrimSpace(c.Server)
 }
 
 // ApplyOperationalDefaults fills unset platform-owned SIP runtime settings.
@@ -524,6 +574,22 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	if domain, ok := stringValue(credMap, "sip_domain"); ok {
 		cfg.Domain = domain
 	}
+	if authUsername, ok := stringValue(credMap, "sip_auth_username"); ok {
+		cfg.AuthUsername = authUsername
+	}
+	if aorUser, ok := stringValue(credMap, "sip_aor_user"); ok {
+		cfg.AORUser = aorUser
+	}
+	if outboundProxy, ok := stringValue(credMap, "sip_outbound_proxy"); ok {
+		cfg.OutboundProxy = outboundProxy
+	}
+	// Transport is provider-owned when supplied; platform defaults fill it otherwise.
+	if transport, ok := stringValue(credMap, "sip_transport"); ok {
+		if candidate := Transport(strings.ToLower(transport)); candidate.IsValid() {
+			cfg.Transport = candidate
+		}
+	}
+	// Caller ID is outbound presentation only; it never feeds REGISTER.
 	if callerID, ok := stringValue(credMap, "sip_caller_id"); ok {
 		cfg.CallerID = callerID
 	}

--- a/api/assistant-api/sip/internal/core/types_test.go
+++ b/api/assistant-api/sip/internal/core/types_test.go
@@ -316,3 +316,48 @@ func TestDefaultInboundAnswerPolicyAnswersImmediately(t *testing.T) {
 	assert.Equal(t, InboundAnswerModeImmediate, policy.Mode)
 	assert.Equal(t, defaultInboundACKTimeout, policy.ACKTimeout)
 }
+
+func TestParseConfigFromVault_IdentityFields(t *testing.T) {
+	cfg, err := ParseConfigFromVault(makeVaultCredential(map[string]interface{}{
+		"sip_server":         "at1.provider.com",
+		"sip_username":       "sip7f2a91",
+		"sip_auth_username":  "auth-user",
+		"sip_aor_user":       "1044",
+		"sip_outbound_proxy": "sbc.provider.com",
+		"sip_transport":      "tcp",
+		"sip_caller_id":      "+15551234567",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "sip7f2a91", cfg.Username)
+	assert.Equal(t, "auth-user", cfg.AuthUsername)
+	assert.Equal(t, "1044", cfg.AORUser)
+	assert.Equal(t, "sbc.provider.com", cfg.OutboundProxy)
+	assert.Equal(t, TransportTCP, cfg.Transport)
+	assert.Equal(t, "+15551234567", cfg.CallerID)
+}
+
+// Credentials written before the identity split carry none of the new keys;
+// they must still parse and keep working off sip_username alone.
+func TestParseConfigFromVault_LegacyCredentialStillResolves(t *testing.T) {
+	cfg, err := ParseConfigFromVault(makeVaultCredential(map[string]interface{}{
+		"sip_uri":      "sip:at1.provider.com:5060",
+		"sip_username": "sip7f2a91",
+		"sip_password": "secret",
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.AORUser)
+	assert.Empty(t, cfg.AuthUsername)
+	assert.Equal(t, "sip7f2a91", cfg.GetAORUser())
+	assert.Equal(t, "sip7f2a91", cfg.GetAuthUsername())
+	assert.Equal(t, "at1.provider.com", cfg.GetOutboundTarget())
+}
+
+// An invalid transport string must not silently corrupt the config.
+func TestParseConfigFromVault_IgnoresInvalidTransport(t *testing.T) {
+	cfg, err := ParseConfigFromVault(makeVaultCredential(map[string]interface{}{
+		"sip_server":    "at1.provider.com",
+		"sip_transport": "carrier-pigeon",
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, string(cfg.Transport))
+}

--- a/api/assistant-api/sip/middleware/route_middleware.go
+++ b/api/assistant-api/sip/middleware/route_middleware.go
@@ -156,14 +156,19 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 				ProjectID      uint64
 				OrganizationID uint64
 			}
+			// Match the INVITE's user part against every inbound identifier a
+			// deployment can be reached by: the DID, the extension the PBX dials,
+			// and the AOR the trunk registered under. Providers differ in which one
+			// they put in the Request-URI, and a "+"-prefixed DID must still match
+			// an unprefixed one.
 			var result didLookupResult
 			tx := db.Model(&internal_assistant_entity.Assistant{}).
 				Select("assistants.id AS assistant_id, assistants.project_id, assistants.organization_id").
 				Joins("JOIN assistant_phone_deployments apd ON apd.assistant_id = assistants.id").
 				Joins("JOIN assistant_deployment_telephony_options o ON o.assistant_deployment_telephony_id = apd.id").
 				Where("apd.telephony_provider = ? AND apd.status = ?", "sip", type_enums.RECORD_ACTIVE).
-				Where("o.key = ?", "phone").
-				Where("o.value = ?", routeValue).
+				Where("o.key IN ?", inboundRouteOptionKeys).
+				Where("o.value IN ?", inboundRouteCandidates(routeValue)).
 				First(&result)
 			if tx.Error != nil {
 				m.logger.Warnw("SIP: DID route lookup failed",
@@ -221,4 +226,26 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 
 		return nil
 	}
+}
+
+// inboundRouteOptionKeys are the deployment option keys an inbound INVITE user
+// part may match. "phone" is the DID, "extension" is the identifier the PBX
+// dials internally, and "sip_aor_user" is the registered AOR — providers put
+// different ones in the Request-URI depending on how the trunk is provisioned.
+var inboundRouteOptionKeys = []string{"phone", "extension", "sip_aor_user"}
+
+// inboundRouteCandidates expands a SIP user part into the equivalent stored
+// values, so a "+"-prefixed DID matches an unprefixed one and vice versa.
+func inboundRouteCandidates(routeValue string) []string {
+	value := strings.TrimSpace(routeValue)
+	if value == "" {
+		return []string{""}
+	}
+	candidates := []string{value}
+	if trimmed := strings.TrimPrefix(value, "+"); trimmed != value {
+		candidates = append(candidates, trimmed)
+	} else {
+		candidates = append(candidates, "+"+value)
+	}
+	return candidates
 }

--- a/api/assistant-api/sip/middleware/vault_middleware.go
+++ b/api/assistant-api/sip/middleware/vault_middleware.go
@@ -68,8 +68,14 @@ func NewVaultMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 			return &sip_infra.SIPError{Code: 500, Message: "Failed to resolve SIP configuration", Err: sip_infra.ErrInvalidConfig}
 		}
 
-		if did, err := opts.GetString("phone"); err == nil && validator.NotBlank(did) {
-			sipConfig.CallerID = strings.TrimPrefix(did, "+")
+		// Outbound caller ID comes from the deployment's dedicated caller-id option.
+		// Fall back to the DID only when no explicit caller ID is set: the DID is a
+		// reasonable outbound presentation number, but it is deployment identity —
+		// it must never reach the credential's registration fields.
+		if callerID, err := opts.GetString("caller_id"); err == nil && validator.NotBlank(callerID) {
+			sipConfig.CallerID = strings.TrimPrefix(strings.TrimSpace(callerID), "+")
+		} else if did, err := opts.GetString("phone"); err == nil && validator.NotBlank(did) {
+			sipConfig.CallerID = strings.TrimPrefix(strings.TrimSpace(did), "+")
 		}
 		if validator.NonNil(m.applySIPConfigDefaults) {
 			m.applySIPConfigDefaults(sipConfig)

--- a/api/assistant-api/sip/registration/owner.go
+++ b/api/assistant-api/sip/registration/owner.go
@@ -67,7 +67,7 @@ func (m *manager) handleClaimOwnership(ctx context.Context, s ClaimOwnershipPipe
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+		m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 			Error:         err.Error(),
 			FailureClass:  RegistrationFailureClassOwnership,
 			FailureReason: RegistrationFailureReasonOwnershipClaimFailed,
@@ -133,7 +133,7 @@ func (m *manager) handleClaimOwnership(ctx context.Context, s ClaimOwnershipPipe
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+		m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 			Error:         err.Error(),
 			FailureClass:  RegistrationFailureClassOwnership,
 			FailureReason: RegistrationFailureReasonOwnershipClaimFailed,

--- a/api/assistant-api/sip/registration/record.go
+++ b/api/assistant-api/sip/registration/record.go
@@ -8,6 +8,8 @@ package sip_registration
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
@@ -17,6 +19,7 @@ import (
 	"github.com/rapidaai/api/assistant-api/internal/observability"
 	"github.com/rapidaai/pkg/types"
 	type_enums "github.com/rapidaai/pkg/types/enums"
+	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/pkg/validator"
 	"github.com/rapidaai/protos"
 )
@@ -62,9 +65,22 @@ func (m *manager) loadRecords(ctx context.Context) ([]Record, error) {
 	for _, dep := range deployments {
 		opts := dep.GetOptions()
 
+		// A terminal status (config_error/rejected/...) permanently parks a
+		// deployment so a broken config is not retried forever. But once the user
+		// edits that config the verdict is stale: clear it and let the corrected
+		// settings be retried, instead of requiring a manual database reset.
 		sipStatus, _ := opts.GetString(OptKeySIPStatus)
+		configHash := sipRegistrationConfigHash(opts)
 		if isTerminalRegistrationStatus(RegistrationStatus(sipStatus)) {
-			continue
+			storedHash, _ := opts.GetString(OptKeySIPConfigHash)
+			if storedHash == configHash {
+				continue
+			}
+			m.logger.Infow("SIP config changed since terminal failure — retrying registration",
+				"deployment_id", dep.Id,
+				"assistant_id", dep.AssistantId,
+				"previous_status", sipStatus)
+			sipStatus = ""
 		}
 
 		sipInbound, _ := opts.GetString(OptKeySIPInbound)
@@ -176,6 +192,7 @@ func (m *manager) loadRecords(ctx context.Context) ([]Record, error) {
 			DeploymentID: dep.Id,
 			CredentialID: credentialID,
 			Status:       sipStatus,
+			ConfigHash:   configHash,
 		}
 		if assistant, ok := assistantByID[dep.AssistantId]; ok {
 			rec.ProjectID = assistant.ProjectId
@@ -296,4 +313,18 @@ func normalizeDIDForCollision(did string) string {
 		return "+" + v
 	}
 	return v
+}
+
+// sipRegistrationConfigHash fingerprints the deployment options that determine
+// whether a registration can succeed. When this changes, a previously terminal
+// failure is retried; when it does not, the failure stays parked.
+func sipRegistrationConfigHash(opts utils.Option) string {
+	keys := []string{OptKeyPhone, OptKeyExtension, OptKeyCredentialID, OptKeySIPInbound}
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value, _ := opts.GetString(key)
+		parts = append(parts, key+"="+strings.TrimSpace(value))
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1f")))
+	return hex.EncodeToString(sum[:8])
 }

--- a/api/assistant-api/sip/registration/register.go
+++ b/api/assistant-api/sip/registration/register.go
@@ -53,7 +53,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 		rec.Outcome = OutcomeConfigError
 		m.logger.Warnw("Failed to load assistant for registration",
 			"assistant_id", rec.AssistantID, "did", rec.DID, "error", err)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+		m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 			Status:        StatusConfigError,
 			Error:         "assistant not found",
 			FailureClass:  RegistrationFailureClassConfig,
@@ -110,7 +110,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+		m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 			Status:        StatusConfigError,
 			Error:         "vault credential not found",
 			FailureClass:  RegistrationFailureClassConfig,
@@ -148,7 +148,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+		m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 			Status:        StatusConfigError,
 			Error:         "invalid SIP config: " + err.Error(),
 			FailureClass:  RegistrationFailureClassConfig,
@@ -259,7 +259,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, statusUpdate)
+		m.writeRecordStatus(ctx, rec, statusUpdate)
 	case RegistrationFailureClassAuth:
 		rec.Outcome = OutcomeAuthFailed
 		m.logger.Errorw("SIP registration auth failed — marking deployment as failed",
@@ -284,7 +284,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, statusUpdate)
+		m.writeRecordStatus(ctx, rec, statusUpdate)
 	case RegistrationFailureClassConfig:
 		rec.Outcome = OutcomeConfigError
 		m.logger.Errorw("SIP registration config failed — will not retry",
@@ -309,7 +309,7 @@ func (m *manager) handleRegister(ctx context.Context, s RegisterPipeline) Pipeli
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, statusUpdate)
+		m.writeRecordStatus(ctx, rec, statusUpdate)
 	default:
 		rec.Outcome = OutcomeTransient
 		m.handleTransient(ctx, rec, regErr)

--- a/api/assistant-api/sip/registration/status.go
+++ b/api/assistant-api/sip/registration/status.go
@@ -33,7 +33,7 @@ func (m *manager) handleMarkActive(ctx context.Context, p MarkActivePipeline) Pi
 	}
 	retryCount := 0
 	now := time.Now().UTC()
-	m.writeRegistrationStatus(ctx, rec.DeploymentID, RegistrationStatusUpdate{
+	m.writeRecordStatus(ctx, rec, RegistrationStatusUpdate{
 		Status:        StatusActive,
 		Error:         "",
 		RetryCount:    &retryCount,
@@ -41,6 +41,19 @@ func (m *manager) handleMarkActive(ctx context.Context, p MarkActivePipeline) Pi
 		LastSuccessAt: now,
 	})
 	return nil
+}
+
+// writeRecordStatus writes a status update for a Record, stamping the config
+// fingerprint the verdict was reached with so a terminal failure is retried
+// automatically once the deployment config changes.
+func (m *manager) writeRecordStatus(ctx context.Context, rec *Record, update RegistrationStatusUpdate) {
+	if !validator.NonNil(rec) {
+		return
+	}
+	if !validator.NotBlank(update.ConfigHash) {
+		update.ConfigHash = rec.ConfigHash
+	}
+	m.writeRegistrationStatus(ctx, rec.DeploymentID, update)
 }
 
 func (m *manager) writeRegistrationStatus(ctx context.Context, deploymentID uint64, update RegistrationStatusUpdate) {
@@ -80,6 +93,11 @@ func (m *manager) writeRegistrationStatus(ctx context.Context, deploymentID uint
 	}
 	if !update.LastSuccessAt.IsZero() {
 		m.upsertOption(ctx, deploymentID, OptKeySIPLastSuccessAt, formatRegistrationTime(update.LastSuccessAt))
+	}
+	// Record which config produced this verdict. loadRecords compares against it
+	// so a terminal failure is retried automatically after the config is edited.
+	if validator.NotBlank(update.ConfigHash) {
+		m.upsertOption(ctx, deploymentID, OptKeySIPConfigHash, update.ConfigHash)
 	}
 }
 
@@ -176,7 +194,7 @@ func (m *manager) handleTransient(ctx context.Context, rec *Record, err error) {
 				Attributes: attributes,
 			},
 		)
-		m.writeRegistrationStatus(ctx, rec.DeploymentID, statusUpdate)
+		m.writeRecordStatus(ctx, rec, statusUpdate)
 		return
 	}
 
@@ -226,5 +244,5 @@ func (m *manager) handleTransient(ctx context.Context, rec *Record, err error) {
 			Attributes: attributes,
 		},
 	)
-	m.writeRegistrationStatus(ctx, rec.DeploymentID, statusUpdate)
+	m.writeRecordStatus(ctx, rec, statusUpdate)
 }

--- a/api/assistant-api/sip/registration/types.go
+++ b/api/assistant-api/sip/registration/types.go
@@ -25,7 +25,10 @@ const (
 	MaxTransientRetries = 10
 
 	OptKeyPhone            = "phone"
+	OptKeyExtension        = "extension"
+	OptKeyCallerID         = "caller_id"
 	OptKeyCredentialID     = "rapida.credential_id"
+	OptKeySIPConfigHash    = "rapida.sip_config_hash"
 	OptKeySIPStatus        = "rapida.sip_status"
 	OptKeySIPError         = "rapida.sip_error"
 	OptKeySIPRetry         = "rapida.sip_retry_count"
@@ -110,6 +113,7 @@ type RegistrationStatusUpdate struct {
 	NextRetryAt   time.Time // Expected time of the next retry, when retrying.
 	OwnerInstance string    // Rapida instance currently owning or attempting the DID.
 	LastSuccessAt time.Time // Time of the latest successful REGISTER or renewal.
+	ConfigHash    string    // Fingerprint of the config this verdict was reached with.
 }
 
 // Record is a single DID-registration work item carried by every Stage. The
@@ -125,6 +129,9 @@ type Record struct {
 	CredentialID   uint64
 	Status         string
 	Outcome        string
+	// ConfigHash fingerprints the registration-relevant options so a terminal
+	// failure can be retried automatically once the config actually changes.
+	ConfigHash string
 }
 
 // Outcome values written by handlers.

--- a/ui/src/app/components/base/modal/create-provider-credential-modal/index.tsx
+++ b/ui/src/app/components/base/modal/create-provider-credential-modal/index.tsx
@@ -31,7 +31,11 @@ import { Add, TrashCan } from '@carbon/icons-react';
 import { connectionConfig } from '@/configs';
 import { useProviderContext } from '@/context/provider-context';
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
-import { INTEGRATION_PROVIDER, RapidaProvider } from '@/providers';
+import {
+  INTEGRATION_PROVIDER,
+  RapidaProvider,
+  RapidaProviderConfiguration,
+} from '@/providers';
 import { createPortal } from 'react-dom';
 
 interface CreateProviderCredentialDialogProps extends ModalProps {
@@ -49,6 +53,7 @@ export function CreateProviderCredentialDialog(
   const [error, setError] = useState('');
   const [keyName, setKeyName] = useState('');
   const [config, setConfig] = useState<Record<string, string>>({});
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   useEffect(() => {
     setProvider(
@@ -71,6 +76,76 @@ export function CreateProviderCredentialDialog(
     if (field.label?.toLowerCase().includes('(optional)')) return false;
     if (provider?.code === 'sip' && field.name === 'sip_headers') return false;
     return true;
+  };
+
+  // Advanced fields stay collapsed until asked for, so the common path is short.
+  const isAdvancedField = (field: { advanced?: boolean }) =>
+    field.advanced === true;
+  const basicConfigurations =
+    provider?.configurations?.filter(x => !isAdvancedField(x)) ?? [];
+  const advancedConfigurations =
+    provider?.configurations?.filter(isAdvancedField) ?? [];
+
+  const renderConfigField = (
+    x: RapidaProviderConfiguration,
+    key: string | number,
+  ) => {
+    const commonProps = {
+      id: `config-${x.name}`,
+      labelText: x.label,
+      helperText: x.helperText,
+      value: config[x.name] || '',
+      required: isConfigFieldRequired(x),
+    };
+
+    if (x.type === 'text') {
+      return (
+        <TextArea
+          {...commonProps}
+          key={key}
+          placeholder={x.placeholder ?? x.label}
+          onChange={e => handleConfigChange(x.name, e.target.value)}
+        />
+      );
+    }
+    if (x.type === 'key_value') {
+      return (
+        <CredentialKeyValueField
+          key={key}
+          name={x.name}
+          label={x.label}
+          helperText={x.helperText}
+          value={config[x.name] || ''}
+          onChange={value => handleConfigChange(x.name, value)}
+        />
+      );
+    }
+    if (x.type === 'select') {
+      return (
+        <CarbonSelect
+          {...commonProps}
+          key={key}
+          onChange={e =>
+            handleConfigChange(x.name, (e.target as HTMLSelectElement).value)
+          }
+        >
+          <SelectItem value="" text={`Select ${x.label.toLowerCase()}`} />
+          {(x.choices ?? []).map(c => (
+            <SelectItem key={c.value} value={c.value} text={c.label} />
+          ))}
+        </CarbonSelect>
+      );
+    }
+    return (
+      <TextInput
+        {...commonProps}
+        key={key}
+        // Secrets are masked on entry and are never read back from the API.
+        type={x.secret ? 'password' : 'text'}
+        placeholder={x.placeholder ?? x.label}
+        onChange={e => handleConfigChange(x.name, e.target.value)}
+      />
+    );
   };
 
   const validateAndSubmit = () => {
@@ -177,57 +252,22 @@ export function CreateProviderCredentialDialog(
             required
             onChange={e => setKeyName(e.target.value)}
           />
-          {provider &&
-            provider.configurations?.map((x, idx) =>
-              x.type === 'text' ? (
-                <TextArea
-                  key={idx}
-                  id={`config-${x.name}`}
-                  labelText={x.label}
-                  placeholder={x.label}
-                  value={config[x.name] || ''}
-                  required={isConfigFieldRequired(x)}
-                  onChange={e => handleConfigChange(x.name, e.target.value)}
-                />
-              ) : x.type === 'key_value' ? (
-                <CredentialKeyValueField
-                  key={idx}
-                  name={x.name}
-                  label={x.label}
-                  value={config[x.name] || ''}
-                  onChange={value => handleConfigChange(x.name, value)}
-                />
-              ) : x.type === 'select' ? (
-                <CarbonSelect
-                  key={idx}
-                  id={`config-${x.name}`}
-                  labelText={x.label}
-                  value={config[x.name] || ''}
-                  onChange={e =>
-                    handleConfigChange(x.name, (e.target as HTMLSelectElement).value)
-                  }
-                >
-                  <SelectItem value="" text={`Select ${x.label.toLowerCase()}`} />
-                  {(x.choices ?? []).map(c => (
-                    <SelectItem
-                      key={c.value}
-                      value={c.value}
-                      text={c.label}
-                    />
-                  ))}
-                </CarbonSelect>
-              ) : (
-                <TextInput
-                  key={idx}
-                  id={`config-${x.name}`}
-                  labelText={x.label}
-                  placeholder={x.label}
-                  value={config[x.name] || ''}
-                  required={isConfigFieldRequired(x)}
-                  onChange={e => handleConfigChange(x.name, e.target.value)}
-                />
-              ),
-            )}
+          {basicConfigurations.map((x, idx) => renderConfigField(x, idx))}
+          {advancedConfigurations.length > 0 && (
+            <>
+              <TertiaryButton
+                size="sm"
+                type="button"
+                onClick={() => setShowAdvanced(prev => !prev)}
+              >
+                {showAdvanced ? 'Hide advanced settings' : 'Show advanced settings'}
+              </TertiaryButton>
+              {showAdvanced &&
+                advancedConfigurations.map((x, idx) =>
+                  renderConfigField(x, `advanced-${idx}`),
+                )}
+            </>
+          )}
           <ErrorMessage message={error} />
         </Stack>
       </ModalBody>
@@ -254,11 +294,13 @@ export function CreateProviderCredentialDialog(
 function CredentialKeyValueField({
   name,
   label,
+  helperText,
   value,
   onChange,
 }: {
   name: string;
   label: string;
+  helperText?: string;
   value: string;
   onChange: (value: string) => void;
 }) {
@@ -312,9 +354,16 @@ function CredentialKeyValueField({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
-        {label} ({entries.length})
-      </p>
+      <div className="flex flex-col gap-1">
+        <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
+          {label} ({entries.length})
+        </p>
+        {helperText && (
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {helperText}
+          </p>
+        )}
+      </div>
       <table className="w-full border-collapse border border-gray-200 dark:border-gray-700 text-sm [&_input]:!border-none [&_.cds--text-input]:!border-none [&_.cds--text-input]:!outline-none [&_.cds--form-item]:!m-0">
         <thead>
           <tr className="bg-gray-50 dark:bg-gray-900">

--- a/ui/src/providers/index.ts
+++ b/ui/src/providers/index.ts
@@ -5,6 +5,22 @@ export interface IntegrationProvider extends RapidaProvider { }
 interface EndOfSpeechProvider extends RapidaProvider { }
 interface VADProvider extends RapidaProvider { }
 interface NoiseCancellationProvider extends RapidaProvider { }
+export interface RapidaProviderConfiguration {
+  name: string;
+  type: string;
+  label: string;
+  required?: boolean;
+  choices?: { label: string; value: string }[];
+  /** Example value shown inside the empty field. */
+  placeholder?: string;
+  /** Short description rendered under the field. */
+  helperText?: string;
+  /** Renders as a password input; never read back from the API. */
+  secret?: boolean;
+  /** Grouped under the collapsed "advanced settings" section. */
+  advanced?: boolean;
+}
+
 export interface RapidaProvider {
   code: string;
   name: string;
@@ -12,13 +28,7 @@ export interface RapidaProvider {
   description?: string;
   image?: string;
   url?: string;
-  configurations?: {
-    name: string;
-    type: string;
-    label: string;
-    required?: boolean;
-    choices?: { label: string; value: string }[];
-  }[];
+  configurations?: RapidaProviderConfiguration[];
 }
 
 /**

--- a/ui/src/providers/provider.development.json
+++ b/ui/src/providers/provider.development.json
@@ -165,24 +165,86 @@
         ],
         "configurations": [
             {
-                "name": "sip_uri",
+                "name": "sip_server",
                 "type": "string",
-                "label": "SIP URI (e.g., sip:trunk.provider.com:5060)"
+                "label": "SIP Server",
+                "placeholder": "at1.provider.com",
+                "helperText": "Registrar hostname or IP. Do not include sip: or a port."
+            },
+            {
+                "name": "sip_port",
+                "type": "string",
+                "label": "SIP Port",
+                "placeholder": "5060",
+                "helperText": "Signalling port of the provider. Usually 5060."
+            },
+            {
+                "name": "sip_transport",
+                "type": "select",
+                "label": "Transport",
+                "choices": [
+                    { "value": "udp", "label": "UDP" },
+                    { "value": "tcp", "label": "TCP" },
+                    { "value": "tls", "label": "TLS" }
+                ],
+                "helperText": "Signalling transport required by the provider."
             },
             {
                 "name": "sip_username",
                 "type": "string",
-                "label": "SIP Username (optional)"
+                "label": "SIP Username",
+                "placeholder": "sip7f2a91",
+                "helperText": "The SIP account name. Not your phone number."
+            },
+            {
+                "name": "sip_auth_username",
+                "type": "string",
+                "label": "Authentication Username (optional)",
+                "required": false,
+                "placeholder": "Defaults to SIP Username",
+                "helperText": "Only set this if the provider issues a separate Digest auth username."
             },
             {
                 "name": "sip_password",
                 "type": "string",
-                "label": "SIP Password (optional)"
+                "label": "SIP Password",
+                "secret": true,
+                "helperText": "Stored encrypted and never returned by the API."
+            },
+            {
+                "name": "sip_aor_user",
+                "type": "string",
+                "label": "AOR User (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "Defaults to SIP Username",
+                "helperText": "Identity used in REGISTER and Contact. Leave empty unless the provider registers you under a different user."
+            },
+            {
+                "name": "sip_realm",
+                "type": "string",
+                "label": "Realm (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "Sent by the provider in the auth challenge",
+                "helperText": "Only needed when the provider requires a fixed realm."
+            },
+            {
+                "name": "sip_outbound_proxy",
+                "type": "string",
+                "label": "Outbound Proxy (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "sbc.provider.com",
+                "helperText": "Route outbound calls via an SBC or proxy instead of the SIP server."
             },
             {
                 "name": "sip_headers",
                 "type": "key_value",
-                "label": "Custom SIP Headers"
+                "label": "Custom SIP Headers",
+                "required": false,
+                "advanced": true,
+                "helperText": "Extra headers added to outbound INVITE requests."
             }
         ]
     },

--- a/ui/src/providers/provider.production.json
+++ b/ui/src/providers/provider.production.json
@@ -204,24 +204,86 @@
         ],
         "configurations": [
             {
-                "name": "sip_uri",
+                "name": "sip_server",
                 "type": "string",
-                "label": "SIP URI (e.g., sip:trunk.provider.com:5060)"
+                "label": "SIP Server",
+                "placeholder": "at1.provider.com",
+                "helperText": "Registrar hostname or IP. Do not include sip: or a port."
+            },
+            {
+                "name": "sip_port",
+                "type": "string",
+                "label": "SIP Port",
+                "placeholder": "5060",
+                "helperText": "Signalling port of the provider. Usually 5060."
+            },
+            {
+                "name": "sip_transport",
+                "type": "select",
+                "label": "Transport",
+                "choices": [
+                    { "value": "udp", "label": "UDP" },
+                    { "value": "tcp", "label": "TCP" },
+                    { "value": "tls", "label": "TLS" }
+                ],
+                "helperText": "Signalling transport required by the provider."
             },
             {
                 "name": "sip_username",
                 "type": "string",
-                "label": "SIP Username (optional)"
+                "label": "SIP Username",
+                "placeholder": "sip7f2a91",
+                "helperText": "The SIP account name. Not your phone number."
+            },
+            {
+                "name": "sip_auth_username",
+                "type": "string",
+                "label": "Authentication Username (optional)",
+                "required": false,
+                "placeholder": "Defaults to SIP Username",
+                "helperText": "Only set this if the provider issues a separate Digest auth username."
             },
             {
                 "name": "sip_password",
                 "type": "string",
-                "label": "SIP Password (optional)"
+                "label": "SIP Password",
+                "secret": true,
+                "helperText": "Stored encrypted and never returned by the API."
+            },
+            {
+                "name": "sip_aor_user",
+                "type": "string",
+                "label": "AOR User (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "Defaults to SIP Username",
+                "helperText": "Identity used in REGISTER and Contact. Leave empty unless the provider registers you under a different user."
+            },
+            {
+                "name": "sip_realm",
+                "type": "string",
+                "label": "Realm (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "Sent by the provider in the auth challenge",
+                "helperText": "Only needed when the provider requires a fixed realm."
+            },
+            {
+                "name": "sip_outbound_proxy",
+                "type": "string",
+                "label": "Outbound Proxy (optional)",
+                "required": false,
+                "advanced": true,
+                "placeholder": "sbc.provider.com",
+                "helperText": "Route outbound calls via an SBC or proxy instead of the SIP server."
             },
             {
                 "name": "sip_headers",
                 "type": "key_value",
-                "label": "Custom SIP Headers"
+                "label": "Custom SIP Headers",
+                "required": false,
+                "advanced": true,
+                "helperText": "Extra headers added to outbound INVITE requests."
             }
         ]
     },

--- a/ui/src/providers/sip/telephony.json
+++ b/ui/src/providers/sip/telephony.json
@@ -3,13 +3,33 @@
     "parameters": [
       {
         "key": "phone",
-        "label": "Caller ID",
+        "label": "DID / Public Phone Number",
         "type": "input",
         "required": true,
         "default": "",
         "placeholder": "e.g., +15551234567",
-        "helpText": "The phone number to display as caller ID for outbound calls.",
-        "errorMessage": "Please provide a valid SIP caller ID."
+        "helpText": "The public number callers dial to reach this assistant. Used for inbound routing only — never for SIP registration.",
+        "errorMessage": "Please provide a valid public phone number."
+      },
+      {
+        "key": "extension",
+        "label": "Extension / Inbound Identifier",
+        "type": "input",
+        "required": false,
+        "default": "",
+        "placeholder": "e.g., 1044",
+        "helpText": "Optional. The extension or user your PBX puts in the INVITE. Set this when the provider routes by extension instead of the DID.",
+        "errorMessage": "Please provide a valid extension."
+      },
+      {
+        "key": "caller_id",
+        "label": "Outbound Caller ID",
+        "type": "input",
+        "required": false,
+        "default": "",
+        "placeholder": "Defaults to the DID above",
+        "helpText": "Optional. The number shown to the person you call. Applies to outbound calls only.",
+        "errorMessage": "Please provide a valid outbound caller ID."
       },
       {
         "key": "rapida.sip_inbound",
@@ -27,7 +47,7 @@
             "value": "false"
           }
         ],
-        "helpText": "Register this number with the SIP provider to receive incoming calls."
+        "helpText": "Register with the SIP provider using the credential's SIP username so incoming calls reach this assistant."
       }
     ]
   }


### PR DESCRIPTION
The SIP credential form conflated three distinct identities, so connecting a provider that keys accounts by username (rather than by DID) required entering the SIP username into the Caller ID field to make REGISTER succeed.

Registration, authentication and caller ID are now independent:

- REGISTER To/From and Contact use AOR User, falling back to SIP Username. Credentials saved before this change have neither, so registration falls back to the DID exactly as before and keeps working.
- Digest auth uses Authentication Username, falling back to SIP Username.
- Caller ID is outbound presentation only and can no longer reach REGISTER. The vault middleware previously overwrote it with the deployment DID.
- Outbound calls honour an optional outbound proxy.
- Only the DID path is number-normalized; alphanumeric account names are sent verbatim rather than being treated as phone numbers.

Inbound routing now matches the INVITE user against the DID, the extension and the registered AOR, with "+"-prefix equivalence, since providers differ in which one they place in the Request-URI.

A terminal registration failure (config_error/rejected/...) previously parked a deployment permanently, so a corrected config was never retried without a manual database reset. Failures now record a fingerprint of the registration-relevant options and are retried automatically once that config changes.

Credential form gains SIP Server, Port, Transport and Authentication Username, with AOR User, Realm, Outbound Proxy and Custom Headers collapsed under advanced settings. Passwords render masked. Server-wide values such as the external IP stay in env/config and are not exposed in the form. The phone deployment form gains Extension and Outbound Caller ID, and its DID field is no longer mislabelled "Caller ID".

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate SIP settings for authentication username, registration identity, outbound proxy, transport, and routing.
  - Added advanced provider configuration fields with guidance, placeholders, validation, and secure password handling.
  - Improved inbound routing and outbound caller ID configuration.

- **Bug Fixes**
  - Improved SIP registration identity handling and routing compatibility.
  - Registration failures now retry when relevant configuration changes.
  - Status updates retain configuration context for more accurate recovery handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates SIP registration, authentication, and outbound caller identities; adds proxy and transport configuration; expands inbound routing; and retries terminal registration failures after selected deployment options change.
- Adds independent AOR, digest-auth username, caller ID, and outbound-proxy handling.
- Adds a registration configuration fingerprint used to retry parked deployments after deployment-option changes.
- Expands inbound routing to DID, extension, and AOR-like option values with `+`-prefix equivalence.
- Extends the SIP credential and phone-deployment forms with the new fields and advanced settings.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The inbound-routing defects should be fixed before merging because configured AOR routes can fail entirely and overlapping identifiers can select the wrong assistant.

The new lookup searches deployment options for an AOR stored only in the vault credential and broadens matching without uniqueness or deterministic precedence, causing missed or misdirected inbound calls.

**Files Needing Attention:** api/assistant-api/sip/middleware/route_middleware.go
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/sip/middleware/route_middleware.go | Expands inbound matching, but cannot read credential-backed AOR values and does not safely resolve collisions among broadened identifiers. |
| api/assistant-api/sip/internal/core/register.go | Separates the REGISTER AOR from caller ID and preserves the normalized DID fallback for legacy credentials. |
| api/assistant-api/sip/internal/core/types.go | Adds identity and proxy fields with explicit fallback resolvers and vault parsing. |
| api/assistant-api/sip/registration/record.go | Adds a deployment-option fingerprint so terminal registration outcomes can be retried after covered configuration changes. |
| api/assistant-api/sip/registration/status.go | Persists the registration fingerprint alongside status updates. |
| ui/src/app/components/base/modal/create-provider-credential-modal/index.tsx | Adds masked secret inputs, helper text, select rendering, and collapsible advanced credential fields. |
| ui/src/providers/sip/telephony.json | Separates DID, extension, and outbound caller ID in the SIP deployment form. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Invite[Inbound SIP INVITE] --> User[Extract Request-URI user]
  User --> Candidates[Generate exact and +/- candidates]
  Candidates --> Options[Search active deployment options]
  Options --> Match{Unique matching deployment?}
  Match -->|Yes| Assistant[Load assistant and route call]
  Match -->|No match| Reject[Inbound routing fails]
  Match -->|Multiple matches| Wrong[Arbitrary deployment may be selected]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/sip/middleware/route_middleware.go:170-171
**Credential AOR Route Is Unreachable**

When a provider sends an INVITE to the credential's configured AOR, this query searches only deployment telephony options even though `sip_aor_user` is stored in the vault credential, causing the lookup to miss the deployment and reject the inbound call.

### Issue 2
api/assistant-api/sip/middleware/route_middleware.go:170-171
**Ambiguous Inbound Route Selection**

If two active SIP deployments have overlapping DID, extension, or AOR values, the prefix-expanded query matches both without precedence, tenant scoping, or collision handling and `First` selects one deployment, causing the call to reach the wrong assistant or be rejected after selecting a cross-project deployment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sip): separate registration identit..."](https://github.com/rapidaai/voice-ai/commit/12c7d565bd6076b3934abea43915bbbbe3e03729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50530006)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->