### PR TITLE
Feat/agentkit packet control

### DIFF
--- a/api/assistant-api/api/assistant-deployment/create_assistant_api_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_api_deployment.go
@@ -33,7 +33,7 @@ func (deploymentApi *assistantDeploymentGrpcApi) CreateAssistantApiDeployment(ct
 		)
 	}
 	if deployment.GetApi().UnclearInputTimeout != nil &&
-		!validator.Between(*deployment.GetApi().UnclearInputTimeout, 0.5, 5) {
+		!validator.Between(*deployment.GetApi().UnclearInputTimeout, 2, 10) {
 		return &assistant_api.GetAssistantApiDeploymentResponse{
 			Code:    pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(),
 			Success: false,

--- a/api/assistant-api/api/assistant-deployment/create_assistant_api_deployment_rest.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_api_deployment_rest.go
@@ -73,7 +73,7 @@ func (deploymentApi *AssistantDeploymentApi) CreateAssistantApiDeploymentRest(c 
 		})
 		return
 	}
-	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 0.5, 5) {
+	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 2, 10) {
 		c.JSON(pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.HTTPStatusCode, openapi.ErrorResponse{
 			Code:    utils.Ptr(pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32()),
 			Success: utils.Ptr(false),

--- a/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment.go
@@ -33,7 +33,7 @@ func (deploymentApi *assistantDeploymentGrpcApi) CreateAssistantDebuggerDeployme
 		)
 	}
 	if deployment.GetDebugger().UnclearInputTimeout != nil &&
-		!validator.Between(*deployment.GetDebugger().UnclearInputTimeout, 0.5, 5) {
+		!validator.Between(*deployment.GetDebugger().UnclearInputTimeout, 2, 10) {
 		return &assistant_api.GetAssistantDebuggerDeploymentResponse{
 			Code:    pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(),
 			Success: false,

--- a/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment_rest.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment_rest.go
@@ -73,7 +73,7 @@ func (deploymentApi *AssistantDeploymentApi) CreateAssistantDebuggerDeploymentRe
 		})
 		return
 	}
-	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 0.5, 5) {
+	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 2, 10) {
 		c.JSON(pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.HTTPStatusCode, openapi.ErrorResponse{
 			Code:    utils.Ptr(pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32()),
 			Success: utils.Ptr(false),

--- a/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment_rest_test.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_debugger_deployment_rest_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -742,22 +743,24 @@ func TestCreateAssistantDebuggerDeploymentRest_InvalidIdealTimeout(t *testing.T)
 
 func TestCreateAssistantDebuggerDeploymentRest_InvalidUnclearInputTimeout(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	deploymentApi := newCreateDebuggerDeploymentRestApi(t, &createDebuggerDeploymentRestServiceStub{})
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		deploymentApi := newCreateDebuggerDeploymentRestApi(t, &createDebuggerDeploymentRestServiceStub{})
 
-	recorder := httptest.NewRecorder()
-	context, _ := gin.CreateTestContext(recorder)
-	context.Request = httptest.NewRequest(
-		http.MethodPost,
-		"/v1/assistant-deployment/create-debugger-deployment",
-		bytes.NewReader([]byte(`{"assistantId":"123","unclearInputTimeout":0.4}`)),
-	)
-	context.Request.Header.Set("Content-Type", "application/json")
-	context.Set(string(types.CTX_), createDebuggerDeploymentRestAuth())
+		recorder := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(recorder)
+		context.Request = httptest.NewRequest(
+			http.MethodPost,
+			"/v1/assistant-deployment/create-debugger-deployment",
+			bytes.NewReader([]byte(fmt.Sprintf(`{"assistantId":"123","unclearInputTimeout":%f}`, unclearInputTimeout))),
+		)
+		context.Request.Header.Set("Content-Type", "application/json")
+		context.Set(string(types.CTX_), createDebuggerDeploymentRestAuth())
 
-	deploymentApi.CreateAssistantDebuggerDeploymentRest(context)
+		deploymentApi.CreateAssistantDebuggerDeploymentRest(context)
 
-	require.Equal(t, http.StatusBadRequest, recorder.Code)
-	assert.Contains(t, recorder.Body.String(), pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.Error)
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.Error)
+	}
 }
 
 func TestCreateAssistantDebuggerDeploymentRest_InvalidIdealTimeoutBackoff(t *testing.T) {
@@ -905,88 +908,93 @@ func TestCreateAssistantWhatsappDeploymentGRPC_InvalidIdealTimeout(t *testing.T)
 }
 
 func TestCreateAssistantDebuggerDeploymentGRPC_InvalidUnclearInputTimeout(t *testing.T) {
-	service := &createDebuggerDeploymentRestServiceStub{}
-	deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
-	request := createDebuggerDeploymentGRPCRequest()
-	unclearInputTimeout := 0.4
-	request.GetDebugger().UnclearInputTimeout = &unclearInputTimeout
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		service := &createDebuggerDeploymentRestServiceStub{}
+		deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
+		request := createDebuggerDeploymentGRPCRequest()
+		request.GetDebugger().UnclearInputTimeout = &unclearInputTimeout
 
-	response, err := deploymentApi.CreateAssistantDebuggerDeployment(createDebuggerDeploymentGRPCContext(), request)
+		response, err := deploymentApi.CreateAssistantDebuggerDeployment(createDebuggerDeploymentGRPCContext(), request)
 
-	require.Error(t, err)
-	require.NotNil(t, response)
-	assert.False(t, service.createCalled)
-	assert.Equal(t, pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
-	require.NotNil(t, response.Error)
-	assert.Equal(t, uint64(pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+		require.Error(t, err)
+		require.NotNil(t, response)
+		assert.False(t, service.createCalled)
+		assert.Equal(t, pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, uint64(pkg_errors.CreateAssistantDebuggerDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+	}
 }
 
 func TestCreateAssistantApiDeploymentGRPC_InvalidUnclearInputTimeout(t *testing.T) {
-	service := &createDebuggerDeploymentRestServiceStub{}
-	deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
-	request := createApiDeploymentGRPCRequest()
-	unclearInputTimeout := 0.4
-	request.GetApi().UnclearInputTimeout = &unclearInputTimeout
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		service := &createDebuggerDeploymentRestServiceStub{}
+		deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
+		request := createApiDeploymentGRPCRequest()
+		request.GetApi().UnclearInputTimeout = &unclearInputTimeout
 
-	response, err := deploymentApi.CreateAssistantApiDeployment(createDebuggerDeploymentGRPCContext(), request)
+		response, err := deploymentApi.CreateAssistantApiDeployment(createDebuggerDeploymentGRPCContext(), request)
 
-	require.Error(t, err)
-	require.NotNil(t, response)
-	assert.False(t, service.createCalled)
-	assert.Equal(t, pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
-	require.NotNil(t, response.Error)
-	assert.Equal(t, uint64(pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+		require.Error(t, err)
+		require.NotNil(t, response)
+		assert.False(t, service.createCalled)
+		assert.Equal(t, pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, uint64(pkg_errors.CreateAssistantApiDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+	}
 }
 
 func TestCreateAssistantPhoneDeploymentGRPC_InvalidUnclearInputTimeout(t *testing.T) {
-	service := &createDebuggerDeploymentRestServiceStub{}
-	deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
-	request := createPhoneDeploymentGRPCRequest()
-	unclearInputTimeout := 0.4
-	request.GetPhone().UnclearInputTimeout = &unclearInputTimeout
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		service := &createDebuggerDeploymentRestServiceStub{}
+		deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
+		request := createPhoneDeploymentGRPCRequest()
+		request.GetPhone().UnclearInputTimeout = &unclearInputTimeout
 
-	response, err := deploymentApi.CreateAssistantPhoneDeployment(createDebuggerDeploymentGRPCContext(), request)
+		response, err := deploymentApi.CreateAssistantPhoneDeployment(createDebuggerDeploymentGRPCContext(), request)
 
-	require.Error(t, err)
-	require.NotNil(t, response)
-	assert.False(t, service.createCalled)
-	assert.Equal(t, pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
-	require.NotNil(t, response.Error)
-	assert.Equal(t, uint64(pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+		require.Error(t, err)
+		require.NotNil(t, response)
+		assert.False(t, service.createCalled)
+		assert.Equal(t, pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, uint64(pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+	}
 }
 
 func TestCreateAssistantWebpluginDeploymentGRPC_InvalidUnclearInputTimeout(t *testing.T) {
-	service := &createDebuggerDeploymentRestServiceStub{}
-	deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
-	request := createWebpluginDeploymentGRPCRequest()
-	unclearInputTimeout := 0.4
-	request.GetPlugin().UnclearInputTimeout = &unclearInputTimeout
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		service := &createDebuggerDeploymentRestServiceStub{}
+		deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
+		request := createWebpluginDeploymentGRPCRequest()
+		request.GetPlugin().UnclearInputTimeout = &unclearInputTimeout
 
-	response, err := deploymentApi.CreateAssistantWebpluginDeployment(createDebuggerDeploymentGRPCContext(), request)
+		response, err := deploymentApi.CreateAssistantWebpluginDeployment(createDebuggerDeploymentGRPCContext(), request)
 
-	require.Error(t, err)
-	require.NotNil(t, response)
-	assert.False(t, service.createCalled)
-	assert.Equal(t, pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
-	require.NotNil(t, response.Error)
-	assert.Equal(t, uint64(pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+		require.Error(t, err)
+		require.NotNil(t, response)
+		assert.False(t, service.createCalled)
+		assert.Equal(t, pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, uint64(pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+	}
 }
 
 func TestCreateAssistantWhatsappDeploymentGRPC_InvalidUnclearInputTimeout(t *testing.T) {
-	service := &createDebuggerDeploymentRestServiceStub{}
-	deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
-	request := createWhatsappDeploymentGRPCRequest()
-	unclearInputTimeout := 0.4
-	request.GetWhatsapp().UnclearInputTimeout = &unclearInputTimeout
+	for _, unclearInputTimeout := range []float64{1.9, 10.1} {
+		service := &createDebuggerDeploymentRestServiceStub{}
+		deploymentApi := newCreateDebuggerDeploymentGRPCApi(t, service)
+		request := createWhatsappDeploymentGRPCRequest()
+		request.GetWhatsapp().UnclearInputTimeout = &unclearInputTimeout
 
-	response, err := deploymentApi.CreateAssistantWhatsappDeployment(createDebuggerDeploymentGRPCContext(), request)
+		response, err := deploymentApi.CreateAssistantWhatsappDeployment(createDebuggerDeploymentGRPCContext(), request)
 
-	require.Error(t, err)
-	require.NotNil(t, response)
-	assert.False(t, service.createCalled)
-	assert.Equal(t, pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
-	require.NotNil(t, response.Error)
-	assert.Equal(t, uint64(pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+		require.Error(t, err)
+		require.NotNil(t, response)
+		assert.False(t, service.createCalled)
+		assert.Equal(t, pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(), response.Code)
+		require.NotNil(t, response.Error)
+		assert.Equal(t, uint64(pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.Code), response.Error.ErrorCode)
+	}
 }
 
 func TestCreateAssistantDebuggerDeploymentGRPC_InvalidIdealTimeoutBackoff(t *testing.T) {

--- a/api/assistant-api/api/assistant-deployment/create_assistant_phone_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_phone_deployment.go
@@ -35,7 +35,7 @@ func (deploymentApi *assistantDeploymentGrpcApi) CreateAssistantPhoneDeployment(
 		)
 	}
 	if deployment.GetPhone().UnclearInputTimeout != nil &&
-		!validator.Between(*deployment.GetPhone().UnclearInputTimeout, 0.5, 5) {
+		!validator.Between(*deployment.GetPhone().UnclearInputTimeout, 2, 10) {
 		return &assistant_api.GetAssistantPhoneDeploymentResponse{
 			Code:    pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(),
 			Success: false,

--- a/api/assistant-api/api/assistant-deployment/create_assistant_phone_deployment_rest.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_phone_deployment_rest.go
@@ -85,7 +85,7 @@ func (deploymentApi *AssistantDeploymentApi) CreateAssistantPhoneDeploymentRest(
 		})
 		return
 	}
-	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 0.5, 5) {
+	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 2, 10) {
 		c.JSON(pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.HTTPStatusCode, openapi.ErrorResponse{
 			Code:    utils.Ptr(pkg_errors.CreateAssistantPhoneDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32()),
 			Success: utils.Ptr(false),

--- a/api/assistant-api/api/assistant-deployment/create_assistant_webplugin_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_webplugin_deployment.go
@@ -34,7 +34,7 @@ func (deploymentApi *assistantDeploymentGrpcApi) CreateAssistantWebpluginDeploym
 		)
 	}
 	if deployment.GetPlugin().UnclearInputTimeout != nil &&
-		!validator.Between(*deployment.GetPlugin().UnclearInputTimeout, 0.5, 5) {
+		!validator.Between(*deployment.GetPlugin().UnclearInputTimeout, 2, 10) {
 		return &assistant_api.GetAssistantWebpluginDeploymentResponse{
 			Code:    pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(),
 			Success: false,

--- a/api/assistant-api/api/assistant-deployment/create_assistant_webplugin_deployment_rest.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_webplugin_deployment_rest.go
@@ -73,7 +73,7 @@ func (deploymentApi *AssistantDeploymentApi) CreateAssistantWebpluginDeploymentR
 		})
 		return
 	}
-	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 0.5, 5) {
+	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 2, 10) {
 		c.JSON(pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.HTTPStatusCode, openapi.ErrorResponse{
 			Code:    utils.Ptr(pkg_errors.CreateAssistantWebpluginDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32()),
 			Success: utils.Ptr(false),

--- a/api/assistant-api/api/assistant-deployment/create_assistant_whatsapp_deployment.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_whatsapp_deployment.go
@@ -34,7 +34,7 @@ func (deploymentApi *assistantDeploymentGrpcApi) CreateAssistantWhatsappDeployme
 		)
 	}
 	if deployment.GetWhatsapp().UnclearInputTimeout != nil &&
-		!validator.Between(*deployment.GetWhatsapp().UnclearInputTimeout, 0.5, 5) {
+		!validator.Between(*deployment.GetWhatsapp().UnclearInputTimeout, 2, 10) {
 		return &assistant_api.GetAssistantWhatsappDeploymentResponse{
 			Code:    pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32(),
 			Success: false,

--- a/api/assistant-api/api/assistant-deployment/create_assistant_whatsapp_deployment_rest.go
+++ b/api/assistant-api/api/assistant-deployment/create_assistant_whatsapp_deployment_rest.go
@@ -85,7 +85,7 @@ func (deploymentApi *AssistantDeploymentApi) CreateAssistantWhatsappDeploymentRe
 		})
 		return
 	}
-	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 0.5, 5) {
+	if validator.NonNil(request.UnclearInputTimeout) && !validator.Between(*request.UnclearInputTimeout, 2, 10) {
 		c.JSON(pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.HTTPStatusCode, openapi.ErrorResponse{
 			Code:    utils.Ptr(pkg_errors.CreateAssistantWhatsappDeploymentInvalidUnclearTimeout.HTTPStatusCodeInt32()),
 			Success: utils.Ptr(false),

--- a/api/assistant-api/api/talk/outbound_bulk_call_rest.go
+++ b/api/assistant-api/api/talk/outbound_bulk_call_rest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	channel_pipeline "github.com/rapidaai/api/assistant-api/internal/channel/pipeline"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	"github.com/rapidaai/openapi"
 	pkg_errors "github.com/rapidaai/pkg/errors"
 	"github.com/rapidaai/pkg/preset"
@@ -127,6 +128,18 @@ func (cApi *ConversationApi) CreateBulkPhoneCallRest(c *gin.Context) {
 		var opts map[string]interface{}
 		if validator.NonNil(phoneCall.Options) {
 			opts = *phoneCall.Options
+		}
+		if value, err := utils.Option(opts).GetFloat64(internal_options.ExperienceOptionUnclearInputTimeout); err == nil && !validator.Between(value, 2, 10) {
+			c.JSON(pkg_errors.CreateBulkPhoneCallInvalidOptions.HTTPStatusCode, openapi.ErrorResponse{
+				Code:    utils.Ptr(pkg_errors.CreateBulkPhoneCallInvalidOptions.HTTPStatusCodeInt32()),
+				Success: utils.Ptr(false),
+				Error: &openapi.Error{
+					ErrorCode:    utils.Ptr(openapi.Uint64String(pkg_errors.CreateBulkPhoneCallInvalidOptions.CodeString())),
+					ErrorMessage: utils.Ptr(pkg_errors.CreateBulkPhoneCallInvalidOptions.Error),
+					HumanMessage: utils.Ptr(pkg_errors.CreateBulkPhoneCallInvalidOptions.ErrorMessage),
+				},
+			})
+			return
 		}
 		result := cApi.channelPipeline.Run(c, channel_pipeline.OutboundRequestedPipeline{
 			ID:          fmt.Sprintf("%d", assistant.GetAssistantId()),

--- a/api/assistant-api/api/talk/outbound_call.go
+++ b/api/assistant-api/api/talk/outbound_call.go
@@ -12,6 +12,7 @@ import (
 
 	channel_pipeline "github.com/rapidaai/api/assistant-api/internal/channel/pipeline"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	pkg_errors "github.com/rapidaai/pkg/errors"
 	"github.com/rapidaai/pkg/preset"
 	"github.com/rapidaai/pkg/types"
@@ -176,6 +177,28 @@ func (cApi *ConversationGrpcApi) CreatePhoneCall(ctx context.Context, ir *protos
 			},
 		}, errors.New(pkg_errors.CreatePhoneCallInvalidOptions.Error)
 	}
+	if value, err := utils.Option(opts).GetFloat64(internal_options.ExperienceOptionUnclearInputTimeout); err == nil && !validator.Between(value, 2, 10) {
+		_ = observer.Record(ctx, observability.AssistantScope{AssistantID: ir.GetAssistant().GetAssistantId()}, observability.RecordLog{
+			Level:   observability.LevelError,
+			Message: "CreatePhoneCall validation failed: invalid options",
+			Attributes: observability.Attributes{
+				"failure_stage": "validation",
+				"field":         internal_options.ExperienceOptionUnclearInputTimeout,
+				"error_code":    pkg_errors.CreatePhoneCallInvalidOptions.CodeString(),
+				"error":         pkg_errors.CreatePhoneCallInvalidOptions.Error,
+				"http_status":   fmt.Sprintf("%d", pkg_errors.CreatePhoneCallInvalidOptions.HTTPStatusCode),
+			},
+		})
+		return &protos.CreatePhoneCallResponse{
+			Code:    pkg_errors.CreatePhoneCallInvalidOptions.HTTPStatusCodeInt32(),
+			Success: false,
+			Error: &protos.Error{
+				ErrorCode:    uint64(pkg_errors.CreatePhoneCallInvalidOptions.Code),
+				ErrorMessage: pkg_errors.CreatePhoneCallInvalidOptions.Error,
+				HumanMessage: pkg_errors.CreatePhoneCallInvalidOptions.ErrorMessage,
+			},
+		}, errors.New(pkg_errors.CreatePhoneCallInvalidOptions.Error)
+	}
 
 	// Pipeline handles the full outbound flow
 	result := cApi.channelPipeline.Run(ctx, channel_pipeline.OutboundRequestedPipeline{
@@ -314,6 +337,17 @@ func (cApi *ConversationGrpcApi) CreateBulkPhoneCall(ctx context.Context, ir *pr
 		opts, err := utils.AnyMapToInterfaceMap(phoneCall.GetOptions())
 		if err != nil {
 			cApi.logger.Errorf("create bulk phone call invalid options: %v", err)
+			return &protos.CreateBulkPhoneCallResponse{
+				Code:    pkg_errors.CreateBulkPhoneCallInvalidOptions.HTTPStatusCodeInt32(),
+				Success: false,
+				Error: &protos.Error{
+					ErrorCode:    uint64(pkg_errors.CreateBulkPhoneCallInvalidOptions.Code),
+					ErrorMessage: pkg_errors.CreateBulkPhoneCallInvalidOptions.Error,
+					HumanMessage: pkg_errors.CreateBulkPhoneCallInvalidOptions.ErrorMessage,
+				},
+			}, errors.New(pkg_errors.CreateBulkPhoneCallInvalidOptions.Error)
+		}
+		if value, err := utils.Option(opts).GetFloat64(internal_options.ExperienceOptionUnclearInputTimeout); err == nil && !validator.Between(value, 2, 10) {
 			return &protos.CreateBulkPhoneCallResponse{
 				Code:    pkg_errors.CreateBulkPhoneCallInvalidOptions.HTTPStatusCodeInt32(),
 				Success: false,

--- a/api/assistant-api/api/talk/outbound_call_rest.go
+++ b/api/assistant-api/api/talk/outbound_call_rest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	channel_pipeline "github.com/rapidaai/api/assistant-api/internal/channel/pipeline"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	"github.com/rapidaai/openapi"
 	pkg_errors "github.com/rapidaai/pkg/errors"
 	"github.com/rapidaai/pkg/preset"
@@ -158,6 +159,18 @@ func (cApi *ConversationApi) CreatePhoneCallRest(c *gin.Context) {
 	var opts map[string]interface{}
 	if validator.NonNil(ir.Options) {
 		opts = *ir.Options
+	}
+	if value, err := utils.Option(opts).GetFloat64(internal_options.ExperienceOptionUnclearInputTimeout); err == nil && !validator.Between(value, 2, 10) {
+		c.JSON(pkg_errors.CreatePhoneCallInvalidOptions.HTTPStatusCode, openapi.ErrorResponse{
+			Code:    utils.Ptr(pkg_errors.CreatePhoneCallInvalidOptions.HTTPStatusCodeInt32()),
+			Success: utils.Ptr(false),
+			Error: &openapi.Error{
+				ErrorCode:    utils.Ptr(openapi.Uint64String(pkg_errors.CreatePhoneCallInvalidOptions.CodeString())),
+				ErrorMessage: utils.Ptr(pkg_errors.CreatePhoneCallInvalidOptions.Error),
+				HumanMessage: utils.Ptr(pkg_errors.CreatePhoneCallInvalidOptions.ErrorMessage),
+			},
+		})
+		return
 	}
 
 	result := cApi.channelPipeline.Run(c, channel_pipeline.OutboundRequestedPipeline{

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -45,12 +45,47 @@ type requestorDispatchHandler struct {
 }
 
 func (h requestorDispatchHandler) HandleUserText(ctx context.Context, vl internal_type.UserTextReceivedPacket) {
-	h.HandleInterruptionDetected(ctx, internal_type.InterruptionDetectedPacket{
-		ContextID: h.r.GetID(),
-		Source:    internal_type.InterruptionSourceWord,
-	})
+	if !validator.NotBlank(vl.Text) {
+		return
+	}
 
+	switch h.r.messageLifecycle.State() {
+	case adapter_lifecycle.MessageStateInterrupt,
+		adapter_lifecycle.MessageStateUserIdle,
+		adapter_lifecycle.MessageStateUserListening,
+		adapter_lifecycle.MessageStateUserSpeaking,
+		adapter_lifecycle.MessageStateUserThinking:
+	default:
+		oldContextID, newContextID, err := h.r.messageLifecycle.RotateContext()
+		if err != nil {
+			return
+		}
+		h.r.OnPacket(ctx,
+			internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+			internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
+		)
+		h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+			ContextID:         newContextID,
+			PreviousContextID: oldContextID,
+			Reason:            "interrupted",
+			Source:            "requestor",
+			Time:              time.Now(),
+		})
+		h.r.OnPacket(ctx,
+			internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+			internal_type.LLMInterruptPacket{ContextID: oldContextID},
+		)
+		utils.Go(ctx, func() {
+			h.r.Notify(ctx, &protos.ConversationInterruption{
+				Type: protos.ConversationInterruption_INTERRUPTION_TYPE_WORD,
+				Time: timestamppb.Now(),
+			})
+		})
+	}
 	vl.ContextID = h.r.GetID()
+	if h.r.unclearInputWatchdog != nil {
+		h.r.unclearInputWatchdog.Stop()
+	}
 	h.r.OnPacket(ctx,
 		internal_type.InterimEndOfSpeechPacket{Speech: vl.Text, ContextID: vl.ContextID},
 		internal_type.ObservabilityEventRecordPacket{
@@ -124,34 +159,26 @@ func (h requestorDispatchHandler) HandleVadSpeechActivity(ctx context.Context, v
 	}
 }
 func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p internal_type.SpeechToTextPacket) {
-	if p.ContextID == "" {
-		p.ContextID = h.r.GetID()
+	if !validator.NotBlank(p.Script) && !p.Interim {
+		return
 	}
+
+	incomingContextID := p.ContextID
+	currentContextID := h.r.GetID()
+	p.ContextID = currentContextID
 	messageState := h.r.messageLifecycle.State()
-	if p.Interim && h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
-		(messageState == adapter_lifecycle.MessageStateUserListening ||
-			messageState == adapter_lifecycle.MessageStateUserSpeaking ||
-			messageState == adapter_lifecycle.MessageStateUserThinking) {
-		_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
-		if behavior, err := h.r.deploymentBehavior(); err == nil &&
-			validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
-			h.r.unclearInputWatchdog.Extend(
-				p.ContextID,
-				time.Duration(*behavior.UnclearInputTimeout*float64(time.Second)),
-			)
+	if validator.NotBlank(p.Script) {
+		userTurnActive := false
+		switch messageState {
+		case adapter_lifecycle.MessageStateInterrupt,
+			adapter_lifecycle.MessageStateUserIdle,
+			adapter_lifecycle.MessageStateUserListening,
+			adapter_lifecycle.MessageStateUserSpeaking,
+			adapter_lifecycle.MessageStateUserThinking:
+			userTurnActive = true
 		}
-	}
-	if !p.Interim && validator.NotBlank(p.Script) {
-		messageState = h.r.messageLifecycle.State()
-		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
-			(messageState == adapter_lifecycle.MessageStateInterrupt ||
-				messageState == adapter_lifecycle.MessageStateUserIdle ||
-				messageState == adapter_lifecycle.MessageStateUserListening ||
-				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
-				messageState == adapter_lifecycle.MessageStateUserThinking) {
-			h.r.unclearInputWatchdog.Stop()
-			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
-			if err != nil {
+		if !userTurnActive {
+			if incomingContextID != "" && incomingContextID != currentContextID {
 				return
 			}
 			bargeInTrigger := internal_options.BargeInTriggerVAD
@@ -162,11 +189,16 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 					bargeInTrigger = value
 				}
 			}
+
 			interruptionSource := internal_type.InterruptionSourceVad
 			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
 			if bargeInTrigger == internal_options.BargeInTriggerWord {
 				interruptionSource = internal_type.InterruptionSourceWord
 				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
+			}
+			oldContextID, newContextID, err := h.r.messageLifecycle.RotateContext()
+			if err != nil {
+				return
 			}
 			h.r.OnPacket(ctx,
 				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
@@ -191,8 +223,22 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 			})
 			p.ContextID = newContextID
 		}
-		_ = h.r.messageLifecycle.UserFinished(p.ContextID)
 	}
+	if validator.NotBlank(p.Script) {
+		switch h.r.messageLifecycle.State() {
+		case adapter_lifecycle.MessageStateAssistantIdle,
+			adapter_lifecycle.MessageStateInterrupt,
+			adapter_lifecycle.MessageStateUserIdle,
+			adapter_lifecycle.MessageStateUserListening:
+			if err := h.r.messageLifecycle.UserListening(p.ContextID); err != nil {
+				return
+			}
+		}
+		if h.r.unclearInputWatchdog != nil {
+			h.r.unclearInputWatchdog.Stop()
+		}
+	}
+
 	if h.r.endOfSpeechExecutor != nil {
 		_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
 		return
@@ -209,16 +255,22 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 }
 func (h requestorDispatchHandler) HandleInterimEndOfSpeech(ctx context.Context, p internal_type.InterimEndOfSpeechPacket) {
 	h.r.Notify(ctx, &protos.ConversationUserMessage{
-		Id:        h.r.GetID(),
+		Id:        p.ContextID,
 		Message:   &protos.ConversationUserMessage_Text{Text: p.Speech},
 		Completed: false,
 		Time:      timestamppb.New(time.Now()),
 	})
 }
 func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p internal_type.EndOfSpeechPacket) {
+	if p.ContextID != h.r.GetID() {
+		return
+	}
+	if h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserSpeaking {
+		return
+	}
 	if validator.NotBlank(p.Speech) {
 		messageState := h.r.messageLifecycle.State()
-		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
+		if h.r.unclearInputWatchdog != nil &&
 			(messageState == adapter_lifecycle.MessageStateInterrupt ||
 				messageState == adapter_lifecycle.MessageStateUserIdle ||
 				messageState == adapter_lifecycle.MessageStateUserListening ||
@@ -226,48 +278,10 @@ func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p inter
 				messageState == adapter_lifecycle.MessageStateUserThinking) {
 			_ = h.r.messageLifecycle.UserThinking(p.ContextID)
 			h.r.unclearInputWatchdog.Stop()
-			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
-			if err != nil {
-				return
-			}
-			bargeInTrigger := internal_options.BargeInTriggerVAD
-			if opts := h.r.GetOptions(); len(opts) > 0 {
-				if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
-					bargeInTrigger = value
-				} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
-					bargeInTrigger = value
-				}
-			}
-			interruptionSource := internal_type.InterruptionSourceVad
-			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
-			if bargeInTrigger == internal_options.BargeInTriggerWord {
-				interruptionSource = internal_type.InterruptionSourceWord
-				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
-			}
-			h.r.OnPacket(ctx,
-				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
-				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
-			)
-			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-				ContextID:         newContextID,
-				PreviousContextID: oldContextID,
-				Reason:            "interrupted",
-				Source:            "requestor",
-				Time:              time.Now(),
-			})
-			h.r.OnPacket(ctx,
-				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
-				internal_type.LLMInterruptPacket{ContextID: oldContextID},
-			)
-			utils.Go(ctx, func() {
-				h.r.Notify(ctx, &protos.ConversationInterruption{
-					Type: interruptionType,
-					Time: timestamppb.Now(),
-				})
-			})
-			p.ContextID = newContextID
 		}
-		_ = h.r.messageLifecycle.UserFinished(p.ContextID)
+		if err := h.r.messageLifecycle.UserFinished(p.ContextID); err != nil {
+			return
+		}
 	}
 	if err := h.callInputNormalizer(ctx, p); err != nil {
 		h.r.OnPacket(ctx, internal_type.UserInputPacket{
@@ -277,67 +291,26 @@ func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p inter
 	}
 }
 func (h requestorDispatchHandler) HandleUserInput(ctx context.Context, p internal_type.UserInputPacket) {
-	if validator.NotBlank(p.Text) {
-		if p.ContextID == "" {
-			p.ContextID = h.r.GetID()
-		}
-		messageState := h.r.messageLifecycle.State()
-		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
-			(messageState == adapter_lifecycle.MessageStateInterrupt ||
-				messageState == adapter_lifecycle.MessageStateUserIdle ||
-				messageState == adapter_lifecycle.MessageStateUserListening ||
-				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
-				messageState == adapter_lifecycle.MessageStateUserThinking) {
-			h.r.unclearInputWatchdog.Stop()
-			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
-			if err != nil {
-				return
-			}
-			bargeInTrigger := internal_options.BargeInTriggerVAD
-			if opts := h.r.GetOptions(); len(opts) > 0 {
-				if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
-					bargeInTrigger = value
-				} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
-					bargeInTrigger = value
-				}
-			}
-			interruptionSource := internal_type.InterruptionSourceVad
-			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
-			if bargeInTrigger == internal_options.BargeInTriggerWord {
-				interruptionSource = internal_type.InterruptionSourceWord
-				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
-			}
-			h.r.OnPacket(ctx,
-				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
-				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
-			)
-			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-				ContextID:         newContextID,
-				PreviousContextID: oldContextID,
-				Reason:            "interrupted",
-				Source:            "requestor",
-				Time:              time.Now(),
-			})
-			h.r.OnPacket(ctx,
-				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
-				internal_type.LLMInterruptPacket{ContextID: oldContextID},
-			)
-			utils.Go(ctx, func() {
-				h.r.Notify(ctx, &protos.ConversationInterruption{
-					Type: interruptionType,
-					Time: timestamppb.Now(),
-				})
-			})
-			p.ContextID = newContextID
-		}
+	if !validator.NotBlank(p.Text) {
+		return
+	}
+	if p.ContextID == "" {
+		p.ContextID = h.r.GetID()
+	}
+	if p.ContextID != h.r.GetID() {
+		return
+	}
+	if h.r.unclearInputWatchdog != nil {
+		h.r.unclearInputWatchdog.Stop()
 	}
 	h.r.OnPacket(ctx, internal_type.StopIdleTimeoutPacket{
 		ContextID: h.r.GetID(), ResetCount: true,
 	})
 
-	contextID := h.r.GetID()
-	p.ContextID = contextID
-	_ = h.r.messageLifecycle.UserFinished(contextID)
+	contextID := p.ContextID
+	if err := h.r.messageLifecycle.UserFinished(contextID); err != nil {
+		return
+	}
 	h.r.OnPacket(ctx,
 		internal_type.MessageCreatePacket{ContextID: contextID, MessageRole: "user", Text: p.Text},
 		internal_type.ObservabilityMetadataRecordPacket{
@@ -394,6 +367,37 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 	if p.ContextID == "" {
 		p.ContextID = h.r.GetID()
 	}
+	if p.ContextID != h.r.GetID() {
+		messageState := h.r.messageLifecycle.State()
+		switch p.Source {
+		case internal_type.InterruptionSourceWord:
+			switch messageState {
+			case adapter_lifecycle.MessageStateInterrupt,
+				adapter_lifecycle.MessageStateUserIdle,
+				adapter_lifecycle.MessageStateUserListening,
+				adapter_lifecycle.MessageStateUserSpeaking,
+				adapter_lifecycle.MessageStateUserThinking:
+				p.ContextID = h.r.GetID()
+			default:
+				return
+			}
+		case internal_type.InterruptionSourceVad:
+			if p.Event != internal_type.InterruptionEventEnd {
+				return
+			}
+			switch messageState {
+			case adapter_lifecycle.MessageStateInterrupt,
+				adapter_lifecycle.MessageStateUserIdle,
+				adapter_lifecycle.MessageStateUserListening,
+				adapter_lifecycle.MessageStateUserSpeaking:
+				p.ContextID = h.r.GetID()
+			default:
+				return
+			}
+		default:
+			return
+		}
+	}
 
 	bargeInTrigger := internal_options.BargeInTriggerVAD
 	if opts := h.r.GetOptions(); len(opts) > 0 {
@@ -413,8 +417,47 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 				return
 			}
 
-			if h.r.messageLifecycle.BeginInterrupt(p.ContextID) == nil {
-				_ = h.r.messageLifecycle.UserIdle(p.ContextID)
+			messageState := h.r.messageLifecycle.State()
+			startedNewTurn := false
+			switch messageState {
+			case adapter_lifecycle.MessageStateInterrupt,
+				adapter_lifecycle.MessageStateUserIdle,
+				adapter_lifecycle.MessageStateUserListening,
+				adapter_lifecycle.MessageStateUserSpeaking,
+				adapter_lifecycle.MessageStateUserThinking:
+			default:
+				oldContextID, newContextID, err := h.r.messageLifecycle.RotateContext()
+				if err != nil {
+					return
+				}
+				h.r.OnPacket(ctx,
+					internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+					internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceVad},
+				)
+				h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+					ContextID:         newContextID,
+					PreviousContextID: oldContextID,
+					Reason:            "interrupted",
+					Source:            "requestor",
+					Time:              time.Now(),
+				})
+				h.r.OnPacket(ctx,
+					internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+					internal_type.LLMInterruptPacket{ContextID: oldContextID},
+				)
+				utils.Go(ctx, func() {
+					h.r.Notify(ctx, &protos.ConversationInterruption{
+						Type: protos.ConversationInterruption_INTERRUPTION_TYPE_VAD,
+						Time: timestamppb.Now(),
+					})
+				})
+				p.ContextID = newContextID
+				startedNewTurn = true
+			}
+			if startedNewTurn ||
+				messageState == adapter_lifecycle.MessageStateInterrupt ||
+				messageState == adapter_lifecycle.MessageStateUserIdle {
+				_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
 			}
 			h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: p.ContextID})
 		case internal_type.InterruptionEventEnd:
@@ -425,7 +468,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 			h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: p.ContextID})
 			if h.r.unclearInputWatchdog != nil &&
 				p.ContextID == h.r.GetID() &&
-				h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserIdle &&
+				h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserSpeaking &&
 				h.r.messageLifecycle.UserListening(p.ContextID) == nil {
 				if behavior, err := h.r.deploymentBehavior(); err == nil &&
 					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
@@ -435,25 +478,99 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 			}
 		}
 	case internal_type.InterruptionSourceWord:
+		if h.r.GetMode().Text() {
+			switch h.r.messageLifecycle.State() {
+			case adapter_lifecycle.MessageStateInterrupt,
+				adapter_lifecycle.MessageStateUserIdle,
+				adapter_lifecycle.MessageStateUserListening,
+				adapter_lifecycle.MessageStateUserSpeaking,
+				adapter_lifecycle.MessageStateUserThinking:
+			default:
+				oldContextID, newContextID, err := h.r.messageLifecycle.RotateContext()
+				if err != nil {
+					return
+				}
+				h.r.OnPacket(ctx,
+					internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+					internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
+				)
+				h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+					ContextID:         newContextID,
+					PreviousContextID: oldContextID,
+					Reason:            "interrupted",
+					Source:            "requestor",
+					Time:              time.Now(),
+				})
+				h.r.OnPacket(ctx,
+					internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+					internal_type.LLMInterruptPacket{ContextID: oldContextID},
+				)
+				utils.Go(ctx, func() {
+					h.r.Notify(ctx, &protos.ConversationInterruption{
+						Type: protos.ConversationInterruption_INTERRUPTION_TYPE_WORD,
+						Time: timestamppb.Now(),
+					})
+				})
+				p.ContextID = newContextID
+			}
+			_ = h.r.messageLifecycle.UserListening(p.ContextID)
+			return
+		}
+
 		if bargeInTrigger != internal_options.BargeInTriggerWord {
 			return
 		}
 
-		if h.r.unclearInputWatchdog != nil {
-			messageState := h.r.messageLifecycle.State()
-			if h.r.messageLifecycle.BeginInterrupt(p.ContextID) == nil {
-				_ = h.r.messageLifecycle.UserListening(p.ContextID)
-				if behavior, err := h.r.deploymentBehavior(); err == nil &&
-					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
-					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
-					h.r.unclearInputWatchdog.Start(p.ContextID, timeout)
-				}
+		messageState := h.r.messageLifecycle.State()
+		switch messageState {
+		case adapter_lifecycle.MessageStateInterrupt,
+			adapter_lifecycle.MessageStateUserIdle,
+			adapter_lifecycle.MessageStateUserListening,
+			adapter_lifecycle.MessageStateUserSpeaking,
+			adapter_lifecycle.MessageStateUserThinking:
+		default:
+			oldContextID, newContextID, err := h.r.messageLifecycle.RotateContext()
+			if err != nil {
 				return
 			}
-			if p.ContextID == h.r.GetID() &&
-				(messageState == adapter_lifecycle.MessageStateUserListening ||
-					messageState == adapter_lifecycle.MessageStateUserSpeaking ||
-					messageState == adapter_lifecycle.MessageStateUserThinking) {
+			h.r.OnPacket(ctx,
+				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
+			)
+			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+				ContextID:         newContextID,
+				PreviousContextID: oldContextID,
+				Reason:            "interrupted",
+				Source:            "requestor",
+				Time:              time.Now(),
+			})
+			h.r.OnPacket(ctx,
+				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+				internal_type.LLMInterruptPacket{ContextID: oldContextID},
+			)
+			utils.Go(ctx, func() {
+				h.r.Notify(ctx, &protos.ConversationInterruption{
+					Type: protos.ConversationInterruption_INTERRUPTION_TYPE_WORD,
+					Time: timestamppb.Now(),
+				})
+			})
+			p.ContextID = newContextID
+			if p.ContextID == h.r.GetID() && h.r.messageLifecycle.UserListening(p.ContextID) == nil {
+				if h.r.unclearInputWatchdog != nil {
+					if behavior, err := h.r.deploymentBehavior(); err == nil &&
+						validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
+						timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
+						h.r.unclearInputWatchdog.Start(p.ContextID, timeout)
+					}
+				}
+			}
+			return
+		}
+		if p.ContextID == h.r.GetID() &&
+			(messageState == adapter_lifecycle.MessageStateUserListening ||
+				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+				messageState == adapter_lifecycle.MessageStateUserThinking) {
+			if h.r.unclearInputWatchdog != nil {
 				if behavior, err := h.r.deploymentBehavior(); err == nil &&
 					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
 					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
@@ -1082,7 +1199,7 @@ func (h requestorDispatchHandler) HandleIdleTimeoutExpired(ctx context.Context, 
 	if err := h.r.messageLifecycle.AssistantPrompted(oldContextID); err != nil {
 		return
 	}
-	newContextID, err := h.r.messageLifecycle.RotateContext()
+	_, newContextID, err := h.r.messageLifecycle.RotateContext()
 	if err != nil {
 		return
 	}
@@ -1149,7 +1266,7 @@ func (h requestorDispatchHandler) HandleUnclearInputExpired(ctx context.Context,
 	if err := h.r.messageLifecycle.UserPrompted(oldContextID); err != nil {
 		return
 	}
-	_, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
+	_, newContextID, err := h.r.messageLifecycle.RotateContext()
 	if err != nil {
 		return
 	}

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -124,8 +124,15 @@ func (h requestorDispatchHandler) HandleVadSpeechActivity(ctx context.Context, v
 	}
 }
 func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p internal_type.SpeechToTextPacket) {
-	p.ContextID = h.r.GetID()
-	if p.Interim && h.r.unclearInputWatchdog != nil {
+	if p.ContextID == "" {
+		p.ContextID = h.r.GetID()
+	}
+	messageState := h.r.messageLifecycle.State()
+	if p.Interim && h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
+		(messageState == adapter_lifecycle.MessageStateUserListening ||
+			messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+			messageState == adapter_lifecycle.MessageStateUserThinking) {
+		_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
 		if behavior, err := h.r.deploymentBehavior(); err == nil &&
 			validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
 			h.r.unclearInputWatchdog.Extend(
@@ -134,8 +141,57 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 			)
 		}
 	}
-	if !p.Interim && h.r.unclearInputWatchdog != nil && validator.NotBlank(p.Script) {
-		h.r.unclearInputWatchdog.Stop()
+	if !p.Interim && validator.NotBlank(p.Script) {
+		messageState = h.r.messageLifecycle.State()
+		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
+			(messageState == adapter_lifecycle.MessageStateInterrupt ||
+				messageState == adapter_lifecycle.MessageStateUserIdle ||
+				messageState == adapter_lifecycle.MessageStateUserListening ||
+				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+				messageState == adapter_lifecycle.MessageStateUserThinking) {
+			h.r.unclearInputWatchdog.Stop()
+			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
+			if err != nil {
+				return
+			}
+			bargeInTrigger := internal_options.BargeInTriggerVAD
+			if opts := h.r.GetOptions(); len(opts) > 0 {
+				if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				}
+			}
+			interruptionSource := internal_type.InterruptionSourceVad
+			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
+			if bargeInTrigger == internal_options.BargeInTriggerWord {
+				interruptionSource = internal_type.InterruptionSourceWord
+				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
+			}
+			h.r.OnPacket(ctx,
+				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
+			)
+			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+				ContextID:         newContextID,
+				PreviousContextID: oldContextID,
+				Reason:            "interrupted",
+				Source:            "requestor",
+				Time:              time.Now(),
+			})
+			h.r.OnPacket(ctx,
+				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+				internal_type.LLMInterruptPacket{ContextID: oldContextID},
+			)
+			utils.Go(ctx, func() {
+				h.r.Notify(ctx, &protos.ConversationInterruption{
+					Type: interruptionType,
+					Time: timestamppb.Now(),
+				})
+			})
+			p.ContextID = newContextID
+		}
+		_ = h.r.messageLifecycle.UserFinished(p.ContextID)
 	}
 	if h.r.endOfSpeechExecutor != nil {
 		_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
@@ -160,8 +216,58 @@ func (h requestorDispatchHandler) HandleInterimEndOfSpeech(ctx context.Context, 
 	})
 }
 func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p internal_type.EndOfSpeechPacket) {
-	if h.r.unclearInputWatchdog != nil && validator.NotBlank(p.Speech) {
-		h.r.unclearInputWatchdog.Stop()
+	if validator.NotBlank(p.Speech) {
+		messageState := h.r.messageLifecycle.State()
+		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
+			(messageState == adapter_lifecycle.MessageStateInterrupt ||
+				messageState == adapter_lifecycle.MessageStateUserIdle ||
+				messageState == adapter_lifecycle.MessageStateUserListening ||
+				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+				messageState == adapter_lifecycle.MessageStateUserThinking) {
+			_ = h.r.messageLifecycle.UserThinking(p.ContextID)
+			h.r.unclearInputWatchdog.Stop()
+			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
+			if err != nil {
+				return
+			}
+			bargeInTrigger := internal_options.BargeInTriggerVAD
+			if opts := h.r.GetOptions(); len(opts) > 0 {
+				if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				}
+			}
+			interruptionSource := internal_type.InterruptionSourceVad
+			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
+			if bargeInTrigger == internal_options.BargeInTriggerWord {
+				interruptionSource = internal_type.InterruptionSourceWord
+				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
+			}
+			h.r.OnPacket(ctx,
+				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
+			)
+			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+				ContextID:         newContextID,
+				PreviousContextID: oldContextID,
+				Reason:            "interrupted",
+				Source:            "requestor",
+				Time:              time.Now(),
+			})
+			h.r.OnPacket(ctx,
+				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+				internal_type.LLMInterruptPacket{ContextID: oldContextID},
+			)
+			utils.Go(ctx, func() {
+				h.r.Notify(ctx, &protos.ConversationInterruption{
+					Type: interruptionType,
+					Time: timestamppb.Now(),
+				})
+			})
+			p.ContextID = newContextID
+		}
+		_ = h.r.messageLifecycle.UserFinished(p.ContextID)
 	}
 	if err := h.callInputNormalizer(ctx, p); err != nil {
 		h.r.OnPacket(ctx, internal_type.UserInputPacket{
@@ -171,35 +277,67 @@ func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p inter
 	}
 }
 func (h requestorDispatchHandler) HandleUserInput(ctx context.Context, p internal_type.UserInputPacket) {
-	if h.r.unclearInputWatchdog != nil && validator.NotBlank(p.Text) {
-		h.r.unclearInputWatchdog.Stop()
+	if validator.NotBlank(p.Text) {
+		if p.ContextID == "" {
+			p.ContextID = h.r.GetID()
+		}
+		messageState := h.r.messageLifecycle.State()
+		if h.r.unclearInputWatchdog != nil && p.ContextID == h.r.GetID() &&
+			(messageState == adapter_lifecycle.MessageStateInterrupt ||
+				messageState == adapter_lifecycle.MessageStateUserIdle ||
+				messageState == adapter_lifecycle.MessageStateUserListening ||
+				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+				messageState == adapter_lifecycle.MessageStateUserThinking) {
+			h.r.unclearInputWatchdog.Stop()
+			oldContextID, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
+			if err != nil {
+				return
+			}
+			bargeInTrigger := internal_options.BargeInTriggerVAD
+			if opts := h.r.GetOptions(); len(opts) > 0 {
+				if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
+					bargeInTrigger = value
+				}
+			}
+			interruptionSource := internal_type.InterruptionSourceVad
+			interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
+			if bargeInTrigger == internal_options.BargeInTriggerWord {
+				interruptionSource = internal_type.InterruptionSourceWord
+				interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
+			}
+			h.r.OnPacket(ctx,
+				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
+			)
+			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+				ContextID:         newContextID,
+				PreviousContextID: oldContextID,
+				Reason:            "interrupted",
+				Source:            "requestor",
+				Time:              time.Now(),
+			})
+			h.r.OnPacket(ctx,
+				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+				internal_type.LLMInterruptPacket{ContextID: oldContextID},
+			)
+			utils.Go(ctx, func() {
+				h.r.Notify(ctx, &protos.ConversationInterruption{
+					Type: interruptionType,
+					Time: timestamppb.Now(),
+				})
+			})
+			p.ContextID = newContextID
+		}
 	}
 	h.r.OnPacket(ctx, internal_type.StopIdleTimeoutPacket{
 		ContextID: h.r.GetID(), ResetCount: true,
 	})
 
-	if err := h.r.Transition(LLMGenerating); err != nil {
-		h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
-			ContextID: h.r.GetID(),
-			Scope:     internal_type.ObservabilityRecordScopeUserMessage,
-			Record: observability.RecordLog{
-				Level:   observability.LevelError,
-				Message: "Message state transition failed; check target_state and current turn state",
-				Attributes: observability.Attributes{
-					"component":    observability.ComponentTurn.String(),
-					"operation":    "transition",
-					"context_id":   h.r.GetID(),
-					"message_role": string(observability.MessageRoleUser),
-					"target_state": LLMGenerating.String(),
-					"error":        err.Error(),
-					"error_type":   fmt.Sprintf("%T", err),
-				},
-			},
-		})
-	}
-
 	contextID := h.r.GetID()
 	p.ContextID = contextID
+	_ = h.r.messageLifecycle.UserFinished(contextID)
 	h.r.OnPacket(ctx,
 		internal_type.MessageCreatePacket{ContextID: contextID, MessageRole: "user", Text: p.Text},
 		internal_type.ObservabilityMetadataRecordPacket{
@@ -236,6 +374,7 @@ func (h requestorDispatchHandler) HandleUserInput(ctx context.Context, p interna
 	)
 
 	if h.r.assistantExecutor != nil {
+		_ = h.r.messageLifecycle.AssistantGenerating(contextID)
 		utils.Go(ctx, func() {
 			if err := h.r.assistantExecutor.Execute(ctx, h.r, p); err != nil {
 				h.r.OnPacket(ctx, internal_type.LLMErrorPacket{ContextID: contextID, Error: err})
@@ -258,7 +397,9 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 
 	bargeInTrigger := internal_options.BargeInTriggerVAD
 	if opts := h.r.GetOptions(); len(opts) > 0 {
-		if value, err := opts.GetString(internal_options.MicrophoneVADOptionBargeInTrigger); err == nil {
+		if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
+			bargeInTrigger = value
+		} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
 			bargeInTrigger = value
 		}
 	}
@@ -272,71 +413,54 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 				return
 			}
 
-			h.r.OnPacket(ctx,
-				internal_type.StopIdleTimeoutPacket{ContextID: p.ContextID},
-				internal_type.EndOfSpeechInterruptionPacket{ContextID: p.ContextID, Source: internal_type.InterruptionSourceVad},
-			)
-			if err := h.r.Transition(Interrupted); err != nil {
-				return
+			if h.r.messageLifecycle.BeginInterrupt(p.ContextID) == nil {
+				_ = h.r.messageLifecycle.UserIdle(p.ContextID)
 			}
-			h.r.OnPacket(ctx,
-				internal_type.TextToSpeechInterruptPacket{ContextID: p.ContextID, StartAt: p.StartAt, EndAt: p.EndAt},
-				internal_type.LLMInterruptPacket{ContextID: p.ContextID},
-			)
-			h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: h.r.GetID()})
-			if h.r.unclearInputWatchdog != nil {
-				if behavior, err := h.r.deploymentBehavior(); err == nil &&
-					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
-					h.r.unclearInputWatchdog.Start(
-						h.r.GetID(),
-						time.Duration(*behavior.UnclearInputTimeout*float64(time.Second)),
-					)
-				}
-			}
-			utils.Go(ctx, func() {
-				h.r.Notify(ctx, &protos.ConversationInterruption{
-					Type: protos.ConversationInterruption_INTERRUPTION_TYPE_VAD,
-					Time: timestamppb.Now(),
-				})
-			})
+			h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: p.ContextID})
 		case internal_type.InterruptionEventEnd:
 			if bargeInTrigger == internal_options.BargeInTriggerWord {
 				h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: p.ContextID})
 				return
 			}
-			h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: h.r.GetID()})
+			h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: p.ContextID})
+			if h.r.unclearInputWatchdog != nil &&
+				p.ContextID == h.r.GetID() &&
+				h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserIdle &&
+				h.r.messageLifecycle.UserListening(p.ContextID) == nil {
+				if behavior, err := h.r.deploymentBehavior(); err == nil &&
+					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
+					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
+					h.r.unclearInputWatchdog.Start(p.ContextID, timeout)
+				}
+			}
 		}
 	case internal_type.InterruptionSourceWord:
 		if bargeInTrigger != internal_options.BargeInTriggerWord {
 			return
 		}
 
-		h.r.OnPacket(ctx,
-			internal_type.StopIdleTimeoutPacket{ContextID: p.ContextID},
-			internal_type.EndOfSpeechInterruptionPacket{ContextID: p.ContextID, Source: internal_type.InterruptionSourceWord},
-		)
-		if err := h.r.Transition(Interrupted); err != nil {
-			return
-		}
-		h.r.OnPacket(ctx,
-			internal_type.TextToSpeechInterruptPacket{ContextID: p.ContextID, StartAt: p.StartAt, EndAt: p.EndAt},
-			internal_type.LLMInterruptPacket{ContextID: p.ContextID},
-		)
 		if h.r.unclearInputWatchdog != nil {
-			if behavior, err := h.r.deploymentBehavior(); err == nil &&
-				validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
-				h.r.unclearInputWatchdog.Start(
-					h.r.GetID(),
-					time.Duration(*behavior.UnclearInputTimeout*float64(time.Second)),
-				)
+			messageState := h.r.messageLifecycle.State()
+			if h.r.messageLifecycle.BeginInterrupt(p.ContextID) == nil {
+				_ = h.r.messageLifecycle.UserListening(p.ContextID)
+				if behavior, err := h.r.deploymentBehavior(); err == nil &&
+					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
+					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
+					h.r.unclearInputWatchdog.Start(p.ContextID, timeout)
+				}
+				return
+			}
+			if p.ContextID == h.r.GetID() &&
+				(messageState == adapter_lifecycle.MessageStateUserListening ||
+					messageState == adapter_lifecycle.MessageStateUserSpeaking ||
+					messageState == adapter_lifecycle.MessageStateUserThinking) {
+				if behavior, err := h.r.deploymentBehavior(); err == nil &&
+					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
+					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
+					h.r.unclearInputWatchdog.Extend(p.ContextID, timeout)
+				}
 			}
 		}
-		utils.Go(ctx, func() {
-			h.r.Notify(ctx, &protos.ConversationInterruption{
-				Type: protos.ConversationInterruption_INTERRUPTION_TYPE_WORD,
-				Time: timestamppb.Now(),
-			})
-		})
 	}
 }
 
@@ -541,26 +665,7 @@ func (h requestorDispatchHandler) HandleLLMResponseDelta(ctx context.Context, p 
 		})
 		return
 	}
-	if err := h.r.Transition(LLMGenerating); err != nil {
-		h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
-			ContextID: p.ContextID,
-			Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
-			Record: observability.RecordLog{
-				Level:   observability.LevelError,
-				Message: "Message state transition failed; check target_state and current turn state",
-				Attributes: observability.Attributes{
-					"component":    observability.ComponentLLM.String(),
-					"operation":    "transition",
-					"packet":       "LLMResponseDeltaPacket",
-					"context_id":   p.ContextID,
-					"message_role": string(observability.MessageRoleAssistant),
-					"target_state": LLMGenerating.String(),
-					"error":        err.Error(),
-					"error_type":   fmt.Sprintf("%T", err),
-				},
-			},
-		})
-	}
+	_ = h.r.messageLifecycle.AssistantGenerating(p.ContextID)
 	if h.r.outputNormalizer != nil {
 		h.r.outputNormalizer.Normalize(ctx, p)
 	} else {
@@ -581,6 +686,7 @@ func (h requestorDispatchHandler) HandleLLMResponseDone(ctx context.Context, p i
 		})
 		return
 	}
+	_ = h.r.messageLifecycle.AssistantGenerated(p.ContextID)
 	if h.r.endOfSpeechExecutor != nil {
 		if err := h.r.endOfSpeechExecutor.Execute(ctx, p); err != nil {
 			h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
@@ -601,27 +707,6 @@ func (h requestorDispatchHandler) HandleLLMResponseDone(ctx context.Context, p i
 				},
 			})
 		}
-	}
-	h.r.OnPacket(ctx, internal_type.StartIdleTimeoutPacket{ContextID: p.ContextID})
-	if err := h.r.Transition(LLMGenerated); err != nil {
-		h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
-			ContextID: p.ContextID,
-			Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
-			Record: observability.RecordLog{
-				Level:   observability.LevelError,
-				Message: "Message state transition failed; check target_state and current turn state",
-				Attributes: observability.Attributes{
-					"component":    observability.ComponentLLM.String(),
-					"operation":    "transition",
-					"packet":       "LLMResponseDonePacket",
-					"context_id":   p.ContextID,
-					"message_role": string(observability.MessageRoleAssistant),
-					"target_state": LLMGenerated.String(),
-					"error":        err.Error(),
-					"error_type":   fmt.Sprintf("%T", err),
-				},
-			},
-		})
 	}
 	h.r.OnPacket(ctx,
 		internal_type.MessageCreatePacket{ContextID: p.ContextID, MessageRole: "assistant", Text: p.Text},
@@ -676,7 +761,6 @@ func (h requestorDispatchHandler) HandleError(ctx context.Context, p internal_ty
 					"message": p.ErrMessage(),
 				}),
 			})
-		h.r.Transition(LLMGenerated)
 	case internal_type.SpeechToTextErrorPacket:
 		h.r.OnPacket(ctx,
 			internal_type.ObservabilityMetricRecordPacket{
@@ -834,27 +918,7 @@ func (h requestorDispatchHandler) HandleError(ctx context.Context, p internal_ty
 
 }
 func (h requestorDispatchHandler) HandleInjectMessage(ctx context.Context, p internal_type.InjectMessagePacket) {
-	if err := h.r.Transition(LLMGenerating); err != nil {
-		h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
-			ContextID: p.ContextID,
-			Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
-			Record: observability.RecordLog{
-				Level:   observability.LevelError,
-				Message: "Message state transition failed; check target_state and current turn state",
-				Attributes: observability.Attributes{
-					"component":    observability.ComponentLLM.String(),
-					"operation":    "transition",
-					"packet":       "InjectMessagePacket",
-					"context_id":   h.r.GetID(),
-					"message_role": string(observability.MessageRoleAssistant),
-					"target_state": LLMGenerating.String(),
-					"error":        err.Error(),
-					"error_type":   fmt.Sprintf("%T", err),
-				},
-			},
-		})
-	}
-
+	_ = h.r.messageLifecycle.AssistantGenerating(h.r.GetID())
 	if h.r.assistantExecutor != nil {
 		utils.Go(ctx, func() {
 			if err := h.r.assistantExecutor.Execute(ctx, h.r, p); err != nil {
@@ -895,26 +959,6 @@ func (h requestorDispatchHandler) HandleInjectMessage(ctx context.Context, p int
 			},
 		)
 		h.r.outputNormalizer.Normalize(ctx, internal_type.InjectMessagePacket{ContextID: contextID, Text: p.Text})
-		if err := h.r.Transition(LLMGenerated); err != nil {
-			h.r.OnPacket(ctx, internal_type.ObservabilityLogRecordPacket{
-				ContextID: contextID,
-				Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
-				Record: observability.RecordLog{
-					Level:   observability.LevelError,
-					Message: "Message state transition failed; check target_state and current turn state",
-					Attributes: observability.Attributes{
-						"component":    observability.ComponentLLM.String(),
-						"operation":    "transition",
-						"packet":       "InjectMessagePacket",
-						"context_id":   contextID,
-						"message_role": string(observability.MessageRoleAssistant),
-						"target_state": LLMGenerated.String(),
-						"error":        err.Error(),
-						"error_type":   fmt.Sprintf("%T", err),
-					},
-				},
-			})
-		}
 	} else {
 		h.r.OnPacket(ctx,
 			internal_type.LLMResponseDeltaPacket{ContextID: contextID, Text: p.Text},
@@ -923,6 +967,13 @@ func (h requestorDispatchHandler) HandleInjectMessage(ctx context.Context, p int
 	}
 }
 func (h requestorDispatchHandler) HandleStartIdleTimeout(ctx context.Context, p internal_type.StartIdleTimeoutPacket) {
+	if p.ContextID != h.r.GetID() {
+		return
+	}
+	if h.r.messageLifecycle.State() != adapter_lifecycle.MessageStateAssistantIdle {
+		return
+	}
+
 	behavior, err := h.r.deploymentBehavior()
 	if err != nil {
 		return
@@ -943,6 +994,13 @@ func (h requestorDispatchHandler) HandleStopIdleTimeout(ctx context.Context, p i
 }
 
 func (h requestorDispatchHandler) HandleIdleTimeoutExpired(ctx context.Context, p internal_type.IdleTimeoutExpiredPacket) {
+	if p.ContextID != h.r.GetID() {
+		return
+	}
+	if h.r.messageLifecycle.State() != adapter_lifecycle.MessageStateAssistantIdle {
+		return
+	}
+
 	behavior, err := h.r.deploymentBehavior()
 	if err != nil {
 		return
@@ -1020,14 +1078,27 @@ func (h requestorDispatchHandler) HandleIdleTimeoutExpired(ctx context.Context, 
 	if validator.NonNil(behavior.IdleTimeoutBackoff) {
 		maxCount = int(*behavior.IdleTimeoutBackoff)
 	}
-	h.r.Transition(Interrupted)
-	contextID := h.r.GetID()
+	oldContextID := h.r.GetID()
+	if err := h.r.messageLifecycle.AssistantPrompted(oldContextID); err != nil {
+		return
+	}
+	newContextID, err := h.r.messageLifecycle.RotateContext()
+	if err != nil {
+		return
+	}
+	h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+		ContextID:         newContextID,
+		PreviousContextID: oldContextID,
+		Reason:            "interrupted",
+		Source:            "requestor",
+		Time:              time.Now(),
+	})
 
 	_ = h.r.OnPacket(ctx,
-		internal_type.TextToSpeechInterruptPacket{ContextID: contextID},
-		internal_type.InjectMessagePacket{ContextID: contextID, Text: timeoutContent},
+		internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+		internal_type.InjectMessagePacket{ContextID: newContextID, Text: timeoutContent},
 		internal_type.ObservabilityEventRecordPacket{
-			ContextID: contextID,
+			ContextID: newContextID,
 			Scope:     internal_type.ObservabilityRecordScopeConversation,
 			Record: observability.NewConversationEventRecord(observability.ConversationAgentStateChanged, observability.Attributes{
 				"type":      "idle_timeout",
@@ -1035,12 +1106,19 @@ func (h requestorDispatchHandler) HandleIdleTimeoutExpired(ctx context.Context, 
 				"max_count": fmt.Sprintf("%d", maxCount),
 			}),
 		},
-		internal_type.StartIdleTimeoutPacket{ContextID: contextID},
 	)
 }
 
 func (h requestorDispatchHandler) HandleUnclearInputExpired(ctx context.Context, p internal_type.UnclearInputExpiredPacket) {
 	if p.ContextID != h.r.GetID() {
+		return
+	}
+	messageState := h.r.messageLifecycle.State()
+	if messageState != adapter_lifecycle.MessageStateInterrupt &&
+		messageState != adapter_lifecycle.MessageStateUserIdle &&
+		messageState != adapter_lifecycle.MessageStateUserListening &&
+		messageState != adapter_lifecycle.MessageStateUserSpeaking &&
+		messageState != adapter_lifecycle.MessageStateUserThinking {
 		return
 	}
 
@@ -1053,18 +1131,84 @@ func (h requestorDispatchHandler) HandleUnclearInputExpired(ctx context.Context,
 		return
 	}
 
-	contextID := h.r.GetID()
+	oldContextID := h.r.GetID()
+	bargeInTrigger := internal_options.BargeInTriggerVAD
+	if opts := h.r.GetOptions(); len(opts) > 0 {
+		if value, err := opts.GetString(internal_options.MicrophoneOptionBargeInTrigger); err == nil {
+			bargeInTrigger = value
+		} else if value, err := opts.GetString(internal_options.MicrophoneLegacyVADOptionBargeInTrigger); err == nil {
+			bargeInTrigger = value
+		}
+	}
+	interruptionSource := internal_type.InterruptionSourceVad
+	interruptionType := protos.ConversationInterruption_INTERRUPTION_TYPE_VAD
+	if bargeInTrigger == internal_options.BargeInTriggerWord {
+		interruptionSource = internal_type.InterruptionSourceWord
+		interruptionType = protos.ConversationInterruption_INTERRUPTION_TYPE_WORD
+	}
+	if err := h.r.messageLifecycle.UserPrompted(oldContextID); err != nil {
+		return
+	}
+	_, newContextID, err := h.r.messageLifecycle.CommitInterrupt()
+	if err != nil {
+		return
+	}
 	h.r.OnPacket(ctx,
-		internal_type.TextToSpeechInterruptPacket{ContextID: contextID},
-		internal_type.InjectMessagePacket{ContextID: contextID, Text: *behavior.UnclearInputMessage},
+		internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
+		internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
+	)
+	h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
+		ContextID:         newContextID,
+		PreviousContextID: oldContextID,
+		Reason:            "interrupted",
+		Source:            "requestor",
+		Time:              time.Now(),
+	})
+	h.r.OnPacket(ctx,
+		internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
+		internal_type.LLMInterruptPacket{ContextID: oldContextID},
+	)
+	utils.Go(ctx, func() {
+		h.r.Notify(ctx, &protos.ConversationInterruption{
+			Type: interruptionType,
+			Time: timestamppb.Now(),
+		})
+	})
+
+	if h.r.GetMode().Audio() {
+		h.r.OnPacket(ctx,
+			internal_type.DispatchPolicyPacket{
+				ContextID: newContextID,
+				Policy: internal_type.DispatchPolicy{
+					Target: internal_type.PacketNameUserAudioReceived,
+					Action: internal_type.DispatchActionIgnore,
+				},
+			},
+			internal_type.DispatchPolicyPacket{
+				ContextID: newContextID,
+				Policy: internal_type.DispatchPolicy{
+					Target: internal_type.PacketNameUserTextReceived,
+					Action: internal_type.DispatchActionIgnore,
+				},
+			},
+			internal_type.DispatchPolicyPacket{
+				ContextID: newContextID,
+				Policy: internal_type.DispatchPolicy{
+					Target: internal_type.PacketNameInterruptionDetected,
+					Action: internal_type.DispatchActionIgnore,
+				},
+			},
+		)
+	}
+	h.r.OnPacket(ctx,
+		internal_type.InjectMessagePacket{ContextID: newContextID, Text: *behavior.UnclearInputMessage},
 		internal_type.ObservabilityEventRecordPacket{
-			ContextID: contextID,
+			ContextID: newContextID,
 			Scope:     internal_type.ObservabilityRecordScopeConversation,
 			Record: observability.NewConversationEventRecord(observability.ConversationAgentStateChanged, observability.Attributes{
 				"type": "unclear_input",
 			}),
 		},
-		internal_type.StartIdleTimeoutPacket{ContextID: contextID},
 	)
 }
 
@@ -1132,6 +1276,7 @@ func (h requestorDispatchHandler) HandleTextToSpeechText(ctx context.Context, p 
 		})
 		return
 	}
+	_ = h.r.messageLifecycle.AssistantSpeaking(p.ContextID)
 
 	if h.r.textToSpeechTransformer != nil && h.r.GetMode().Audio() {
 		if h.r.ttsCompletionWatchdog != nil {
@@ -1167,8 +1312,10 @@ func (h requestorDispatchHandler) HandleTextToSpeechDone(ctx context.Context, p 
 	if p.ContextID != h.r.GetID() {
 		return
 	}
+	_ = h.r.messageLifecycle.AssistantGenerated(p.ContextID)
 
 	if h.r.textToSpeechTransformer != nil && h.r.GetMode().Audio() {
+		_ = h.r.messageLifecycle.AssistantSpeaking(p.ContextID)
 		if h.r.ttsCompletionWatchdog != nil {
 			h.r.ttsCompletionWatchdog.StartFromText(p.ContextID, p.Text)
 		}
@@ -1197,6 +1344,12 @@ func (h requestorDispatchHandler) HandleTextToSpeechDone(ctx context.Context, p 
 		Time: timestamppb.Now(), Id: p.ContextID, Completed: true,
 		Message: &protos.ConversationAssistantMessage_Text{Text: p.Text},
 	})
+	if h.r.textToSpeechTransformer == nil || !h.r.GetMode().Audio() {
+		if h.r.messageLifecycle.AssistantFinished(p.ContextID) == nil &&
+			h.r.messageLifecycle.AssistantIdle(p.ContextID) == nil {
+			h.r.OnPacket(ctx, internal_type.StartIdleTimeoutPacket{ContextID: p.ContextID})
+		}
+	}
 }
 func (h requestorDispatchHandler) HandleTextToSpeechAudio(ctx context.Context, p internal_type.TextToSpeechAudioPacket) {
 	if h.r.GetMode().Audio() {
@@ -1231,6 +1384,7 @@ func (h requestorDispatchHandler) HandleTextToSpeechAudio(ctx context.Context, p
 			})
 		return
 	}
+	_ = h.r.messageLifecycle.AssistantSpeaking(p.ContextID)
 	if err := h.r.Notify(ctx, &protos.ConversationAssistantMessage{
 		Time:      timestamppb.Now(),
 		Id:        p.ContextID,
@@ -1266,11 +1420,16 @@ func (h requestorDispatchHandler) HandleTextToSpeechEnd(ctx context.Context, p i
 			})
 		return
 	}
+	assistantIdle := h.r.messageLifecycle.AssistantFinished(p.ContextID) == nil &&
+		h.r.messageLifecycle.AssistantIdle(p.ContextID) == nil
 	h.r.Notify(ctx, &protos.ConversationAssistantMessage{
 		Time:      timestamppb.Now(),
 		Id:        p.ContextID,
 		Completed: true,
 	})
+	if assistantIdle {
+		h.r.OnPacket(ctx, internal_type.StartIdleTimeoutPacket{ContextID: p.ContextID})
+	}
 	h.r.OnPacket(ctx,
 		internal_type.DispatchPolicyPacket{
 			ContextID: p.ContextID,
@@ -2511,10 +2670,12 @@ func (h requestorDispatchHandler) HandleInitializeBehavior(ctx context.Context, 
 		})
 		return
 	}
+	greetingInjected := false
 	if validator.NonNil(behavior.Greeting) {
 		greetingContent := *behavior.Greeting
 		if validator.NotBlank(greetingContent) {
 			contextID := h.r.GetID()
+			greetingInjected = true
 			if h.r.GetMode().Audio() && validator.NonNil(behavior.GreetingInterruptible) && !*behavior.GreetingInterruptible {
 				_ = h.r.OnPacket(ctx,
 					internal_type.DispatchPolicyPacket{
@@ -2554,7 +2715,7 @@ func (h requestorDispatchHandler) HandleInitializeBehavior(ctx context.Context, 
 			)
 		}
 	}
-	if validator.NonNil(behavior.IdleTimeout) && *behavior.IdleTimeout > 0 {
+	if !greetingInjected && validator.NonNil(behavior.IdleTimeout) && *behavior.IdleTimeout > 0 {
 		_ = h.r.OnPacket(ctx, internal_type.StartIdleTimeoutPacket{ContextID: h.r.GetID()})
 	}
 	if validator.NonNil(behavior.MaxSessionDuration) && *behavior.MaxSessionDuration > 0 {

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -50,8 +50,7 @@ func (h requestorDispatchHandler) HandleUserText(ctx context.Context, vl interna
 	}
 
 	switch h.r.messageLifecycle.State() {
-	case adapter_lifecycle.MessageStateInterrupt,
-		adapter_lifecycle.MessageStateUserIdle,
+	case adapter_lifecycle.MessageStateUserIdle,
 		adapter_lifecycle.MessageStateUserListening,
 		adapter_lifecycle.MessageStateUserSpeaking,
 		adapter_lifecycle.MessageStateUserThinking:
@@ -63,15 +62,13 @@ func (h requestorDispatchHandler) HandleUserText(ctx context.Context, vl interna
 		h.r.OnPacket(ctx,
 			internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 			internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
-		)
-		h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-			ContextID:         newContextID,
-			PreviousContextID: oldContextID,
-			Reason:            "interrupted",
-			Source:            "requestor",
-			Time:              time.Now(),
-		})
-		h.r.OnPacket(ctx,
+			internal_type.TurnChangePacket{
+				ContextID:         newContextID,
+				PreviousContextID: oldContextID,
+				Reason:            "interrupted",
+				Source:            "requestor",
+				Time:              time.Now(),
+			},
 			internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 			internal_type.LLMInterruptPacket{ContextID: oldContextID},
 		)
@@ -153,11 +150,6 @@ func (h requestorDispatchHandler) HandleDenoisedAudio(ctx context.Context, vl in
 func (h requestorDispatchHandler) HandleVadAudio(ctx context.Context, vl internal_type.VadAudioPacket) {
 	_ = h.r.vadExecutor.Execute(ctx, internal_type.UserAudioReceivedPacket{ContextID: vl.ContextID, Audio: vl.Audio})
 }
-func (h requestorDispatchHandler) HandleVadSpeechActivity(ctx context.Context, vl internal_type.VadSpeechActivityPacket) {
-	if h.r.endOfSpeechExecutor != nil {
-		_ = h.r.endOfSpeechExecutor.Execute(ctx, vl)
-	}
-}
 func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p internal_type.SpeechToTextPacket) {
 	if !validator.NotBlank(p.Script) && !p.Interim {
 		return
@@ -168,16 +160,12 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 	p.ContextID = currentContextID
 	messageState := h.r.messageLifecycle.State()
 	if validator.NotBlank(p.Script) {
-		userTurnActive := false
 		switch messageState {
-		case adapter_lifecycle.MessageStateInterrupt,
-			adapter_lifecycle.MessageStateUserIdle,
+		case adapter_lifecycle.MessageStateUserIdle,
 			adapter_lifecycle.MessageStateUserListening,
 			adapter_lifecycle.MessageStateUserSpeaking,
 			adapter_lifecycle.MessageStateUserThinking:
-			userTurnActive = true
-		}
-		if !userTurnActive {
+		default:
 			if incomingContextID != "" && incomingContextID != currentContextID {
 				return
 			}
@@ -203,15 +191,13 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 			h.r.OnPacket(ctx,
 				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
-			)
-			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-				ContextID:         newContextID,
-				PreviousContextID: oldContextID,
-				Reason:            "interrupted",
-				Source:            "requestor",
-				Time:              time.Now(),
-			})
-			h.r.OnPacket(ctx,
+				internal_type.TurnChangePacket{
+					ContextID:         newContextID,
+					PreviousContextID: oldContextID,
+					Reason:            "interrupted",
+					Source:            "requestor",
+					Time:              time.Now(),
+				},
 				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 				internal_type.LLMInterruptPacket{ContextID: oldContextID},
 			)
@@ -227,7 +213,6 @@ func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p inte
 	if validator.NotBlank(p.Script) {
 		switch h.r.messageLifecycle.State() {
 		case adapter_lifecycle.MessageStateAssistantIdle,
-			adapter_lifecycle.MessageStateInterrupt,
 			adapter_lifecycle.MessageStateUserIdle,
 			adapter_lifecycle.MessageStateUserListening:
 			if err := h.r.messageLifecycle.UserListening(p.ContextID); err != nil {
@@ -265,19 +250,17 @@ func (h requestorDispatchHandler) HandleEndOfSpeech(ctx context.Context, p inter
 	if p.ContextID != h.r.GetID() {
 		return
 	}
-	if h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserSpeaking {
-		return
-	}
 	if validator.NotBlank(p.Speech) {
 		messageState := h.r.messageLifecycle.State()
-		if h.r.unclearInputWatchdog != nil &&
-			(messageState == adapter_lifecycle.MessageStateInterrupt ||
-				messageState == adapter_lifecycle.MessageStateUserIdle ||
-				messageState == adapter_lifecycle.MessageStateUserListening ||
-				messageState == adapter_lifecycle.MessageStateUserSpeaking ||
-				messageState == adapter_lifecycle.MessageStateUserThinking) {
+		switch messageState {
+		case adapter_lifecycle.MessageStateUserIdle,
+			adapter_lifecycle.MessageStateUserListening,
+			adapter_lifecycle.MessageStateUserSpeaking,
+			adapter_lifecycle.MessageStateUserThinking:
 			_ = h.r.messageLifecycle.UserThinking(p.ContextID)
-			h.r.unclearInputWatchdog.Stop()
+			if h.r.unclearInputWatchdog != nil {
+				h.r.unclearInputWatchdog.Stop()
+			}
 		}
 		if err := h.r.messageLifecycle.UserFinished(p.ContextID); err != nil {
 			return
@@ -372,8 +355,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 		switch p.Source {
 		case internal_type.InterruptionSourceWord:
 			switch messageState {
-			case adapter_lifecycle.MessageStateInterrupt,
-				adapter_lifecycle.MessageStateUserIdle,
+			case adapter_lifecycle.MessageStateUserIdle,
 				adapter_lifecycle.MessageStateUserListening,
 				adapter_lifecycle.MessageStateUserSpeaking,
 				adapter_lifecycle.MessageStateUserThinking:
@@ -386,8 +368,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 				return
 			}
 			switch messageState {
-			case adapter_lifecycle.MessageStateInterrupt,
-				adapter_lifecycle.MessageStateUserIdle,
+			case adapter_lifecycle.MessageStateUserIdle,
 				adapter_lifecycle.MessageStateUserListening,
 				adapter_lifecycle.MessageStateUserSpeaking:
 				p.ContextID = h.r.GetID()
@@ -413,16 +394,18 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 		switch p.Event {
 		case internal_type.InterruptionEventStart:
 			if bargeInTrigger == internal_options.BargeInTriggerWord {
+				if h.r.endOfSpeechExecutor != nil {
+					_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
+				}
 				h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: p.ContextID})
 				return
 			}
 
 			messageState := h.r.messageLifecycle.State()
-			startedNewTurn := false
 			switch messageState {
-			case adapter_lifecycle.MessageStateInterrupt,
-				adapter_lifecycle.MessageStateUserIdle,
-				adapter_lifecycle.MessageStateUserListening,
+			case adapter_lifecycle.MessageStateUserIdle:
+				_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
+			case adapter_lifecycle.MessageStateUserListening,
 				adapter_lifecycle.MessageStateUserSpeaking,
 				adapter_lifecycle.MessageStateUserThinking:
 			default:
@@ -433,15 +416,13 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 				h.r.OnPacket(ctx,
 					internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 					internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceVad},
-				)
-				h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-					ContextID:         newContextID,
-					PreviousContextID: oldContextID,
-					Reason:            "interrupted",
-					Source:            "requestor",
-					Time:              time.Now(),
-				})
-				h.r.OnPacket(ctx,
+					internal_type.TurnChangePacket{
+						ContextID:         newContextID,
+						PreviousContextID: oldContextID,
+						Reason:            "interrupted",
+						Source:            "requestor",
+						Time:              time.Now(),
+					},
 					internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 					internal_type.LLMInterruptPacket{ContextID: oldContextID},
 				)
@@ -452,24 +433,41 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 					})
 				})
 				p.ContextID = newContextID
-				startedNewTurn = true
-			}
-			if startedNewTurn ||
-				messageState == adapter_lifecycle.MessageStateInterrupt ||
-				messageState == adapter_lifecycle.MessageStateUserIdle {
 				_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
+			}
+			if h.r.endOfSpeechExecutor != nil {
+				_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
 			}
 			h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: p.ContextID})
 		case internal_type.InterruptionEventEnd:
 			if bargeInTrigger == internal_options.BargeInTriggerWord {
 				h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: p.ContextID})
+				if h.r.endOfSpeechExecutor != nil {
+					_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
+				}
 				return
 			}
 			h.r.OnPacket(ctx, internal_type.SpeechToTextEndPacket{ContextID: p.ContextID})
+			if p.ContextID == h.r.GetID() {
+				switch h.r.messageLifecycle.State() {
+				case adapter_lifecycle.MessageStateUserSpeaking:
+					if h.r.messageLifecycle.UserListening(p.ContextID) != nil {
+						return
+					}
+					if h.r.endOfSpeechExecutor != nil {
+						_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
+					}
+				case adapter_lifecycle.MessageStateUserListening:
+					// VAD end still belongs to EOS even when STT already moved
+					// lifecycle into listening for this turn.
+					if h.r.endOfSpeechExecutor != nil {
+						_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
+					}
+				}
+			}
 			if h.r.unclearInputWatchdog != nil &&
 				p.ContextID == h.r.GetID() &&
-				h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserSpeaking &&
-				h.r.messageLifecycle.UserListening(p.ContextID) == nil {
+				h.r.messageLifecycle.State() == adapter_lifecycle.MessageStateUserListening {
 				if behavior, err := h.r.deploymentBehavior(); err == nil &&
 					validator.NonNil(behavior.UnclearInputTimeout) && *behavior.UnclearInputTimeout > 0 {
 					timeout := time.Duration(*behavior.UnclearInputTimeout * float64(time.Second))
@@ -480,8 +478,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 	case internal_type.InterruptionSourceWord:
 		if h.r.GetMode().Text() {
 			switch h.r.messageLifecycle.State() {
-			case adapter_lifecycle.MessageStateInterrupt,
-				adapter_lifecycle.MessageStateUserIdle,
+			case adapter_lifecycle.MessageStateUserIdle,
 				adapter_lifecycle.MessageStateUserListening,
 				adapter_lifecycle.MessageStateUserSpeaking,
 				adapter_lifecycle.MessageStateUserThinking:
@@ -493,15 +490,13 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 				h.r.OnPacket(ctx,
 					internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 					internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
-				)
-				h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-					ContextID:         newContextID,
-					PreviousContextID: oldContextID,
-					Reason:            "interrupted",
-					Source:            "requestor",
-					Time:              time.Now(),
-				})
-				h.r.OnPacket(ctx,
+					internal_type.TurnChangePacket{
+						ContextID:         newContextID,
+						PreviousContextID: oldContextID,
+						Reason:            "interrupted",
+						Source:            "requestor",
+						Time:              time.Now(),
+					},
 					internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 					internal_type.LLMInterruptPacket{ContextID: oldContextID},
 				)
@@ -523,8 +518,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 
 		messageState := h.r.messageLifecycle.State()
 		switch messageState {
-		case adapter_lifecycle.MessageStateInterrupt,
-			adapter_lifecycle.MessageStateUserIdle,
+		case adapter_lifecycle.MessageStateUserIdle,
 			adapter_lifecycle.MessageStateUserListening,
 			adapter_lifecycle.MessageStateUserSpeaking,
 			adapter_lifecycle.MessageStateUserThinking:
@@ -536,15 +530,13 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 			h.r.OnPacket(ctx,
 				internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 				internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: internal_type.InterruptionSourceWord},
-			)
-			h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-				ContextID:         newContextID,
-				PreviousContextID: oldContextID,
-				Reason:            "interrupted",
-				Source:            "requestor",
-				Time:              time.Now(),
-			})
-			h.r.OnPacket(ctx,
+				internal_type.TurnChangePacket{
+					ContextID:         newContextID,
+					PreviousContextID: oldContextID,
+					Reason:            "interrupted",
+					Source:            "requestor",
+					Time:              time.Now(),
+				},
 				internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 				internal_type.LLMInterruptPacket{ContextID: oldContextID},
 			)
@@ -1203,15 +1195,14 @@ func (h requestorDispatchHandler) HandleIdleTimeoutExpired(ctx context.Context, 
 	if err != nil {
 		return
 	}
-	h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-		ContextID:         newContextID,
-		PreviousContextID: oldContextID,
-		Reason:            "interrupted",
-		Source:            "requestor",
-		Time:              time.Now(),
-	})
-
-	_ = h.r.OnPacket(ctx,
+	h.r.OnPacket(ctx,
+		internal_type.TurnChangePacket{
+			ContextID:         newContextID,
+			PreviousContextID: oldContextID,
+			Reason:            "interrupted",
+			Source:            "requestor",
+			Time:              time.Now(),
+		},
 		internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 		internal_type.InjectMessagePacket{ContextID: newContextID, Text: timeoutContent},
 		internal_type.ObservabilityEventRecordPacket{
@@ -1231,8 +1222,7 @@ func (h requestorDispatchHandler) HandleUnclearInputExpired(ctx context.Context,
 		return
 	}
 	messageState := h.r.messageLifecycle.State()
-	if messageState != adapter_lifecycle.MessageStateInterrupt &&
-		messageState != adapter_lifecycle.MessageStateUserIdle &&
+	if messageState != adapter_lifecycle.MessageStateUserIdle &&
 		messageState != adapter_lifecycle.MessageStateUserListening &&
 		messageState != adapter_lifecycle.MessageStateUserSpeaking &&
 		messageState != adapter_lifecycle.MessageStateUserThinking {
@@ -1273,15 +1263,13 @@ func (h requestorDispatchHandler) HandleUnclearInputExpired(ctx context.Context,
 	h.r.OnPacket(ctx,
 		internal_type.StopIdleTimeoutPacket{ContextID: oldContextID},
 		internal_type.EndOfSpeechInterruptionPacket{ContextID: oldContextID, Source: interruptionSource},
-	)
-	h.HandleTurnChange(ctx, internal_type.TurnChangePacket{
-		ContextID:         newContextID,
-		PreviousContextID: oldContextID,
-		Reason:            "interrupted",
-		Source:            "requestor",
-		Time:              time.Now(),
-	})
-	h.r.OnPacket(ctx,
+		internal_type.TurnChangePacket{
+			ContextID:         newContextID,
+			PreviousContextID: oldContextID,
+			Reason:            "interrupted",
+			Source:            "requestor",
+			Time:              time.Now(),
+		},
 		internal_type.TextToSpeechInterruptPacket{ContextID: oldContextID},
 		internal_type.LLMInterruptPacket{ContextID: oldContextID},
 	)

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_eos_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_eos_test.go
@@ -146,14 +146,14 @@ func TestHandleEndOfSpeechAudio_ExecutesEOS(t *testing.T) {
 
 func TestHandleSpeechToText_WithEOSExecutor_ExecutesAndSkipsFallback(t *testing.T) {
 	r := newDispatchHandlerVADTestRequestor(t)
-	r.messageLifecycle = adapter_lifecycle.NewMessageLifecycle()
-	r.messageLifecycle.SetContextID("ctx-eos-stt")
+	r.streamer = &streamTestStreamer{}
+	r.messageLifecycle = adapter_lifecycle.NewMessageLifecycleWithContext("ctx-eos-stt", "")
 	executor := &recordingEOSExecutor{}
 	r.endOfSpeechExecutor = executor
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleSpeechToText(t.Context(), internal_type.SpeechToTextPacket{
-		ContextID: "ctx-stt-packet",
+		ContextID: "ctx-eos-stt",
 		Script:    "hello world",
 		Interim:   false,
 	})
@@ -162,7 +162,8 @@ func TestHandleSpeechToText_WithEOSExecutor_ExecutesAndSkipsFallback(t *testing.
 	require.Len(t, executed, 1)
 	sttPkt, ok := executed[0].(internal_type.SpeechToTextPacket)
 	require.True(t, ok)
-	assert.Equal(t, "ctx-stt-packet", sttPkt.ContextID)
+	assert.NotEmpty(t, sttPkt.ContextID)
+	assert.NotEqual(t, "ctx-eos-stt", sttPkt.ContextID)
 
 	select {
 	case env := <-r.channels.IngressChannel():
@@ -173,8 +174,8 @@ func TestHandleSpeechToText_WithEOSExecutor_ExecutesAndSkipsFallback(t *testing.
 
 func TestHandleSpeechToText_WithoutEOSExecutor_EmitsFallbackOnlyForFinal(t *testing.T) {
 	r := newDispatchHandlerVADTestRequestor(t)
-	r.messageLifecycle = adapter_lifecycle.NewMessageLifecycle()
-	r.messageLifecycle.SetContextID("ctx-eos-fallback")
+	r.streamer = &streamTestStreamer{}
+	r.messageLifecycle = adapter_lifecycle.NewMessageLifecycleWithContext("ctx-eos-fallback", "")
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleSpeechToText(t.Context(), internal_type.SpeechToTextPacket{
@@ -189,7 +190,7 @@ func TestHandleSpeechToText_WithoutEOSExecutor_EmitsFallbackOnlyForFinal(t *test
 	}
 
 	h.HandleSpeechToText(t.Context(), internal_type.SpeechToTextPacket{
-		ContextID: "ctx-final-packet",
+		ContextID: "ctx-eos-fallback",
 		Script:    "final text",
 		Interim:   false,
 	})
@@ -198,7 +199,8 @@ func TestHandleSpeechToText_WithoutEOSExecutor_EmitsFallbackOnlyForFinal(t *test
 	case env := <-r.channels.IngressChannel():
 		eosPkt, ok := env.Pkt.(internal_type.EndOfSpeechPacket)
 		require.True(t, ok, "expected EndOfSpeechPacket, got %T", env.Pkt)
-		assert.Equal(t, "ctx-final-packet", eosPkt.ContextID)
+		assert.NotEmpty(t, eosPkt.ContextID)
+		assert.NotEqual(t, "ctx-eos-fallback", eosPkt.ContextID)
 		assert.Equal(t, "final text", eosPkt.Speech)
 		require.Len(t, eosPkt.Speechs, 1)
 		assert.False(t, eosPkt.Speechs[0].Interim)

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_eos_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_eos_test.go
@@ -153,7 +153,7 @@ func TestHandleSpeechToText_WithEOSExecutor_ExecutesAndSkipsFallback(t *testing.
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleSpeechToText(t.Context(), internal_type.SpeechToTextPacket{
-		ContextID: "ignored",
+		ContextID: "ctx-stt-packet",
 		Script:    "hello world",
 		Interim:   false,
 	})
@@ -162,7 +162,7 @@ func TestHandleSpeechToText_WithEOSExecutor_ExecutesAndSkipsFallback(t *testing.
 	require.Len(t, executed, 1)
 	sttPkt, ok := executed[0].(internal_type.SpeechToTextPacket)
 	require.True(t, ok)
-	assert.Equal(t, "ctx-eos-stt", sttPkt.ContextID)
+	assert.Equal(t, "ctx-stt-packet", sttPkt.ContextID)
 
 	select {
 	case env := <-r.channels.IngressChannel():
@@ -189,15 +189,16 @@ func TestHandleSpeechToText_WithoutEOSExecutor_EmitsFallbackOnlyForFinal(t *test
 	}
 
 	h.HandleSpeechToText(t.Context(), internal_type.SpeechToTextPacket{
-		Script:  "final text",
-		Interim: false,
+		ContextID: "ctx-final-packet",
+		Script:    "final text",
+		Interim:   false,
 	})
 
 	select {
 	case env := <-r.channels.IngressChannel():
 		eosPkt, ok := env.Pkt.(internal_type.EndOfSpeechPacket)
 		require.True(t, ok, "expected EndOfSpeechPacket, got %T", env.Pkt)
-		assert.Equal(t, "ctx-eos-fallback", eosPkt.ContextID)
+		assert.Equal(t, "ctx-final-packet", eosPkt.ContextID)
 		assert.Equal(t, "final text", eosPkt.Speech)
 		require.Len(t, eosPkt.Speechs, 1)
 		assert.False(t, eosPkt.Speechs[0].Interim)

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rapidaai/api/assistant-api/internal/watchdog"
 	type_enums "github.com/rapidaai/pkg/types/enums"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,8 +24,7 @@ func newInterruptionTestRequestor(trigger string) *genericRequestor {
 		options[internal_options.MicrophoneOptionBargeInTrigger] = trigger
 	}
 
-	lifecycle := adapter_lifecycle.NewMessageLifecycle()
-	lifecycle.SetContextID("ctx-active")
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-active", type_enums.AudioMode)
 	_ = lifecycle.AssistantGenerating("ctx-active")
 	_ = lifecycle.AssistantSpeaking("ctx-active")
 
@@ -100,6 +100,347 @@ func waitForUnclearInputExpired(t *testing.T, r *genericRequestor) internal_type
 	return expired
 }
 
+func TestHandleUserText_TextModeRotatesWordInterruptionBeforeEOS(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-active", type_enums.TextMode)
+	require.NoError(t, lifecycle.AssistantGenerating("ctx-active"))
+	require.NoError(t, lifecycle.AssistantSpeaking("ctx-active"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserText(context.Background(), internal_type.UserTextReceivedPacket{
+		ContextID: "ctx-active",
+		Text:      "interrupt with text",
+	})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, "ctx-active", newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", eosInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceWord, eosInterrupt.Source)
+	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+
+	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StopIdleTimeoutPacket); ok {
+			stopIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", stopIdleTimeout.ContextID)
+
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 2)
+	interim, ok := ingressPackets[0].(internal_type.InterimEndOfSpeechPacket)
+	require.True(t, ok, "expected InterimEndOfSpeechPacket, got %T", ingressPackets[0])
+	assert.Equal(t, newContextID, interim.ContextID)
+	assert.Equal(t, "interrupt with text", interim.Speech)
+	eos, ok := ingressPackets[1].(internal_type.EndOfSpeechPacket)
+	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[1])
+	assert.Equal(t, newContextID, eos.ContextID)
+	assert.Equal(t, "interrupt with text", eos.Speech)
+}
+
+func TestHandleUserText_TextModeRotatesAfterPreviousUserFinished(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-first", type_enums.TextMode)
+	require.NoError(t, lifecycle.UserFinished("ctx-first"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserText(context.Background(), internal_type.UserTextReceivedPacket{
+		ContextID: "ctx-first",
+		Text:      "second text",
+	})
+
+	secondContextID := r.GetID()
+	require.NotEqual(t, "ctx-first", secondContextID)
+
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 2)
+	interim, ok := ingressPackets[0].(internal_type.InterimEndOfSpeechPacket)
+	require.True(t, ok, "expected InterimEndOfSpeechPacket, got %T", ingressPackets[0])
+	assert.Equal(t, secondContextID, interim.ContextID)
+	assert.Equal(t, "second text", interim.Speech)
+	eos, ok := ingressPackets[1].(internal_type.EndOfSpeechPacket)
+	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[1])
+	assert.Equal(t, secondContextID, eos.ContextID)
+	assert.Equal(t, "second text", eos.Speech)
+}
+
+func TestHandleUserText_TextModeDoesNotRotateWhileUserSpeaking(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-user-speaking", type_enums.TextMode)
+	require.NoError(t, lifecycle.AssistantGenerating("ctx-user-speaking"))
+	require.NoError(t, lifecycle.BeginInterrupt("ctx-user-speaking"))
+	require.NoError(t, lifecycle.UserSpeaking("ctx-user-speaking"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserText(context.Background(), internal_type.UserTextReceivedPacket{
+		ContextID: "ctx-user-speaking",
+		Text:      "same turn text",
+	})
+
+	assert.Equal(t, "ctx-user-speaking", r.GetID())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 2)
+	interim, ok := ingressPackets[0].(internal_type.InterimEndOfSpeechPacket)
+	require.True(t, ok, "expected InterimEndOfSpeechPacket, got %T", ingressPackets[0])
+	assert.Equal(t, "ctx-user-speaking", interim.ContextID)
+	eos, ok := ingressPackets[1].(internal_type.EndOfSpeechPacket)
+	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[1])
+	assert.Equal(t, "ctx-user-speaking", eos.ContextID)
+}
+
+func TestHandleUserText_TextModeDoesNotRotateWhenAlreadyInterrupted(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-interrupt", type_enums.TextMode)
+	require.NoError(t, lifecycle.AssistantGenerating("ctx-interrupt"))
+	require.NoError(t, lifecycle.BeginInterrupt("ctx-interrupt"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserText(context.Background(), internal_type.UserTextReceivedPacket{
+		ContextID: "ctx-interrupt",
+		Text:      "same interrupt text",
+	})
+
+	assert.Equal(t, "ctx-interrupt", r.GetID())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 2)
+	interim, ok := ingressPackets[0].(internal_type.InterimEndOfSpeechPacket)
+	require.True(t, ok, "expected InterimEndOfSpeechPacket, got %T", ingressPackets[0])
+	assert.Equal(t, "ctx-interrupt", interim.ContextID)
+	eos, ok := ingressPackets[1].(internal_type.EndOfSpeechPacket)
+	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[1])
+	assert.Equal(t, "ctx-interrupt", eos.ContextID)
+}
+
+func TestHandleInterruptionDetected_TextModeIgnoresStaleWordInterruption(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-current", type_enums.TextMode)
+	require.NoError(t, lifecycle.AssistantGenerating("ctx-current"))
+	require.NoError(t, lifecycle.AssistantSpeaking("ctx-current"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: "ctx-stale",
+		Source:    internal_type.InterruptionSourceWord,
+	})
+
+	assert.Equal(t, "ctx-current", r.GetID())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+	assert.Empty(t, drainIngressPackets(r))
+}
+
+func TestHandleUserInput_DropsStaleContext(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-current", type_enums.TextMode)
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserInput(context.Background(), internal_type.UserInputPacket{
+		ContextID: "ctx-stale",
+		Text:      "old input",
+	})
+
+	assert.Equal(t, "ctx-current", r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+	assert.Empty(t, drainIngressPackets(r))
+}
+
+func TestHandleSpeechToText_FinalRotatesAfterPreviousUserFinished(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-first", type_enums.AudioMode)
+	require.NoError(t, lifecycle.UserFinished("ctx-first"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-first",
+		Script:    "new audio turn",
+		Interim:   false,
+	})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, "ctx-first", newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
+	}
+	assert.Equal(t, "ctx-first", eosInterrupt.ContextID)
+	assert.Equal(t, "ctx-first", ttsInterrupt.ContextID)
+	assert.Equal(t, "ctx-first", llmInterrupt.ContextID)
+
+	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StopIdleTimeoutPacket); ok {
+			stopIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, "ctx-first", stopIdleTimeout.ContextID)
+
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 1)
+	eos, ok := ingressPackets[0].(internal_type.EndOfSpeechPacket)
+	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[0])
+	assert.Equal(t, newContextID, eos.ContextID)
+	assert.Equal(t, "new audio turn", eos.Speech)
+
+	h.HandleEndOfSpeech(context.Background(), eos)
+	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
+}
+
+func TestHandleSpeechToText_DoesNotRotateAgainForSameSpeechSegment(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-first", type_enums.AudioMode)
+	require.NoError(t, lifecycle.UserFinished("ctx-first"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	executor := &recordingEOSExecutor{}
+	r.endOfSpeechExecutor = executor
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-first",
+		Script:    "Yes. I am.",
+		Interim:   false,
+	})
+
+	turnContextID := r.GetID()
+	require.NotEqual(t, "ctx-first", turnContextID)
+
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-first",
+		Script:    "Yeah.",
+		Interim:   false,
+	})
+
+	assert.Equal(t, turnContextID, r.GetID())
+	executed := executor.snapshotExecuted()
+	require.Len(t, executed, 2)
+	first, ok := executed[0].(internal_type.SpeechToTextPacket)
+	require.True(t, ok)
+	second, ok := executed[1].(internal_type.SpeechToTextPacket)
+	require.True(t, ok)
+	assert.Equal(t, turnContextID, first.ContextID)
+	assert.Equal(t, turnContextID, second.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+}
+
+func TestHandleSpeechToText_DropsStaleTranscriptAfterUserFinished(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-current", type_enums.AudioMode)
+	require.NoError(t, lifecycle.UserFinished("ctx-current"))
+	r := &genericRequestor{
+		streamer:         &streamTestStreamer{},
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: lifecycle,
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-old",
+		Script:    "late transcript",
+		Interim:   false,
+	})
+
+	assert.Equal(t, "ctx-current", r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+	assert.Empty(t, drainIngressPackets(r))
+}
+
+func TestHandleInterimEndOfSpeech_UsesPacketContextID(t *testing.T) {
+	streamer := &streamTestStreamer{}
+	r := &genericRequestor{
+		streamer:         streamer,
+		channels:         adapter_channel.NewRequestorChannels(),
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-current", type_enums.AudioMode),
+		vadExecutor:      &blockingVADExecutor{},
+	}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleInterimEndOfSpeech(context.Background(), internal_type.InterimEndOfSpeechPacket{
+		ContextID: "ctx-segment",
+		Speech:    "partial text",
+	})
+
+	require.Len(t, streamer.sent, 1)
+	userMessage, ok := streamer.sent[0].(*protos.ConversationUserMessage)
+	require.True(t, ok, "expected ConversationUserMessage, got %T", streamer.sent[0])
+	assert.Equal(t, "ctx-segment", userMessage.Id)
+	assert.False(t, userMessage.Completed)
+}
+
 func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.2, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
@@ -119,13 +460,38 @@ func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
 		Event:     internal_type.InterruptionEventStart,
 	})
 
-	assert.Equal(t, "ctx-active", r.GetID())
+	userTurnContextID := r.GetID()
+	require.NotEqual(t, "ctx-active", userTurnContextID)
 	controlPackets := drainControlPackets(r)
-	require.Len(t, controlPackets, 1)
-	sttStart, ok := controlPackets[0].(internal_type.SpeechToTextStartPacket)
-	require.True(t, ok, "expected SpeechToTextStartPacket, got %T", controlPackets[0])
-	assert.Equal(t, "ctx-active", sttStart.ContextID)
-	assert.Empty(t, r.channels.EgressChannel())
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	var sttStart internal_type.SpeechToTextStartPacket
+	for _, packet := range controlPackets {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		case internal_type.SpeechToTextStartPacket:
+			sttStart = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", eosInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceVad, eosInterrupt.Source)
+	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, sttStart.ContextID)
+
+	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StopIdleTimeoutPacket); ok {
+			stopIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", stopIdleTimeout.ContextID)
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -140,7 +506,7 @@ func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, sttEnd.ContextID)
-	assert.Equal(t, "ctx-active", sttEnd.ContextID)
+	assert.Equal(t, userTurnContextID, sttEnd.ContextID)
 }
 
 func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
@@ -166,9 +532,34 @@ func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
 		Source:    internal_type.InterruptionSourceWord,
 	})
 
-	assert.Equal(t, "ctx-active", r.GetID())
-	assert.Empty(t, r.channels.ControlChannel())
-	assert.Empty(t, r.channels.EgressChannel())
+	userTurnContextID := r.GetID()
+	require.NotEqual(t, "ctx-active", userTurnContextID)
+	controlPackets = drainControlPackets(r)
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range controlPackets {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", eosInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceWord, eosInterrupt.Source)
+	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+
+	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StopIdleTimeoutPacket); ok {
+			stopIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, "ctx-active", stopIdleTimeout.ContextID)
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -183,7 +574,7 @@ func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, sttEnd.ContextID)
-	assert.Equal(t, "ctx-active", sttEnd.ContextID)
+	assert.Equal(t, userTurnContextID, sttEnd.ContextID)
 }
 
 func TestHandleInterruptionDetected_VADTriggerStartsUnclearInputWatchdogAfterVADEnd(t *testing.T) {
@@ -196,11 +587,15 @@ func TestHandleInterruptionDetected_VADTriggerStartsUnclearInputWatchdogAfterVAD
 		Event:     internal_type.InterruptionEventStart,
 	})
 
-	select {
-	case packet := <-r.channels.EgressChannel():
-		t.Fatalf("unclear input watchdog started before VAD end: %+v", packet.Pkt)
-	case <-time.After(40 * time.Millisecond):
-	}
+	drainEgressPackets(r)
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 40*time.Millisecond, 10*time.Millisecond)
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -302,9 +697,10 @@ func TestHandleInterruptionDetected_WordTriggerDuplicateAfterFinalDoesNotRestart
 	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
-func TestHandleSpeechToText_InterimExtendsUnclearInputWatchdog(t *testing.T) {
+func TestHandleSpeechToText_InterimStopsUnclearInputWatchdog(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.06, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -320,19 +716,23 @@ func TestHandleSpeechToText_InterimExtendsUnclearInputWatchdog(t *testing.T) {
 
 	time.Sleep(35 * time.Millisecond)
 	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
-		ContextID: "ctx-active",
+		ContextID: oldContextID,
 		Script:    "hel",
 		Interim:   true,
 	})
 
-	select {
-	case packet := <-r.channels.EgressChannel():
-		t.Fatalf("unclear input watchdog expired before extended deadline: %+v", packet.Pkt)
-	case <-time.After(35 * time.Millisecond):
-	}
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
 
-	expired := waitForUnclearInputExpired(t, r)
-	assert.Equal(t, r.GetID(), expired.ContextID)
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestHandleEndOfSpeech_StopsUnclearInputWatchdogForAcceptedSpeech(t *testing.T) {
@@ -350,24 +750,23 @@ func TestHandleEndOfSpeech_StopsUnclearInputWatchdogForAcceptedSpeech(t *testing
 		Event:     internal_type.InterruptionEventEnd,
 	})
 	drainEgressPackets(r)
+	turnContextID := r.GetID()
+	require.NotEqual(t, "ctx-active", turnContextID)
+	drainControlPackets(r)
+
 	h.HandleEndOfSpeech(context.Background(), internal_type.EndOfSpeechPacket{
-		ContextID: r.GetID(),
+		ContextID: turnContextID,
 		Speech:    "hello",
 	})
 
-	assert.NotEqual(t, "ctx-active", r.GetID())
-	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
-	var llmInterrupt internal_type.LLMInterruptPacket
+	assert.Equal(t, turnContextID, r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
 	for _, packet := range drainControlPackets(r) {
-		switch typed := packet.(type) {
-		case internal_type.TextToSpeechInterruptPacket:
-			ttsInterrupt = typed
-		case internal_type.LLMInterruptPacket:
-			llmInterrupt = typed
+		switch packet.(type) {
+		case internal_type.TextToSpeechInterruptPacket, internal_type.LLMInterruptPacket:
+			t.Fatalf("unexpected interrupt packet from EOS completion: %T", packet)
 		}
 	}
-	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
-	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
 
 	require.Never(t, func() bool {
 		for _, packet := range drainEgressPackets(r) {
@@ -377,6 +776,53 @@ func TestHandleEndOfSpeech_StopsUnclearInputWatchdogForAcceptedSpeech(t *testing
 		}
 		return false
 	}, 80*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestHandleEndOfSpeech_DoesNotFinalizeWhileVADSpeaking(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventStart,
+	})
+
+	turnContextID := r.GetID()
+	require.NotEqual(t, oldContextID, turnContextID)
+	drainControlPackets(r)
+	drainEgressPackets(r)
+
+	h.HandleEndOfSpeech(context.Background(), internal_type.EndOfSpeechPacket{
+		ContextID: turnContextID,
+		Speech:    "still speaking",
+	})
+
+	assert.Equal(t, turnContextID, r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserSpeaking, r.messageLifecycle.State())
+	assert.Empty(t, drainIngressPackets(r))
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
+	drainControlPackets(r)
+	drainEgressPackets(r)
+
+	h.HandleEndOfSpeech(context.Background(), internal_type.EndOfSpeechPacket{
+		ContextID: turnContextID,
+		Speech:    "done speaking",
+	})
+
+	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 1)
+	userInput, ok := ingressPackets[0].(internal_type.UserInputPacket)
+	require.True(t, ok, "expected UserInputPacket, got %T", ingressPackets[0])
+	assert.Equal(t, turnContextID, userInput.ContextID)
+	assert.Equal(t, "done speaking", userInput.Text)
 }
 
 func TestHandleSpeechToText_FinalStopsUnclearInputWatchdog(t *testing.T) {
@@ -437,7 +883,7 @@ func TestHandleSpeechToText_FinalStopsUnclearInputWatchdog(t *testing.T) {
 	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
-func TestHandleSpeechToText_InterimExtendsAndFinalStopsUnclearInputWatchdog(t *testing.T) {
+func TestHandleSpeechToText_InterimStartsTurnAndFinalKeepsContext(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.06, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 	oldContextID := r.GetID()
@@ -461,15 +907,16 @@ func TestHandleSpeechToText_InterimExtendsAndFinalStopsUnclearInputWatchdog(t *t
 		Interim:   true,
 	})
 
-	time.Sleep(35 * time.Millisecond)
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+
 	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
 		ContextID: oldContextID,
 		Script:    "hello",
 		Interim:   false,
 	})
 
-	newContextID := r.GetID()
-	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, newContextID, r.GetID())
 
 	require.Never(t, func() bool {
 		for _, packet := range drainEgressPackets(r) {
@@ -525,12 +972,22 @@ func TestHandleUnclearInputExpired_VADTriggerRotatesFromInterruptedContextAndInj
 		Event:     internal_type.InterruptionEventStart,
 	})
 	controlPackets := drainControlPackets(r)
-	require.Len(t, controlPackets, 1)
-	sttStart, ok := controlPackets[0].(internal_type.SpeechToTextStartPacket)
-	require.True(t, ok)
-	assert.Equal(t, oldContextID, sttStart.ContextID)
-	assert.Equal(t, oldContextID, r.GetID())
-	assert.Equal(t, adapter_lifecycle.MessageStateUserIdle, r.messageLifecycle.State())
+	var startEOSInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var sttStart internal_type.SpeechToTextStartPacket
+	for _, packet := range controlPackets {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			startEOSInterrupt = typed
+		case internal_type.SpeechToTextStartPacket:
+			sttStart = typed
+		}
+	}
+	userTurnContextID := r.GetID()
+	require.NotEqual(t, oldContextID, userTurnContextID)
+	assert.Equal(t, oldContextID, startEOSInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceVad, startEOSInterrupt.Source)
+	assert.Equal(t, userTurnContextID, sttStart.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateUserSpeaking, r.messageLifecycle.State())
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: oldContextID,
@@ -541,14 +998,15 @@ func TestHandleUnclearInputExpired_VADTriggerRotatesFromInterruptedContextAndInj
 	require.Len(t, controlPackets, 1)
 	sttEnd, ok := controlPackets[0].(internal_type.SpeechToTextEndPacket)
 	require.True(t, ok)
-	assert.Equal(t, oldContextID, sttEnd.ContextID)
-	assert.Equal(t, oldContextID, r.GetID())
+	assert.Equal(t, userTurnContextID, sttEnd.ContextID)
+	assert.Equal(t, userTurnContextID, r.GetID())
 	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
 
-	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: oldContextID})
+	drainEgressPackets(r)
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: userTurnContextID})
 
-	newContextID := r.GetID()
-	require.NotEqual(t, oldContextID, newContextID)
+	promptContextID := r.GetID()
+	require.NotEqual(t, userTurnContextID, promptContextID)
 	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
 	assert.Equal(t, uint64(1), r.messageLifecycle.UserPromptCount())
 
@@ -565,10 +1023,10 @@ func TestHandleUnclearInputExpired_VADTriggerRotatesFromInterruptedContextAndInj
 			llmInterrupt = typed
 		}
 	}
-	assert.Equal(t, oldContextID, eosInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, eosInterrupt.ContextID)
 	assert.Equal(t, internal_type.InterruptionSourceVad, eosInterrupt.Source)
-	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
-	assert.Equal(t, oldContextID, llmInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, llmInterrupt.ContextID)
 
 	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
 	var injectMessage internal_type.InjectMessagePacket
@@ -582,8 +1040,8 @@ func TestHandleUnclearInputExpired_VADTriggerRotatesFromInterruptedContextAndInj
 			t.Fatalf("unclear prompt should not start idle before assistant completion: %+v", typed)
 		}
 	}
-	assert.Equal(t, oldContextID, stopIdleTimeout.ContextID)
-	assert.Equal(t, newContextID, injectMessage.ContextID)
+	assert.Equal(t, userTurnContextID, stopIdleTimeout.ContextID)
+	assert.Equal(t, promptContextID, injectMessage.ContextID)
 	assert.Equal(t, "I didn't catch that.", injectMessage.Text)
 }
 
@@ -608,8 +1066,18 @@ func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndIn
 		ContextID: oldContextID,
 		Source:    internal_type.InterruptionSourceWord,
 	})
-	assert.Equal(t, oldContextID, r.GetID())
+	userTurnContextID := r.GetID()
+	require.NotEqual(t, oldContextID, userTurnContextID)
 	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+	controlPackets = drainControlPackets(r)
+	var wordEOSInterrupt internal_type.EndOfSpeechInterruptionPacket
+	for _, packet := range controlPackets {
+		if typed, ok := packet.(internal_type.EndOfSpeechInterruptionPacket); ok {
+			wordEOSInterrupt = typed
+		}
+	}
+	assert.Equal(t, oldContextID, wordEOSInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceWord, wordEOSInterrupt.Source)
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: oldContextID,
@@ -620,12 +1088,13 @@ func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndIn
 	require.Len(t, controlPackets, 1)
 	sttEnd, ok := controlPackets[0].(internal_type.SpeechToTextEndPacket)
 	require.True(t, ok)
-	assert.Equal(t, oldContextID, sttEnd.ContextID)
+	assert.Equal(t, userTurnContextID, sttEnd.ContextID)
 
-	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: oldContextID})
+	drainEgressPackets(r)
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: userTurnContextID})
 
-	newContextID := r.GetID()
-	require.NotEqual(t, oldContextID, newContextID)
+	promptContextID := r.GetID()
+	require.NotEqual(t, userTurnContextID, promptContextID)
 	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
 	assert.Equal(t, uint64(1), r.messageLifecycle.UserPromptCount())
 
@@ -642,10 +1111,10 @@ func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndIn
 			llmInterrupt = typed
 		}
 	}
-	assert.Equal(t, oldContextID, eosInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, eosInterrupt.ContextID)
 	assert.Equal(t, internal_type.InterruptionSourceWord, eosInterrupt.Source)
-	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
-	assert.Equal(t, oldContextID, llmInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, userTurnContextID, llmInterrupt.ContextID)
 
 	var injectMessage internal_type.InjectMessagePacket
 	for _, packet := range drainEgressPackets(r) {
@@ -656,7 +1125,7 @@ func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndIn
 			t.Fatalf("unclear prompt should not start idle before assistant completion: %+v", typed)
 		}
 	}
-	assert.Equal(t, newContextID, injectMessage.ContextID)
+	assert.Equal(t, promptContextID, injectMessage.ContextID)
 	assert.Equal(t, "I didn't catch that.", injectMessage.Text)
 }
 

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
@@ -11,6 +11,7 @@ import (
 	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/api/assistant-api/internal/watchdog"
+	type_enums "github.com/rapidaai/pkg/types/enums"
 	"github.com/rapidaai/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,11 +20,13 @@ import (
 func newInterruptionTestRequestor(trigger string) *genericRequestor {
 	options := map[string]interface{}{}
 	if trigger != "" {
-		options[internal_options.MicrophoneVADOptionBargeInTrigger] = trigger
+		options[internal_options.MicrophoneOptionBargeInTrigger] = trigger
 	}
 
 	lifecycle := adapter_lifecycle.NewMessageLifecycle()
 	lifecycle.SetContextID("ctx-active")
+	_ = lifecycle.AssistantGenerating("ctx-active")
+	_ = lifecycle.AssistantSpeaking("ctx-active")
 
 	return &genericRequestor{
 		streamer:         &streamTestStreamer{},
@@ -66,6 +69,14 @@ func drainEgressPackets(r *genericRequestor) []internal_type.Packet {
 	return packets
 }
 
+func drainIngressPackets(r *genericRequestor) []internal_type.Packet {
+	packets := make([]internal_type.Packet, 0, len(r.channels.IngressChannel()))
+	for len(r.channels.IngressChannel()) > 0 {
+		packets = append(packets, (<-r.channels.IngressChannel()).Pkt)
+	}
+	return packets
+}
+
 func drainBackgroundPackets(r *genericRequestor) []internal_type.Packet {
 	packets := make([]internal_type.Packet, 0, len(r.channels.BackgroundChannel()))
 	for len(r.channels.BackgroundChannel()) > 0 {
@@ -90,7 +101,7 @@ func waitForUnclearInputExpired(t *testing.T, r *genericRequestor) internal_type
 }
 
 func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
-	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.2, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
@@ -108,37 +119,13 @@ func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
 		Event:     internal_type.InterruptionEventStart,
 	})
 
-	require.NotEqual(t, "ctx-active", r.GetID())
-
-	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
-	var sttStart internal_type.SpeechToTextStartPacket
-	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
-	var llmInterrupt internal_type.LLMInterruptPacket
-
-	require.Eventually(t, func() bool {
-		for _, packet := range drainControlPackets(r) {
-			switch typed := packet.(type) {
-			case internal_type.EndOfSpeechInterruptionPacket:
-				eosInterrupt = typed
-			case internal_type.SpeechToTextStartPacket:
-				sttStart = typed
-			case internal_type.TextToSpeechInterruptPacket:
-				ttsInterrupt = typed
-			case internal_type.LLMInterruptPacket:
-				llmInterrupt = typed
-			}
-		}
-		return eosInterrupt.ContextID != "" &&
-			sttStart.ContextID != "" &&
-			ttsInterrupt.ContextID != "" &&
-			llmInterrupt.ContextID != ""
-	}, time.Second, 10*time.Millisecond)
-
-	assert.Equal(t, internal_type.InterruptionSourceVad, eosInterrupt.Source)
-	assert.Equal(t, "ctx-active", eosInterrupt.ContextID)
-	assert.Equal(t, r.GetID(), sttStart.ContextID)
-	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
-	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", r.GetID())
+	controlPackets := drainControlPackets(r)
+	require.Len(t, controlPackets, 1)
+	sttStart, ok := controlPackets[0].(internal_type.SpeechToTextStartPacket)
+	require.True(t, ok, "expected SpeechToTextStartPacket, got %T", controlPackets[0])
+	assert.Equal(t, "ctx-active", sttStart.ContextID)
+	assert.Empty(t, r.channels.EgressChannel())
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -153,11 +140,11 @@ func TestHandleInterruptionDetected_VADTriggerUsesVADOnly(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, sttEnd.ContextID)
-	assert.Equal(t, r.GetID(), sttEnd.ContextID)
+	assert.Equal(t, "ctx-active", sttEnd.ContextID)
 }
 
 func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
-	r := newInterruptionTestRequestor(internal_options.BargeInTriggerWord)
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerWord, 0.2, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
@@ -179,32 +166,9 @@ func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
 		Source:    internal_type.InterruptionSourceWord,
 	})
 
-	require.NotEqual(t, "ctx-active", r.GetID())
-
-	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
-	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
-	var llmInterrupt internal_type.LLMInterruptPacket
-
-	require.Eventually(t, func() bool {
-		for _, packet := range drainControlPackets(r) {
-			switch typed := packet.(type) {
-			case internal_type.EndOfSpeechInterruptionPacket:
-				eosInterrupt = typed
-			case internal_type.TextToSpeechInterruptPacket:
-				ttsInterrupt = typed
-			case internal_type.LLMInterruptPacket:
-				llmInterrupt = typed
-			}
-		}
-		return eosInterrupt.ContextID != "" &&
-			ttsInterrupt.ContextID != "" &&
-			llmInterrupt.ContextID != ""
-	}, time.Second, 10*time.Millisecond)
-
-	assert.Equal(t, internal_type.InterruptionSourceWord, eosInterrupt.Source)
-	assert.Equal(t, "ctx-active", eosInterrupt.ContextID)
-	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
-	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", r.GetID())
+	assert.Empty(t, r.channels.ControlChannel())
+	assert.Empty(t, r.channels.EgressChannel())
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: "ctx-active",
@@ -222,7 +186,7 @@ func TestHandleInterruptionDetected_WordTriggerUsesWordOnly(t *testing.T) {
 	assert.Equal(t, "ctx-active", sttEnd.ContextID)
 }
 
-func TestHandleInterruptionDetected_VADTriggerStartsUnclearInputWatchdog(t *testing.T) {
+func TestHandleInterruptionDetected_VADTriggerStartsUnclearInputWatchdogAfterVADEnd(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.02, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 
@@ -230,6 +194,18 @@ func TestHandleInterruptionDetected_VADTriggerStartsUnclearInputWatchdog(t *test
 		ContextID: "ctx-active",
 		Source:    internal_type.InterruptionSourceVad,
 		Event:     internal_type.InterruptionEventStart,
+	})
+
+	select {
+	case packet := <-r.channels.EgressChannel():
+		t.Fatalf("unclear input watchdog started before VAD end: %+v", packet.Pkt)
+	case <-time.After(40 * time.Millisecond):
+	}
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: "ctx-active",
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
 	})
 
 	expired := waitForUnclearInputExpired(t, r)
@@ -261,6 +237,71 @@ func TestHandleInterruptionDetected_WordTriggerStartsUnclearInputWatchdogOnlyAft
 	assert.Equal(t, r.GetID(), expired.ContextID)
 }
 
+func TestHandleInterruptionDetected_WordTriggerDuplicateWordExtendsUnclearInputWatchdog(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerWord, 0.06, "Please say that again.")
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: contextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+	drainEgressPackets(r)
+
+	time.Sleep(35 * time.Millisecond)
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: contextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+
+	select {
+	case packet := <-r.channels.EgressChannel():
+		t.Fatalf("unclear input watchdog expired before duplicate word extended deadline: %+v", packet.Pkt)
+	case <-time.After(35 * time.Millisecond):
+	}
+
+	expired := waitForUnclearInputExpired(t, r)
+	assert.Equal(t, r.GetID(), expired.ContextID)
+}
+
+func TestHandleInterruptionDetected_WordTriggerDuplicateAfterFinalDoesNotRestartUnclearInputWatchdog(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerWord, 0.03, "Please say that again.")
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+	drainEgressPackets(r)
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: oldContextID,
+		Script:    "hello",
+		Interim:   false,
+	})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: newContextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 80*time.Millisecond, 10*time.Millisecond)
+}
+
 func TestHandleSpeechToText_InterimExtendsUnclearInputWatchdog(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.06, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
@@ -269,6 +310,11 @@ func TestHandleSpeechToText_InterimExtendsUnclearInputWatchdog(t *testing.T) {
 		ContextID: "ctx-active",
 		Source:    internal_type.InterruptionSourceVad,
 		Event:     internal_type.InterruptionEventStart,
+	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: "ctx-active",
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
 	})
 	drainEgressPackets(r)
 
@@ -298,48 +344,153 @@ func TestHandleEndOfSpeech_StopsUnclearInputWatchdogForAcceptedSpeech(t *testing
 		Source:    internal_type.InterruptionSourceVad,
 		Event:     internal_type.InterruptionEventStart,
 	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: "ctx-active",
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
 	drainEgressPackets(r)
 	h.HandleEndOfSpeech(context.Background(), internal_type.EndOfSpeechPacket{
 		ContextID: r.GetID(),
 		Speech:    "hello",
 	})
 
-	select {
-	case packet := <-r.channels.EgressChannel():
-		t.Fatalf("unclear input watchdog expired after accepted speech: %+v", packet.Pkt)
-	case <-time.After(80 * time.Millisecond):
+	assert.NotEqual(t, "ctx-active", r.GetID())
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
 	}
+	assert.Equal(t, "ctx-active", ttsInterrupt.ContextID)
+	assert.Equal(t, "ctx-active", llmInterrupt.ContextID)
+
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestHandleSpeechToText_FinalStopsUnclearInputWatchdog(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
-		ContextID: "ctx-active",
+		ContextID: oldContextID,
 		Source:    internal_type.InterruptionSourceVad,
 		Event:     internal_type.InterruptionEventStart,
 	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
 	drainEgressPackets(r)
 	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
-		ContextID: "ctx-active",
+		ContextID: oldContextID,
 		Script:    "hello",
 		Interim:   false,
 	})
 
-	select {
-	case packet := <-r.channels.EgressChannel():
-		t.Fatalf("unclear input watchdog expired after final speech: %+v", packet.Pkt)
-	case <-time.After(80 * time.Millisecond):
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
 	}
+	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, oldContextID, llmInterrupt.ContextID)
+
+	var eos internal_type.EndOfSpeechPacket
+	for _, packet := range drainIngressPackets(r) {
+		if typed, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+			eos = typed
+		}
+	}
+	require.Equal(t, "hello", eos.Speech)
+	assert.Equal(t, newContextID, eos.ContextID)
+	h.HandleEndOfSpeech(context.Background(), eos)
+
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 80*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestHandleSpeechToText_InterimExtendsAndFinalStopsUnclearInputWatchdog(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.06, "Please say that again.")
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventStart,
+	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
+	drainEgressPackets(r)
+
+	time.Sleep(35 * time.Millisecond)
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: oldContextID,
+		Script:    "hel",
+		Interim:   true,
+	})
+
+	time.Sleep(35 * time.Millisecond)
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: oldContextID,
+		Script:    "hello",
+		Interim:   false,
+	})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+
+	require.Never(t, func() bool {
+		for _, packet := range drainEgressPackets(r) {
+			if _, ok := packet.(internal_type.UnclearInputExpiredPacket); ok {
+				return true
+			}
+		}
+		return false
+	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestHandleUnclearInputExpired_InjectsConfiguredMessage(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 	contextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.BeginInterrupt(contextID))
 
 	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: contextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, contextID, newContextID)
 
 	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
 	for _, packet := range drainControlPackets(r) {
@@ -349,18 +500,415 @@ func TestHandleUnclearInputExpired_InjectsConfiguredMessage(t *testing.T) {
 	}
 
 	var injectMessage internal_type.InjectMessagePacket
-	var startIdleTimeout internal_type.StartIdleTimeoutPacket
 	for _, packet := range drainEgressPackets(r) {
 		switch typed := packet.(type) {
 		case internal_type.InjectMessagePacket:
 			injectMessage = typed
 		case internal_type.StartIdleTimeoutPacket:
-			startIdleTimeout = typed
+			t.Fatalf("unclear prompt should not restart idle timer before assistant completion: %+v", typed)
 		}
 	}
 
 	assert.Equal(t, contextID, ttsInterrupt.ContextID)
-	assert.Equal(t, contextID, injectMessage.ContextID)
+	assert.Equal(t, newContextID, injectMessage.ContextID)
 	assert.Equal(t, "Please say that again.", injectMessage.Text)
+}
+
+func TestHandleUnclearInputExpired_VADTriggerRotatesFromInterruptedContextAndInjectsNewPrompt(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "I didn't catch that.")
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventStart,
+	})
+	controlPackets := drainControlPackets(r)
+	require.Len(t, controlPackets, 1)
+	sttStart, ok := controlPackets[0].(internal_type.SpeechToTextStartPacket)
+	require.True(t, ok)
+	assert.Equal(t, oldContextID, sttStart.ContextID)
+	assert.Equal(t, oldContextID, r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserIdle, r.messageLifecycle.State())
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
+	controlPackets = drainControlPackets(r)
+	require.Len(t, controlPackets, 1)
+	sttEnd, ok := controlPackets[0].(internal_type.SpeechToTextEndPacket)
+	require.True(t, ok)
+	assert.Equal(t, oldContextID, sttEnd.ContextID)
+	assert.Equal(t, oldContextID, r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: oldContextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+	assert.Equal(t, uint64(1), r.messageLifecycle.UserPromptCount())
+
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
+	}
+	assert.Equal(t, oldContextID, eosInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceVad, eosInterrupt.Source)
+	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, oldContextID, llmInterrupt.ContextID)
+
+	var stopIdleTimeout internal_type.StopIdleTimeoutPacket
+	var injectMessage internal_type.InjectMessagePacket
+	for _, packet := range drainEgressPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.StopIdleTimeoutPacket:
+			stopIdleTimeout = typed
+		case internal_type.InjectMessagePacket:
+			injectMessage = typed
+		case internal_type.StartIdleTimeoutPacket:
+			t.Fatalf("unclear prompt should not start idle before assistant completion: %+v", typed)
+		}
+	}
+	assert.Equal(t, oldContextID, stopIdleTimeout.ContextID)
+	assert.Equal(t, newContextID, injectMessage.ContextID)
+	assert.Equal(t, "I didn't catch that.", injectMessage.Text)
+}
+
+func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndInjectsNewPrompt(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerWord, 0.03, "I didn't catch that.")
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventStart,
+	})
+	controlPackets := drainControlPackets(r)
+	require.Len(t, controlPackets, 1)
+	sttStart, ok := controlPackets[0].(internal_type.SpeechToTextStartPacket)
+	require.True(t, ok)
+	assert.Equal(t, oldContextID, sttStart.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantSpeaking, r.messageLifecycle.State())
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceWord,
+	})
+	assert.Equal(t, oldContextID, r.GetID())
+	assert.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: oldContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
+	controlPackets = drainControlPackets(r)
+	require.Len(t, controlPackets, 1)
+	sttEnd, ok := controlPackets[0].(internal_type.SpeechToTextEndPacket)
+	require.True(t, ok)
+	assert.Equal(t, oldContextID, sttEnd.ContextID)
+
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: oldContextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+	assert.Equal(t, uint64(1), r.messageLifecycle.UserPromptCount())
+
+	var eosInterrupt internal_type.EndOfSpeechInterruptionPacket
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	var llmInterrupt internal_type.LLMInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.EndOfSpeechInterruptionPacket:
+			eosInterrupt = typed
+		case internal_type.TextToSpeechInterruptPacket:
+			ttsInterrupt = typed
+		case internal_type.LLMInterruptPacket:
+			llmInterrupt = typed
+		}
+	}
+	assert.Equal(t, oldContextID, eosInterrupt.ContextID)
+	assert.Equal(t, internal_type.InterruptionSourceWord, eosInterrupt.Source)
+	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, oldContextID, llmInterrupt.ContextID)
+
+	var injectMessage internal_type.InjectMessagePacket
+	for _, packet := range drainEgressPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.InjectMessagePacket:
+			injectMessage = typed
+		case internal_type.StartIdleTimeoutPacket:
+			t.Fatalf("unclear prompt should not start idle before assistant completion: %+v", typed)
+		}
+	}
+	assert.Equal(t, newContextID, injectMessage.ContextID)
+	assert.Equal(t, "I didn't catch that.", injectMessage.Text)
+}
+
+func TestHandleUnclearInputExpired_IgnoresWhenInterruptionIsNotPending(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.AssistantFinished(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantIdle(contextID))
+
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: contextID})
+
+	assert.Equal(t, contextID, r.GetID())
+	assert.Empty(t, drainControlPackets(r))
+	assert.Empty(t, drainEgressPackets(r))
+}
+
+func TestHandleIdleTimeoutExpired_InterruptsOldContextAndInjectsOnNewContext(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	idleTimeout := uint64(10)
+	message := "Are you still there?"
+	r.source = utils.PhoneCall
+	r.assistant = &internal_assistant_entity.Assistant{
+		AssistantPhoneDeployment: &internal_assistant_entity.AssistantPhoneDeployment{
+			AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
+				IdleTimeout:        &idleTimeout,
+				IdleTimeoutMessage: &message,
+			},
+		},
+	}
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.AssistantFinished(oldContextID))
+	require.NoError(t, r.messageLifecycle.AssistantIdle(oldContextID))
+
+	h.HandleIdleTimeoutExpired(context.Background(), internal_type.IdleTimeoutExpiredPacket{ContextID: oldContextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, uint64(1), r.messageLifecycle.AssistantPromptCount())
+
+	var ttsInterrupt internal_type.TextToSpeechInterruptPacket
+	for _, packet := range drainControlPackets(r) {
+		if typed, ok := packet.(internal_type.TextToSpeechInterruptPacket); ok {
+			ttsInterrupt = typed
+		}
+	}
+
+	var injectMessage internal_type.InjectMessagePacket
+	for _, packet := range drainEgressPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.InjectMessagePacket:
+			injectMessage = typed
+		case internal_type.StartIdleTimeoutPacket:
+			t.Fatalf("idle timeout prompt should not restart idle timer before assistant completion: %+v", typed)
+		}
+	}
+
+	assert.Equal(t, oldContextID, ttsInterrupt.ContextID)
+	assert.Equal(t, newContextID, injectMessage.ContextID)
+	assert.Equal(t, message, injectMessage.Text)
+}
+
+func TestHandleIdleTimeoutExpired_InjectedPromptSpeaksBeforeIdleRestarts(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	idleTimeout := uint64(10)
+	message := "Are you still there?"
+	r.source = utils.PhoneCall
+	r.assistant = &internal_assistant_entity.Assistant{
+		AssistantPhoneDeployment: &internal_assistant_entity.AssistantPhoneDeployment{
+			AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
+				IdleTimeout:        &idleTimeout,
+				IdleTimeoutMessage: &message,
+			},
+		},
+	}
+	r.messageLifecycle.SetMode(type_enums.AudioMode)
+	r.textToSpeechTransformer = noopSpeechToTextTransformer{}
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.AssistantFinished(oldContextID))
+	require.NoError(t, r.messageLifecycle.AssistantIdle(oldContextID))
+
+	h.HandleIdleTimeoutExpired(context.Background(), internal_type.IdleTimeoutExpiredPacket{ContextID: oldContextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, oldContextID, newContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+
+	var injectMessage internal_type.InjectMessagePacket
+	for _, packet := range drainEgressPackets(r) {
+		switch typed := packet.(type) {
+		case internal_type.InjectMessagePacket:
+			injectMessage = typed
+		case internal_type.StartIdleTimeoutPacket:
+			t.Fatalf("idle prompt should not restart idle before assistant completion: %+v", typed)
+		}
+	}
+	require.Equal(t, newContextID, injectMessage.ContextID)
+	require.Equal(t, message, injectMessage.Text)
+
+	h.HandleInjectMessage(context.Background(), injectMessage)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantGenerating, r.messageLifecycle.State())
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			t.Fatalf("injected idle prompt should not start idle while generating: %+v", typed)
+		}
+	}
+
+	h.HandleLLMResponseDone(context.Background(), internal_type.LLMResponseDonePacket{
+		ContextID: newContextID,
+		Text:      message,
+	})
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantGenerated, r.messageLifecycle.State())
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			t.Fatalf("idle prompt should not start idle at LLM done before TTS completion: %+v", typed)
+		}
+	}
+
+	h.HandleTextToSpeechDone(context.Background(), internal_type.TextToSpeechDonePacket{
+		ContextID: newContextID,
+		Text:      message,
+	})
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantSpeaking, r.messageLifecycle.State())
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			t.Fatalf("audio idle prompt should wait for TTS end before idle restart: %+v", typed)
+		}
+	}
+
+	h.HandleTextToSpeechEnd(context.Background(), internal_type.TextToSpeechEndPacket{ContextID: newContextID})
+
+	var startIdleTimeout internal_type.StartIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			startIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, newContextID, startIdleTimeout.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+}
+
+func TestHandleLLMResponseDone_DoesNotStartIdleTimeout(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+
+	h.HandleLLMResponseDone(context.Background(), internal_type.LLMResponseDonePacket{
+		ContextID: contextID,
+		Text:      "done",
+	})
+
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			t.Fatalf("LLM done should not start idle timeout before assistant finishes: %+v", typed)
+		}
+	}
+}
+
+func TestHandleTextToSpeechDone_TextModeStartsIdleTimeout(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.AssistantFinished(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantIdle(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantGenerating(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantGenerated(contextID))
+
+	h.HandleTextToSpeechDone(context.Background(), internal_type.TextToSpeechDonePacket{
+		ContextID: contextID,
+		Text:      "done",
+	})
+
+	var startIdleTimeout internal_type.StartIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			startIdleTimeout = typed
+		}
+	}
 	assert.Equal(t, contextID, startIdleTimeout.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+}
+
+func TestHandleTextToSpeechDone_AudioModeWaitsForTextToSpeechEndBeforeIdleTimeout(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	r.messageLifecycle.SetMode(type_enums.AudioMode)
+	r.textToSpeechTransformer = noopSpeechToTextTransformer{}
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.AssistantFinished(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantIdle(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantGenerating(contextID))
+	require.NoError(t, r.messageLifecycle.AssistantGenerated(contextID))
+
+	h.HandleTextToSpeechDone(context.Background(), internal_type.TextToSpeechDonePacket{
+		ContextID: contextID,
+		Text:      "done",
+	})
+
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			t.Fatalf("audio TTS done should wait for TTS end before idle timeout: %+v", typed)
+		}
+	}
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantSpeaking, r.messageLifecycle.State())
+
+	h.HandleTextToSpeechEnd(context.Background(), internal_type.TextToSpeechEndPacket{ContextID: contextID})
+
+	var startIdleTimeout internal_type.StartIdleTimeoutPacket
+	for _, packet := range drainEgressPackets(r) {
+		if typed, ok := packet.(internal_type.StartIdleTimeoutPacket); ok {
+			startIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, contextID, startIdleTimeout.ContextID)
+	assert.Equal(t, adapter_lifecycle.MessageStateAssistantIdle, r.messageLifecycle.State())
+}
+
+func TestHandleUnclearInputExpired_AudioModeBlocksInputUntilTextToSpeechEnd(t *testing.T) {
+	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
+	r.messageLifecycle.SetMode(type_enums.AudioMode)
+	h := requestorDispatchHandler{r: r}
+	contextID := r.GetID()
+	require.NoError(t, r.messageLifecycle.BeginInterrupt(contextID))
+
+	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: contextID})
+
+	newContextID := r.GetID()
+	require.NotEqual(t, contextID, newContextID)
+	controlPackets := drainControlPackets(r)
+	require.Len(t, controlPackets, 6)
+
+	audioPolicy, ok := controlPackets[3].(internal_type.DispatchPolicyPacket)
+	require.True(t, ok)
+	assert.Equal(t, newContextID, audioPolicy.ContextID)
+	assert.Equal(t, internal_type.PacketNameUserAudioReceived, audioPolicy.Policy.Target)
+	assert.Equal(t, internal_type.DispatchActionIgnore, audioPolicy.Policy.Action)
+
+	textPolicy, ok := controlPackets[4].(internal_type.DispatchPolicyPacket)
+	require.True(t, ok)
+	assert.Equal(t, newContextID, textPolicy.ContextID)
+	assert.Equal(t, internal_type.PacketNameUserTextReceived, textPolicy.Policy.Target)
+	assert.Equal(t, internal_type.DispatchActionIgnore, textPolicy.Policy.Action)
+
+	interruptionPolicy, ok := controlPackets[5].(internal_type.DispatchPolicyPacket)
+	require.True(t, ok)
+	assert.Equal(t, newContextID, interruptionPolicy.ContextID)
+	assert.Equal(t, internal_type.PacketNameInterruptionDetected, interruptionPolicy.Policy.Target)
+	assert.Equal(t, internal_type.DispatchActionIgnore, interruptionPolicy.Policy.Action)
+
+	ttsInterrupt, ok := controlPackets[1].(internal_type.TextToSpeechInterruptPacket)
+	require.True(t, ok)
+	assert.Equal(t, contextID, ttsInterrupt.ContextID)
 }

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_interruption_test.go
@@ -192,8 +192,6 @@ func TestHandleUserText_TextModeRotatesAfterPreviousUserFinished(t *testing.T) {
 
 func TestHandleUserText_TextModeDoesNotRotateWhileUserSpeaking(t *testing.T) {
 	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-user-speaking", type_enums.TextMode)
-	require.NoError(t, lifecycle.AssistantGenerating("ctx-user-speaking"))
-	require.NoError(t, lifecycle.BeginInterrupt("ctx-user-speaking"))
 	require.NoError(t, lifecycle.UserSpeaking("ctx-user-speaking"))
 	r := &genericRequestor{
 		streamer:         &streamTestStreamer{},
@@ -222,10 +220,9 @@ func TestHandleUserText_TextModeDoesNotRotateWhileUserSpeaking(t *testing.T) {
 	assert.Equal(t, "ctx-user-speaking", eos.ContextID)
 }
 
-func TestHandleUserText_TextModeDoesNotRotateWhenAlreadyInterrupted(t *testing.T) {
-	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-interrupt", type_enums.TextMode)
-	require.NoError(t, lifecycle.AssistantGenerating("ctx-interrupt"))
-	require.NoError(t, lifecycle.BeginInterrupt("ctx-interrupt"))
+func TestHandleUserText_TextModeDoesNotRotateWhenUserTurnActive(t *testing.T) {
+	lifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-listening", type_enums.TextMode)
+	require.NoError(t, lifecycle.UserListening("ctx-listening"))
 	r := &genericRequestor{
 		streamer:         &streamTestStreamer{},
 		channels:         adapter_channel.NewRequestorChannels(),
@@ -235,11 +232,11 @@ func TestHandleUserText_TextModeDoesNotRotateWhenAlreadyInterrupted(t *testing.T
 	h := requestorDispatchHandler{r: r}
 
 	h.HandleUserText(context.Background(), internal_type.UserTextReceivedPacket{
-		ContextID: "ctx-interrupt",
-		Text:      "same interrupt text",
+		ContextID: "ctx-listening",
+		Text:      "same turn text",
 	})
 
-	assert.Equal(t, "ctx-interrupt", r.GetID())
+	assert.Equal(t, "ctx-listening", r.GetID())
 	assert.Empty(t, drainControlPackets(r))
 	assert.Empty(t, drainEgressPackets(r))
 
@@ -247,10 +244,10 @@ func TestHandleUserText_TextModeDoesNotRotateWhenAlreadyInterrupted(t *testing.T
 	require.Len(t, ingressPackets, 2)
 	interim, ok := ingressPackets[0].(internal_type.InterimEndOfSpeechPacket)
 	require.True(t, ok, "expected InterimEndOfSpeechPacket, got %T", ingressPackets[0])
-	assert.Equal(t, "ctx-interrupt", interim.ContextID)
+	assert.Equal(t, "ctx-listening", interim.ContextID)
 	eos, ok := ingressPackets[1].(internal_type.EndOfSpeechPacket)
 	require.True(t, ok, "expected EndOfSpeechPacket, got %T", ingressPackets[1])
-	assert.Equal(t, "ctx-interrupt", eos.ContextID)
+	assert.Equal(t, "ctx-listening", eos.ContextID)
 }
 
 func TestHandleInterruptionDetected_TextModeIgnoresStaleWordInterruption(t *testing.T) {
@@ -778,7 +775,7 @@ func TestHandleEndOfSpeech_StopsUnclearInputWatchdogForAcceptedSpeech(t *testing
 	}, 80*time.Millisecond, 10*time.Millisecond)
 }
 
-func TestHandleEndOfSpeech_DoesNotFinalizeWhileVADSpeaking(t *testing.T) {
+func TestHandleEndOfSpeech_FinalizesWhenEOSCompletesDuringVADSpeaking(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
 	oldContextID := r.GetID()
@@ -800,20 +797,34 @@ func TestHandleEndOfSpeech_DoesNotFinalizeWhileVADSpeaking(t *testing.T) {
 	})
 
 	assert.Equal(t, turnContextID, r.GetID())
-	assert.Equal(t, adapter_lifecycle.MessageStateUserSpeaking, r.messageLifecycle.State())
-	assert.Empty(t, drainIngressPackets(r))
+	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
+	ingressPackets := drainIngressPackets(r)
+	require.Len(t, ingressPackets, 1)
+	userInput, ok := ingressPackets[0].(internal_type.UserInputPacket)
+	require.True(t, ok, "expected UserInputPacket, got %T", ingressPackets[0])
+	assert.Equal(t, turnContextID, userInput.ContextID)
+	assert.Equal(t, "still speaking", userInput.Text)
+}
+
+func TestHandleEndOfSpeech_FinalizesDuringVADSpeakingWithoutWatchdog(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
 
 	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
 		ContextID: oldContextID,
 		Source:    internal_type.InterruptionSourceVad,
-		Event:     internal_type.InterruptionEventEnd,
+		Event:     internal_type.InterruptionEventStart,
 	})
+
+	turnContextID := r.GetID()
+	require.NotEqual(t, oldContextID, turnContextID)
 	drainControlPackets(r)
 	drainEgressPackets(r)
 
 	h.HandleEndOfSpeech(context.Background(), internal_type.EndOfSpeechPacket{
 		ContextID: turnContextID,
-		Speech:    "done speaking",
+		Speech:    "fallback speech",
 	})
 
 	assert.Equal(t, adapter_lifecycle.MessageStateUserFinished, r.messageLifecycle.State())
@@ -822,7 +833,7 @@ func TestHandleEndOfSpeech_DoesNotFinalizeWhileVADSpeaking(t *testing.T) {
 	userInput, ok := ingressPackets[0].(internal_type.UserInputPacket)
 	require.True(t, ok, "expected UserInputPacket, got %T", ingressPackets[0])
 	assert.Equal(t, turnContextID, userInput.ContextID)
-	assert.Equal(t, "done speaking", userInput.Text)
+	assert.Equal(t, "fallback speech", userInput.Text)
 }
 
 func TestHandleSpeechToText_FinalStopsUnclearInputWatchdog(t *testing.T) {
@@ -931,8 +942,9 @@ func TestHandleSpeechToText_InterimStartsTurnAndFinalKeepsContext(t *testing.T) 
 func TestHandleUnclearInputExpired_InjectsConfiguredMessage(t *testing.T) {
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
 	h := requestorDispatchHandler{r: r}
-	contextID := r.GetID()
-	require.NoError(t, r.messageLifecycle.BeginInterrupt(contextID))
+	_, contextID, err := r.messageLifecycle.RotateContext()
+	require.NoError(t, err)
+	require.NoError(t, r.messageLifecycle.UserListening(contextID))
 
 	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: contextID})
 
@@ -1127,6 +1139,55 @@ func TestHandleUnclearInputExpired_WordTriggerRotatesFromInterruptedContextAndIn
 	}
 	assert.Equal(t, promptContextID, injectMessage.ContextID)
 	assert.Equal(t, "I didn't catch that.", injectMessage.Text)
+}
+
+func TestHandleInterruptionDetected_ForwardsVADEndToEOSWhenLifecycleAlreadyListening(t *testing.T) {
+	r := newInterruptionTestRequestor(internal_options.BargeInTriggerVAD)
+	executor := &recordingEOSExecutor{}
+	r.endOfSpeechExecutor = executor
+	h := requestorDispatchHandler{r: r}
+	oldContextID := r.GetID()
+
+	h.HandleSpeechToText(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: oldContextID,
+		Script:    "hello",
+		Interim:   false,
+	})
+	turnContextID := r.GetID()
+	require.NotEqual(t, oldContextID, turnContextID)
+	require.Equal(t, adapter_lifecycle.MessageStateUserListening, r.messageLifecycle.State())
+
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: turnContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventStart,
+	})
+	h.HandleInterruptionDetected(context.Background(), internal_type.InterruptionDetectedPacket{
+		ContextID: turnContextID,
+		Source:    internal_type.InterruptionSourceVad,
+		Event:     internal_type.InterruptionEventEnd,
+	})
+
+	controlPackets := drainControlPackets(r)
+	var sttEnd internal_type.SpeechToTextEndPacket
+	for _, packet := range controlPackets {
+		if typed, ok := packet.(internal_type.SpeechToTextEndPacket); ok {
+			sttEnd = typed
+		}
+	}
+	assert.Equal(t, turnContextID, sttEnd.ContextID)
+
+	executed := executor.snapshotExecuted()
+	require.Len(t, executed, 3)
+	_, ok := executed[0].(internal_type.SpeechToTextPacket)
+	require.True(t, ok, "expected STT packet, got %T", executed[0])
+	vadStart, ok := executed[1].(internal_type.InterruptionDetectedPacket)
+	require.True(t, ok, "expected VAD start packet, got %T", executed[1])
+	assert.Equal(t, internal_type.InterruptionEventStart, vadStart.Event)
+	vadEnd, ok := executed[2].(internal_type.InterruptionDetectedPacket)
+	require.True(t, ok, "expected VAD end packet, got %T", executed[2])
+	assert.Equal(t, internal_type.InterruptionEventEnd, vadEnd.Event)
+	assert.Equal(t, turnContextID, vadEnd.ContextID)
 }
 
 func TestHandleUnclearInputExpired_IgnoresWhenInterruptionIsNotPending(t *testing.T) {
@@ -1349,35 +1410,41 @@ func TestHandleUnclearInputExpired_AudioModeBlocksInputUntilTextToSpeechEnd(t *t
 	r := newUnclearInputTestRequestor(internal_options.BargeInTriggerVAD, 0.03, "Please say that again.")
 	r.messageLifecycle.SetMode(type_enums.AudioMode)
 	h := requestorDispatchHandler{r: r}
-	contextID := r.GetID()
-	require.NoError(t, r.messageLifecycle.BeginInterrupt(contextID))
+	_, contextID, err := r.messageLifecycle.RotateContext()
+	require.NoError(t, err)
+	require.NoError(t, r.messageLifecycle.UserListening(contextID))
 
 	h.HandleUnclearInputExpired(context.Background(), internal_type.UnclearInputExpiredPacket{ContextID: contextID})
 
 	newContextID := r.GetID()
 	require.NotEqual(t, contextID, newContextID)
 	controlPackets := drainControlPackets(r)
-	require.Len(t, controlPackets, 6)
+	require.Len(t, controlPackets, 7)
 
-	audioPolicy, ok := controlPackets[3].(internal_type.DispatchPolicyPacket)
+	turnChange, ok := controlPackets[1].(internal_type.TurnChangePacket)
+	require.True(t, ok)
+	assert.Equal(t, newContextID, turnChange.ContextID)
+	assert.Equal(t, contextID, turnChange.PreviousContextID)
+
+	audioPolicy, ok := controlPackets[4].(internal_type.DispatchPolicyPacket)
 	require.True(t, ok)
 	assert.Equal(t, newContextID, audioPolicy.ContextID)
 	assert.Equal(t, internal_type.PacketNameUserAudioReceived, audioPolicy.Policy.Target)
 	assert.Equal(t, internal_type.DispatchActionIgnore, audioPolicy.Policy.Action)
 
-	textPolicy, ok := controlPackets[4].(internal_type.DispatchPolicyPacket)
+	textPolicy, ok := controlPackets[5].(internal_type.DispatchPolicyPacket)
 	require.True(t, ok)
 	assert.Equal(t, newContextID, textPolicy.ContextID)
 	assert.Equal(t, internal_type.PacketNameUserTextReceived, textPolicy.Policy.Target)
 	assert.Equal(t, internal_type.DispatchActionIgnore, textPolicy.Policy.Action)
 
-	interruptionPolicy, ok := controlPackets[5].(internal_type.DispatchPolicyPacket)
+	interruptionPolicy, ok := controlPackets[6].(internal_type.DispatchPolicyPacket)
 	require.True(t, ok)
 	assert.Equal(t, newContextID, interruptionPolicy.ContextID)
 	assert.Equal(t, internal_type.PacketNameInterruptionDetected, interruptionPolicy.Policy.Target)
 	assert.Equal(t, internal_type.DispatchActionIgnore, interruptionPolicy.Policy.Action)
 
-	ttsInterrupt, ok := controlPackets[1].(internal_type.TextToSpeechInterruptPacket)
+	ttsInterrupt, ok := controlPackets[2].(internal_type.TextToSpeechInterruptPacket)
 	require.True(t, ok)
 	assert.Equal(t, contextID, ttsInterrupt.ContextID)
 }

--- a/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
@@ -159,13 +159,11 @@ func TestInitializeBehavior_GreetingInterruptibleOption_ControlsAudioBlock(t *te
 						},
 					},
 				},
-				messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+				messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-greeting-init", type_enums.AudioMode),
 				sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
 				dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
 				channels:         requestorChannels,
 			}
-			requestor.messageLifecycle.SetContextID("ctx-greeting-init")
-			requestor.messageLifecycle.SetMode(type_enums.AudioMode)
 
 			requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
 				ContextID: "ctx-greeting-init",
@@ -214,12 +212,11 @@ func TestInitializeBehavior_GreetingDoesNotStartIdleTimeoutBeforeCompletion(t *t
 				},
 			},
 		},
-		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-greeting-idle", type_enums.TextMode),
 		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
 		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
 		channels:         requestorChannels,
 	}
-	requestor.messageLifecycle.SetContextID("ctx-greeting-idle")
 
 	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
 		ContextID: "ctx-greeting-idle",
@@ -251,12 +248,11 @@ func TestInitializeBehavior_StartsIdleTimeoutWhenNoGreetingIsInjected(t *testing
 				},
 			},
 		},
-		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-no-greeting-idle", type_enums.TextMode),
 		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
 		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
 		channels:         requestorChannels,
 	}
-	requestor.messageLifecycle.SetContextID("ctx-no-greeting-idle")
 
 	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
 		ContextID: "ctx-no-greeting-idle",
@@ -288,13 +284,11 @@ func TestInitializeBehavior_NonInterruptibleGreeting_BlocksAudioAndAcceptsAfterT
 				},
 			},
 		},
-		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-greeting-audio", type_enums.AudioMode),
 		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
 		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
 		channels:         requestorChannels,
 	}
-	requestor.messageLifecycle.SetContextID("ctx-greeting-audio")
-	requestor.messageLifecycle.SetMode(type_enums.AudioMode)
 
 	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
 		ContextID: "ctx-greeting-audio",
@@ -349,13 +343,11 @@ func TestInitializeBehavior_NonInterruptibleGreeting_TextInputDoesNotKeepAudioBl
 				},
 			},
 		},
-		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycleWithContext("ctx-greeting-text", type_enums.AudioMode),
 		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
 		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
 		channels:         requestorChannels,
 	}
-	requestor.messageLifecycle.SetContextID("ctx-greeting-text")
-	requestor.messageLifecycle.SetMode(type_enums.AudioMode)
 
 	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
 		ContextID: "ctx-greeting-text",

--- a/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
@@ -200,6 +200,78 @@ func TestInitializeBehavior_GreetingInterruptibleOption_ControlsAudioBlock(t *te
 	}
 }
 
+func TestInitializeBehavior_GreetingDoesNotStartIdleTimeoutBeforeCompletion(t *testing.T) {
+	greeting := "Welcome!"
+	idleTimeout := uint64(10)
+	requestorChannels := adapter_channel.NewRequestorChannels()
+	requestor := &genericRequestor{
+		source: utils.Debugger,
+		assistant: &internal_assistant_entity.Assistant{
+			AssistantDebuggerDeployment: &internal_assistant_entity.AssistantDebuggerDeployment{
+				AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
+					Greeting:    &greeting,
+					IdleTimeout: &idleTimeout,
+				},
+			},
+		},
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
+		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
+		channels:         requestorChannels,
+	}
+	requestor.messageLifecycle.SetContextID("ctx-greeting-idle")
+
+	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
+		ContextID: "ctx-greeting-idle",
+		Config:    &protos.ConversationInitialization{StreamMode: protos.StreamMode_STREAM_MODE_TEXT},
+	})
+
+	var injectMessage internal_type.InjectMessagePacket
+	for len(requestor.channels.EgressChannel()) > 0 {
+		packet := (<-requestor.channels.EgressChannel()).Pkt
+		switch typed := packet.(type) {
+		case internal_type.InjectMessagePacket:
+			injectMessage = typed
+		case internal_type.StartIdleTimeoutPacket:
+			t.Fatalf("greeting should not start idle timeout before assistant completion: %+v", typed)
+		}
+	}
+	assert.Equal(t, greeting, injectMessage.Text)
+}
+
+func TestInitializeBehavior_StartsIdleTimeoutWhenNoGreetingIsInjected(t *testing.T) {
+	idleTimeout := uint64(10)
+	requestorChannels := adapter_channel.NewRequestorChannels()
+	requestor := &genericRequestor{
+		source: utils.Debugger,
+		assistant: &internal_assistant_entity.Assistant{
+			AssistantDebuggerDeployment: &internal_assistant_entity.AssistantDebuggerDeployment{
+				AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
+					IdleTimeout: &idleTimeout,
+				},
+			},
+		},
+		messageLifecycle: adapter_lifecycle.NewMessageLifecycle(),
+		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateInitializing),
+		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), requestorChannels),
+		channels:         requestorChannels,
+	}
+	requestor.messageLifecycle.SetContextID("ctx-no-greeting-idle")
+
+	requestorDispatchHandler{r: requestor}.HandleInitializeBehavior(context.Background(), internal_type.InitializeBehaviorPacket{
+		ContextID: "ctx-no-greeting-idle",
+		Config:    &protos.ConversationInitialization{StreamMode: protos.StreamMode_STREAM_MODE_TEXT},
+	})
+
+	var startIdleTimeout internal_type.StartIdleTimeoutPacket
+	for len(requestor.channels.EgressChannel()) > 0 {
+		if typed, ok := (<-requestor.channels.EgressChannel()).Pkt.(internal_type.StartIdleTimeoutPacket); ok {
+			startIdleTimeout = typed
+		}
+	}
+	assert.Equal(t, "ctx-no-greeting-idle", startIdleTimeout.ContextID)
+}
+
 func TestInitializeBehavior_NonInterruptibleGreeting_BlocksAudioAndAcceptsAfterTextToSpeechEnd(t *testing.T) {
 	greeting := "Welcome!"
 	nonInterruptibleGreeting := false

--- a/api/assistant-api/internal/adapters/internal/dispatch_init_packets_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_init_packets_test.go
@@ -450,9 +450,7 @@ func TestHandleInitializationCompleted_EmitsConversationWebhookRecord(t *testing
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			requestorChannels := adapter_channel.NewRequestorChannels()
-			messageLifecycle := adapter_lifecycle.NewMessageLifecycle()
-			messageLifecycle.SetContextID("ctx-init-webhook")
-			messageLifecycle.SetMode(type_enums.TextMode)
+			messageLifecycle := adapter_lifecycle.NewMessageLifecycleWithContext("ctx-init-webhook", type_enums.TextMode)
 			requestor := &genericRequestor{
 				source:           utils.Debugger,
 				streamer:         &streamTestStreamer{},

--- a/api/assistant-api/internal/adapters/internal/requestor.go
+++ b/api/assistant-api/internal/adapters/internal/requestor.go
@@ -44,10 +44,6 @@ import (
 )
 
 const (
-	Unknown            = adapter_lifecycle.Unknown
-	Interrupted        = adapter_lifecycle.Interrupted
-	LLMGenerating      = adapter_lifecycle.LLMGenerating
-	LLMGenerated       = adapter_lifecycle.LLMGenerated
 	dbWriteTimeout     = 5 * time.Second
 	recordingTimeout   = 3*storages.FileWriteTimeout + dbWriteTimeout
 	connectDeadline    = 30 * time.Second
@@ -311,8 +307,6 @@ func (dm *genericRequestor) GetHistories() []internal_type.MessagePacket {
 // Interaction state methods — inline replacement for the former Messaging wrapper
 // =============================================================================
 
-// GetID returns the current interaction context UUID.
-// Rotates to a new UUID each time an Interrupted transition fires.
 func (r *genericRequestor) GetID() string {
 	return r.messageLifecycle.ContextID()
 }
@@ -325,29 +319,6 @@ func (r *genericRequestor) GetMode() type_enums.MessageMode {
 // SwitchMode sets the stream mode.
 func (r *genericRequestor) SwitchMode(mm type_enums.MessageMode) {
 	r.messageLifecycle.SetMode(mm)
-}
-
-func (r *genericRequestor) Transition(newState adapter_lifecycle.MessageState) error {
-	oldCtxID := r.GetID()
-	if err := r.messageLifecycle.Transition(newState); err != nil {
-		return err
-	}
-	if newState == Interrupted {
-		nCtxID := r.GetID()
-		if oldCtxID == nCtxID {
-			return nil
-		}
-		utils.Go(context.Background(), func() {
-			r.OnPacket(context.Background(), internal_type.TurnChangePacket{
-				ContextID:         nCtxID,
-				PreviousContextID: oldCtxID,
-				Reason:            "interrupted",
-				Source:            "state_machine",
-				Time:              time.Now(),
-			})
-		})
-	}
-	return nil
 }
 
 func (r *genericRequestor) canSwitchSession() bool {

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
@@ -42,8 +42,7 @@ var (
 
 type MessageLifecycle interface {
 	ContextID() string
-	SetContextID(string)
-	RotateContext() (string, error)
+	RotateContext() (string, string, error)
 	Mode() type_enums.MessageMode
 	SetMode(type_enums.MessageMode)
 	State() MessageState
@@ -62,7 +61,6 @@ type MessageLifecycle interface {
 	AssistantPrompted(string) error
 	AssistantPromptCount() uint64
 	BeginInterrupt(string) error
-	CommitInterrupt() (string, string, error)
 	CancelInterrupt(string) error
 }
 
@@ -73,32 +71,26 @@ type messageLifecycle struct {
 	state            MessageState
 	userPrompts      uint64
 	assistantPrompts uint64
-	nextContextID    func() string
 }
 
 func NewMessageLifecycle() MessageLifecycle {
-	return NewMessageLifecycleWithContext(uuid.NewString(), type_enums.TextMode, uuid.NewString)
+	return NewMessageLifecycleWithContext(uuid.NewString(), type_enums.TextMode)
 }
 
 func NewMessageLifecycleWithContext(
 	initialContextID string,
 	initialMode type_enums.MessageMode,
-	nextContextID func() string,
 ) MessageLifecycle {
 	if initialContextID == "" {
 		initialContextID = uuid.NewString()
-	}
-	if nextContextID == nil {
-		nextContextID = uuid.NewString
 	}
 	if initialMode == "" {
 		initialMode = type_enums.TextMode
 	}
 	return &messageLifecycle{
-		contextID:     initialContextID,
-		mode:          initialMode,
-		state:         MessageStateAssistantIdle,
-		nextContextID: nextContextID,
+		contextID: initialContextID,
+		mode:      initialMode,
+		state:     MessageStateAssistantIdle,
 	}
 }
 
@@ -108,24 +100,15 @@ func (l *messageLifecycle) ContextID() string {
 	return l.contextID
 }
 
-func (l *messageLifecycle) SetContextID(id string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.contextID = id
-	l.state = MessageStateAssistantIdle
-}
-
-func (l *messageLifecycle) RotateContext() (string, error) {
+func (l *messageLifecycle) RotateContext() (string, string, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	nctx := l.nextContextID()
-	if nctx == "" {
-		return "", fmt.Errorf("RotateContext: generated empty context id")
-	}
-	l.contextID = nctx
+	oldContextID := l.contextID
+	newContextID := uuid.NewString()
+	l.contextID = newContextID
 	l.state = MessageStateAssistantIdle
-	return nctx, nil
+	return oldContextID, newContextID, nil
 }
 
 func (l *messageLifecycle) Mode() type_enums.MessageMode {
@@ -153,7 +136,7 @@ func (l *messageLifecycle) UserIdle(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle:
+	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle:
 		l.state = MessageStateUserIdle
 		return nil
 	default:
@@ -168,7 +151,7 @@ func (l *messageLifecycle) UserListening(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening:
+	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
 		l.state = MessageStateUserListening
 		return nil
 	default:
@@ -183,7 +166,7 @@ func (l *messageLifecycle) UserSpeaking(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
+	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
 		l.state = MessageStateUserSpeaking
 		return nil
 	default:
@@ -353,25 +336,6 @@ func (l *messageLifecycle) BeginInterrupt(contextID string) error {
 	default:
 		return fmt.Errorf("%w: interrupt from %s", ErrInvalidTransition, l.state)
 	}
-}
-
-func (l *messageLifecycle) CommitInterrupt() (string, string, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking, MessageStateUserPrompted:
-	default:
-		return "", "", fmt.Errorf("%w: commit_interrupt from %s", ErrInvalidTransition, l.state)
-	}
-
-	oldContextID := l.contextID
-	newContextID := l.nextContextID()
-	if newContextID == "" {
-		return "", "", fmt.Errorf("CommitInterrupt: generated empty context id")
-	}
-	l.contextID = newContextID
-	l.state = MessageStateAssistantIdle
-	return oldContextID, newContextID, nil
 }
 
 func (l *messageLifecycle) CancelInterrupt(contextID string) error {

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
@@ -6,6 +6,7 @@
 package lifecycle
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -13,58 +14,73 @@ import (
 	type_enums "github.com/rapidaai/pkg/types/enums"
 )
 
-// MessageState tracks current message/turn processing lifecycle.
-type MessageState int
+type MessageState string
 
 const (
-	Unknown       MessageState = 1
-	Interrupt     MessageState = 6
-	Interrupted   MessageState = 7
-	LLMGenerating MessageState = 8
-	LLMGenerated  MessageState = 5
+	MessageStateInterrupt MessageState = "interrupt"
+
+	MessageStateUserIdle      MessageState = "user_idle"
+	MessageStateUserListening MessageState = "user_listening"
+	MessageStateUserSpeaking  MessageState = "user_speaking"
+	MessageStateUserThinking  MessageState = "user_thinking"
+	MessageStateUserFinished  MessageState = "user_finished"
+	MessageStateUserPrompted  MessageState = "user_prompted"
+
+	MessageStateAssistantGenerating MessageState = "assistant_generating"
+	MessageStateAssistantGenerated  MessageState = "assistant_generated"
+	MessageStateAssistantSpeaking   MessageState = "assistant_speaking"
+	MessageStateAssistantFinished   MessageState = "assistant_finished"
+	MessageStateAssistantIdle       MessageState = "assistant_idle"
+	MessageStateAssistantPrompted   MessageState = "assistant_prompted"
 )
 
-func (s MessageState) String() string {
-	switch s {
-	case Unknown:
-		return "Unknown"
-	case LLMGenerated:
-		return "LLMGenerated"
-	case Interrupt:
-		return "Interrupt"
-	case Interrupted:
-		return "Interrupted"
-	case LLMGenerating:
-		return "LLMGenerating"
-	default:
-		return "InvalidState"
-	}
-}
+var (
+	ErrEmptyContextID    = errors.New("empty context id")
+	ErrStaleContext      = errors.New("stale context")
+	ErrInvalidTransition = errors.New("invalid message lifecycle transition")
+)
 
 type MessageLifecycle interface {
-	Current() MessageState
-	CanBe(MessageState) bool
-	Transition(MessageState) error
 	ContextID() string
 	SetContextID(string)
+	RotateContext() (string, error)
 	Mode() type_enums.MessageMode
 	SetMode(type_enums.MessageMode)
+	State() MessageState
+	UserIdle(string) error
+	UserListening(string) error
+	UserSpeaking(string) error
+	UserThinking(string) error
+	UserFinished(string) error
+	UserPrompted(string) error
+	UserPromptCount() uint64
+	AssistantGenerating(string) error
+	AssistantGenerated(string) error
+	AssistantSpeaking(string) error
+	AssistantFinished(string) error
+	AssistantIdle(string) error
+	AssistantPrompted(string) error
+	AssistantPromptCount() uint64
+	BeginInterrupt(string) error
+	CommitInterrupt() (string, string, error)
+	CancelInterrupt(string) error
 }
 
 type messageLifecycle struct {
-	mu            sync.RWMutex
-	state         MessageState
-	contextID     string
-	mode          type_enums.MessageMode
-	nextContextID func() string
+	mu               sync.RWMutex
+	contextID        string
+	mode             type_enums.MessageMode
+	state            MessageState
+	userPrompts      uint64
+	assistantPrompts uint64
+	nextContextID    func() string
 }
 
 func NewMessageLifecycle() MessageLifecycle {
-	return NewMessageLifecycleWithState(Unknown, uuid.NewString(), type_enums.TextMode, uuid.NewString)
+	return NewMessageLifecycleWithContext(uuid.NewString(), type_enums.TextMode, uuid.NewString)
 }
 
-func NewMessageLifecycleWithState(
-	initial MessageState,
+func NewMessageLifecycleWithContext(
 	initialContextID string,
 	initialMode type_enums.MessageMode,
 	nextContextID func() string,
@@ -79,40 +95,11 @@ func NewMessageLifecycleWithState(
 		initialMode = type_enums.TextMode
 	}
 	return &messageLifecycle{
-		state:         initial,
 		contextID:     initialContextID,
 		mode:          initialMode,
+		state:         MessageStateAssistantIdle,
 		nextContextID: nextContextID,
 	}
-}
-
-func (l *messageLifecycle) Current() MessageState {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return l.state
-}
-
-func (l *messageLifecycle) CanBe(next MessageState) bool {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return canTransitionMessage(l.state, next) == nil
-}
-
-func (l *messageLifecycle) Transition(next MessageState) error {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if err := canTransitionMessage(l.state, next); err != nil {
-		return err
-	}
-	if next == Interrupted {
-		nctx := l.nextContextID()
-		if nctx == "" {
-			return fmt.Errorf("Transition: generated empty context id")
-		}
-		l.contextID = nctx
-	}
-	l.state = next
-	return nil
 }
 
 func (l *messageLifecycle) ContextID() string {
@@ -125,6 +112,20 @@ func (l *messageLifecycle) SetContextID(id string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.contextID = id
+	l.state = MessageStateAssistantIdle
+}
+
+func (l *messageLifecycle) RotateContext() (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	nctx := l.nextContextID()
+	if nctx == "" {
+		return "", fmt.Errorf("RotateContext: generated empty context id")
+	}
+	l.contextID = nctx
+	l.state = MessageStateAssistantIdle
+	return nctx, nil
 }
 
 func (l *messageLifecycle) Mode() type_enums.MessageMode {
@@ -139,21 +140,261 @@ func (l *messageLifecycle) SetMode(mode type_enums.MessageMode) {
 	l.mode = mode
 }
 
-func canTransitionMessage(current, next MessageState) error {
-	switch next {
-	case Unknown:
-		return fmt.Errorf("Transition: cannot transition to Unknown state")
-	case Interrupt:
-		if current == Interrupted || current == Interrupt {
-			return fmt.Errorf("Transition: cannot soft-interrupt from state %s", current)
-		}
-		if current == Unknown {
-			return fmt.Errorf("Transition: nothing active to soft-interrupt in state %s", current)
-		}
-	case Interrupted:
-		if current == Interrupted {
-			return fmt.Errorf("Transition: already interrupted")
-		}
+func (l *messageLifecycle) State() MessageState {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.state
+}
+
+func (l *messageLifecycle) UserIdle(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle:
+		l.state = MessageStateUserIdle
+		return nil
+	default:
+		return fmt.Errorf("%w: user_idle from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserListening(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening:
+		l.state = MessageStateUserListening
+		return nil
+	default:
+		return fmt.Errorf("%w: user_listening from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserSpeaking(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
+		l.state = MessageStateUserSpeaking
+		return nil
+	default:
+		return fmt.Errorf("%w: user_speaking from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserThinking(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
+		l.state = MessageStateUserThinking
+		return nil
+	default:
+		return fmt.Errorf("%w: user_thinking from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserFinished(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking, MessageStateUserFinished:
+		l.state = MessageStateUserFinished
+		return nil
+	default:
+		return fmt.Errorf("%w: user_finished from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserPrompted(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
+		l.state = MessageStateUserPrompted
+		l.userPrompts++
+		return nil
+	default:
+		return fmt.Errorf("%w: user_prompted from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) UserPromptCount() uint64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.userPrompts
+}
+
+func (l *messageLifecycle) AssistantGenerating(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantIdle, MessageStateAssistantFinished, MessageStateAssistantPrompted, MessageStateUserFinished, MessageStateUserPrompted, MessageStateAssistantGenerating:
+		l.state = MessageStateAssistantGenerating
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_generating from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantGenerated(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantGenerating, MessageStateAssistantGenerated:
+		l.state = MessageStateAssistantGenerated
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_generated from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantSpeaking(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantGenerating, MessageStateAssistantGenerated, MessageStateAssistantSpeaking, MessageStateAssistantPrompted:
+		l.state = MessageStateAssistantSpeaking
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_speaking from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantFinished(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantGenerating, MessageStateAssistantGenerated, MessageStateAssistantSpeaking, MessageStateAssistantFinished:
+		l.state = MessageStateAssistantFinished
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_finished from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantIdle(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantFinished, MessageStateAssistantIdle:
+		l.state = MessageStateAssistantIdle
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_idle from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantPrompted(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantIdle:
+		l.state = MessageStateAssistantPrompted
+		l.assistantPrompts++
+		return nil
+	default:
+		return fmt.Errorf("%w: assistant_prompted from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) AssistantPromptCount() uint64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.assistantPrompts
+}
+
+func (l *messageLifecycle) BeginInterrupt(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateAssistantGenerating, MessageStateAssistantGenerated, MessageStateAssistantSpeaking, MessageStateAssistantPrompted:
+		l.state = MessageStateInterrupt
+		return nil
+	default:
+		return fmt.Errorf("%w: interrupt from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) CommitInterrupt() (string, string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking, MessageStateUserPrompted:
+	default:
+		return "", "", fmt.Errorf("%w: commit_interrupt from %s", ErrInvalidTransition, l.state)
+	}
+
+	oldContextID := l.contextID
+	newContextID := l.nextContextID()
+	if newContextID == "" {
+		return "", "", fmt.Errorf("CommitInterrupt: generated empty context id")
+	}
+	l.contextID = newContextID
+	l.state = MessageStateAssistantIdle
+	return oldContextID, newContextID, nil
+}
+
+func (l *messageLifecycle) CancelInterrupt(contextID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.validateContextLocked(contextID); err != nil {
+		return err
+	}
+	switch l.state {
+	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
+		l.state = MessageStateAssistantSpeaking
+		return nil
+	default:
+		return fmt.Errorf("%w: cancel_interrupt from %s", ErrInvalidTransition, l.state)
+	}
+}
+
+func (l *messageLifecycle) validateContextLocked(contextID string) error {
+	if contextID == "" {
+		return ErrEmptyContextID
+	}
+	if contextID != l.contextID {
+		return fmt.Errorf("%w: got %s, current %s", ErrStaleContext, contextID, l.contextID)
 	}
 	return nil
 }

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go
@@ -17,8 +17,6 @@ import (
 type MessageState string
 
 const (
-	MessageStateInterrupt MessageState = "interrupt"
-
 	MessageStateUserIdle      MessageState = "user_idle"
 	MessageStateUserListening MessageState = "user_listening"
 	MessageStateUserSpeaking  MessageState = "user_speaking"
@@ -60,8 +58,6 @@ type MessageLifecycle interface {
 	AssistantIdle(string) error
 	AssistantPrompted(string) error
 	AssistantPromptCount() uint64
-	BeginInterrupt(string) error
-	CancelInterrupt(string) error
 }
 
 type messageLifecycle struct {
@@ -136,7 +132,7 @@ func (l *messageLifecycle) UserIdle(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle:
+	case MessageStateAssistantIdle, MessageStateUserIdle:
 		l.state = MessageStateUserIdle
 		return nil
 	default:
@@ -151,7 +147,7 @@ func (l *messageLifecycle) UserListening(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
+	case MessageStateAssistantIdle, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
 		l.state = MessageStateUserListening
 		return nil
 	default:
@@ -166,7 +162,7 @@ func (l *messageLifecycle) UserSpeaking(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
+	case MessageStateAssistantIdle, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking:
 		l.state = MessageStateUserSpeaking
 		return nil
 	default:
@@ -181,7 +177,7 @@ func (l *messageLifecycle) UserThinking(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
+	case MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
 		l.state = MessageStateUserThinking
 		return nil
 	default:
@@ -196,7 +192,7 @@ func (l *messageLifecycle) UserFinished(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateAssistantIdle, MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking, MessageStateUserFinished:
+	case MessageStateAssistantIdle, MessageStateUserIdle, MessageStateUserListening, MessageStateUserThinking, MessageStateUserFinished:
 		l.state = MessageStateUserFinished
 		return nil
 	default:
@@ -211,7 +207,7 @@ func (l *messageLifecycle) UserPrompted(contextID string) error {
 		return err
 	}
 	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
+	case MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
 		l.state = MessageStateUserPrompted
 		l.userPrompts++
 		return nil
@@ -321,36 +317,6 @@ func (l *messageLifecycle) AssistantPromptCount() uint64 {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.assistantPrompts
-}
-
-func (l *messageLifecycle) BeginInterrupt(contextID string) error {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if err := l.validateContextLocked(contextID); err != nil {
-		return err
-	}
-	switch l.state {
-	case MessageStateAssistantGenerating, MessageStateAssistantGenerated, MessageStateAssistantSpeaking, MessageStateAssistantPrompted:
-		l.state = MessageStateInterrupt
-		return nil
-	default:
-		return fmt.Errorf("%w: interrupt from %s", ErrInvalidTransition, l.state)
-	}
-}
-
-func (l *messageLifecycle) CancelInterrupt(contextID string) error {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if err := l.validateContextLocked(contextID); err != nil {
-		return err
-	}
-	switch l.state {
-	case MessageStateInterrupt, MessageStateUserIdle, MessageStateUserListening, MessageStateUserSpeaking, MessageStateUserThinking:
-		l.state = MessageStateAssistantSpeaking
-		return nil
-	default:
-		return fmt.Errorf("%w: cancel_interrupt from %s", ErrInvalidTransition, l.state)
-	}
 }
 
 func (l *messageLifecycle) validateContextLocked(contextID string) error {

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMessageLifecycle_DefaultsMode(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.MessageMode(""), func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.MessageMode(""))
 	if got := l.Mode(); got != type_enums.TextMode {
 		t.Fatalf("unexpected mode, got=%v want=%v", got, type_enums.TextMode)
 	}
@@ -18,30 +18,30 @@ func TestMessageLifecycle_DefaultsMode(t *testing.T) {
 }
 
 func TestMessageLifecycle_RotateContext(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx-old", type_enums.MessageMode(""), func() string { return "ctx-new" })
+	l := NewMessageLifecycleWithContext("ctx-old", type_enums.MessageMode(""))
 	if err := l.AssistantGenerating("ctx-old"); err != nil {
 		t.Fatalf("unexpected assistant generating error: %v", err)
 	}
-	if _, err := l.RotateContext(); err != nil {
+	oldContextID, newContextID, err := l.RotateContext()
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := l.ContextID(); got != "ctx-new" {
-		t.Fatalf("unexpected context id, got=%s want=%s", got, "ctx-new")
+	if oldContextID != "ctx-old" {
+		t.Fatalf("unexpected old context id, got=%s want=ctx-old", oldContextID)
+	}
+	if newContextID == "" || newContextID == "ctx-old" {
+		t.Fatalf("unexpected new context id, got=%s", newContextID)
+	}
+	if got := l.ContextID(); got != newContextID {
+		t.Fatalf("unexpected context id, got=%s want=%s", got, newContextID)
 	}
 	if got := l.State(); got != MessageStateAssistantIdle {
 		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
 	}
 }
 
-func TestMessageLifecycle_RotateContextEmptyIDFails(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "" })
-	if _, err := l.RotateContext(); err == nil {
-		t.Fatalf("expected error when generated context id is empty")
-	}
-}
-
 func TestMessageLifecycle_BeginInterruptRequiresAssistantStarted(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.BeginInterrupt("ctx"); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("expected invalid transition, got=%v", err)
 	}
@@ -62,8 +62,8 @@ func TestMessageLifecycle_BeginInterruptRequiresAssistantStarted(t *testing.T) {
 	}
 }
 
-func TestMessageLifecycle_CommitInterruptRotatesAndResetsState(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx-old", type_enums.TextMode, func() string { return "ctx-new" })
+func TestMessageLifecycle_RotateContextAfterInterruptResetsState(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx-old", type_enums.TextMode)
 	if err := l.AssistantGenerating("ctx-old"); err != nil {
 		t.Fatalf("unexpected assistant generating error: %v", err)
 	}
@@ -73,18 +73,18 @@ func TestMessageLifecycle_CommitInterruptRotatesAndResetsState(t *testing.T) {
 	if err := l.UserSpeaking("ctx-old"); err != nil {
 		t.Fatalf("unexpected user speaking error: %v", err)
 	}
-	oldContextID, newContextID, err := l.CommitInterrupt()
+	oldContextID, newContextID, err := l.RotateContext()
 	if err != nil {
-		t.Fatalf("unexpected commit interrupt error: %v", err)
+		t.Fatalf("unexpected rotate context error: %v", err)
 	}
 	if oldContextID != "ctx-old" {
 		t.Fatalf("unexpected old context id, got=%s want=ctx-old", oldContextID)
 	}
-	if newContextID != "ctx-new" {
-		t.Fatalf("unexpected new context id, got=%s want=ctx-new", newContextID)
+	if newContextID == "" || newContextID == "ctx-old" {
+		t.Fatalf("unexpected new context id, got=%s", newContextID)
 	}
-	if got := l.ContextID(); got != "ctx-new" {
-		t.Fatalf("unexpected current context id, got=%s want=ctx-new", got)
+	if got := l.ContextID(); got != newContextID {
+		t.Fatalf("unexpected current context id, got=%s want=%s", got, newContextID)
 	}
 	if got := l.State(); got != MessageStateAssistantIdle {
 		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
@@ -92,7 +92,7 @@ func TestMessageLifecycle_CommitInterruptRotatesAndResetsState(t *testing.T) {
 }
 
 func TestMessageLifecycle_UserFlow(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.AssistantGenerating("ctx"); err != nil {
 		t.Fatalf("unexpected assistant generating error: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestMessageLifecycle_UserFlow(t *testing.T) {
 }
 
 func TestMessageLifecycle_AssistantFlow(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.UserFinished("ctx"); err != nil {
 		t.Fatalf("unexpected user finished error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestMessageLifecycle_AssistantFlow(t *testing.T) {
 }
 
 func TestMessageLifecycle_UserPromptedCountsAndBlocksDuplicate(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.AssistantGenerating("ctx"); err != nil {
 		t.Fatalf("unexpected assistant generating error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestMessageLifecycle_UserPromptedCountsAndBlocksDuplicate(t *testing.T) {
 }
 
 func TestMessageLifecycle_AssistantPromptedCountsAndBlocksDuplicate(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.AssistantPrompted("ctx"); err != nil {
 		t.Fatalf("unexpected assistant prompted error: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestMessageLifecycle_AssistantPromptedCountsAndBlocksDuplicate(t *testing.T
 }
 
 func TestMessageLifecycle_StaleContextRejected(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
 	if err := l.AssistantGenerating("old"); !errors.Is(err, ErrStaleContext) {
 		t.Fatalf("expected stale context error, got=%v", err)
 	}

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
@@ -1,37 +1,193 @@
 package lifecycle
 
 import (
+	"errors"
 	"testing"
 
 	type_enums "github.com/rapidaai/pkg/types/enums"
 )
 
-func TestMessageLifecycle_InterruptFromUnknown_Fails(t *testing.T) {
-	l := NewMessageLifecycleWithState(Unknown, "ctx", type_enums.MessageMode(""), func() string { return "ctx2" })
-	if err := l.Transition(Interrupt); err == nil {
-		t.Fatalf("expected error when transitioning Unknown -> Interrupt")
+func TestMessageLifecycle_DefaultsMode(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.MessageMode(""), func() string { return "ctx2" })
+	if got := l.Mode(); got != type_enums.TextMode {
+		t.Fatalf("unexpected mode, got=%v want=%v", got, type_enums.TextMode)
+	}
+	if got := l.State(); got != MessageStateAssistantIdle {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
 	}
 }
 
-func TestMessageLifecycle_Interrupted_Succeeds(t *testing.T) {
-	l := NewMessageLifecycleWithState(LLMGenerating, "ctx-old", type_enums.MessageMode(""), func() string { return "ctx-new" })
-	if err := l.Transition(Interrupted); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestMessageLifecycle_RotateContext(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx-old", type_enums.MessageMode(""), func() string { return "ctx-new" })
+	if err := l.AssistantGenerating("ctx-old"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
 	}
-	if got := l.Current(); got != Interrupted {
-		t.Fatalf("unexpected state, got=%v want=%v", got, Interrupted)
+	if _, err := l.RotateContext(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := l.ContextID(); got != "ctx-new" {
 		t.Fatalf("unexpected context id, got=%s want=%s", got, "ctx-new")
 	}
+	if got := l.State(); got != MessageStateAssistantIdle {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
+	}
 }
 
-func TestMessageLifecycle_LLMGeneratingToLLMGenerated(t *testing.T) {
-	l := NewMessageLifecycleWithState(LLMGenerating, "ctx", type_enums.MessageMode(""), func() string { return "ignored" })
-	if err := l.Transition(LLMGenerated); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestMessageLifecycle_RotateContextEmptyIDFails(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "" })
+	if _, err := l.RotateContext(); err == nil {
+		t.Fatalf("expected error when generated context id is empty")
 	}
-	if got := l.Current(); got != LLMGenerated {
-		t.Fatalf("unexpected state, got=%v want=%v", got, LLMGenerated)
+}
+
+func TestMessageLifecycle_BeginInterruptRequiresAssistantStarted(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.BeginInterrupt("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected invalid transition, got=%v", err)
+	}
+	if err := l.AssistantSpeaking("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected assistant speaking before generation to fail, got=%v", err)
+	}
+	if err := l.AssistantGenerating("ctx"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
+	}
+	if err := l.BeginInterrupt("ctx"); err != nil {
+		t.Fatalf("unexpected begin interrupt error: %v", err)
+	}
+	if got := l.State(); got != MessageStateInterrupt {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateInterrupt)
+	}
+	if err := l.BeginInterrupt("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected duplicate begin interrupt to fail, got=%v", err)
+	}
+}
+
+func TestMessageLifecycle_CommitInterruptRotatesAndResetsState(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx-old", type_enums.TextMode, func() string { return "ctx-new" })
+	if err := l.AssistantGenerating("ctx-old"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
+	}
+	if err := l.BeginInterrupt("ctx-old"); err != nil {
+		t.Fatalf("unexpected begin interrupt error: %v", err)
+	}
+	if err := l.UserSpeaking("ctx-old"); err != nil {
+		t.Fatalf("unexpected user speaking error: %v", err)
+	}
+	oldContextID, newContextID, err := l.CommitInterrupt()
+	if err != nil {
+		t.Fatalf("unexpected commit interrupt error: %v", err)
+	}
+	if oldContextID != "ctx-old" {
+		t.Fatalf("unexpected old context id, got=%s want=ctx-old", oldContextID)
+	}
+	if newContextID != "ctx-new" {
+		t.Fatalf("unexpected new context id, got=%s want=ctx-new", newContextID)
+	}
+	if got := l.ContextID(); got != "ctx-new" {
+		t.Fatalf("unexpected current context id, got=%s want=ctx-new", got)
+	}
+	if got := l.State(); got != MessageStateAssistantIdle {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
+	}
+}
+
+func TestMessageLifecycle_UserFlow(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.AssistantGenerating("ctx"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
+	}
+	if err := l.BeginInterrupt("ctx"); err != nil {
+		t.Fatalf("unexpected interrupt error: %v", err)
+	}
+	if err := l.UserIdle("ctx"); err != nil {
+		t.Fatalf("unexpected user idle error: %v", err)
+	}
+	if err := l.UserListening("ctx"); err != nil {
+		t.Fatalf("unexpected user listening error: %v", err)
+	}
+	if err := l.UserSpeaking("ctx"); err != nil {
+		t.Fatalf("unexpected user speaking error: %v", err)
+	}
+	if err := l.UserThinking("ctx"); err != nil {
+		t.Fatalf("unexpected user thinking error: %v", err)
+	}
+	if err := l.UserFinished("ctx"); err != nil {
+		t.Fatalf("unexpected user finished error: %v", err)
+	}
+	if got := l.State(); got != MessageStateUserFinished {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateUserFinished)
+	}
+}
+
+func TestMessageLifecycle_AssistantFlow(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.UserFinished("ctx"); err != nil {
+		t.Fatalf("unexpected user finished error: %v", err)
+	}
+	if err := l.AssistantGenerating("ctx"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
+	}
+	if err := l.AssistantGenerated("ctx"); err != nil {
+		t.Fatalf("unexpected assistant generated error: %v", err)
+	}
+	if err := l.AssistantSpeaking("ctx"); err != nil {
+		t.Fatalf("unexpected assistant speaking error: %v", err)
+	}
+	if err := l.AssistantFinished("ctx"); err != nil {
+		t.Fatalf("unexpected assistant finished error: %v", err)
+	}
+	if err := l.AssistantIdle("ctx"); err != nil {
+		t.Fatalf("unexpected assistant idle error: %v", err)
+	}
+	if got := l.State(); got != MessageStateAssistantIdle {
+		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateAssistantIdle)
+	}
+}
+
+func TestMessageLifecycle_UserPromptedCountsAndBlocksDuplicate(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.AssistantGenerating("ctx"); err != nil {
+		t.Fatalf("unexpected assistant generating error: %v", err)
+	}
+	if err := l.BeginInterrupt("ctx"); err != nil {
+		t.Fatalf("unexpected interrupt error: %v", err)
+	}
+	if err := l.UserListening("ctx"); err != nil {
+		t.Fatalf("unexpected user listening error: %v", err)
+	}
+	if err := l.UserPrompted("ctx"); err != nil {
+		t.Fatalf("unexpected user prompted error: %v", err)
+	}
+	if got := l.UserPromptCount(); got != 1 {
+		t.Fatalf("unexpected user prompt count, got=%d want=1", got)
+	}
+	if err := l.UserPrompted("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected duplicate user prompted to fail, got=%v", err)
+	}
+	if got := l.UserPromptCount(); got != 1 {
+		t.Fatalf("unexpected user prompt count, got=%d want=1", got)
+	}
+}
+
+func TestMessageLifecycle_AssistantPromptedCountsAndBlocksDuplicate(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.AssistantPrompted("ctx"); err != nil {
+		t.Fatalf("unexpected assistant prompted error: %v", err)
+	}
+	if got := l.AssistantPromptCount(); got != 1 {
+		t.Fatalf("unexpected assistant prompt count, got=%d want=1", got)
+	}
+	if err := l.AssistantPrompted("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected duplicate assistant prompted to fail, got=%v", err)
+	}
+	if got := l.AssistantPromptCount(); got != 1 {
+		t.Fatalf("unexpected assistant prompt count, got=%d want=1", got)
+	}
+}
+
+func TestMessageLifecycle_StaleContextRejected(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode, func() string { return "ctx2" })
+	if err := l.AssistantGenerating("old"); !errors.Is(err, ErrStaleContext) {
+		t.Fatalf("expected stale context error, got=%v", err)
 	}
 }

--- a/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
+++ b/api/assistant-api/internal/adapters/lifecycle/message_lifecycle_test.go
@@ -40,36 +40,8 @@ func TestMessageLifecycle_RotateContext(t *testing.T) {
 	}
 }
 
-func TestMessageLifecycle_BeginInterruptRequiresAssistantStarted(t *testing.T) {
-	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
-	if err := l.BeginInterrupt("ctx"); !errors.Is(err, ErrInvalidTransition) {
-		t.Fatalf("expected invalid transition, got=%v", err)
-	}
-	if err := l.AssistantSpeaking("ctx"); !errors.Is(err, ErrInvalidTransition) {
-		t.Fatalf("expected assistant speaking before generation to fail, got=%v", err)
-	}
-	if err := l.AssistantGenerating("ctx"); err != nil {
-		t.Fatalf("unexpected assistant generating error: %v", err)
-	}
-	if err := l.BeginInterrupt("ctx"); err != nil {
-		t.Fatalf("unexpected begin interrupt error: %v", err)
-	}
-	if got := l.State(); got != MessageStateInterrupt {
-		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateInterrupt)
-	}
-	if err := l.BeginInterrupt("ctx"); !errors.Is(err, ErrInvalidTransition) {
-		t.Fatalf("expected duplicate begin interrupt to fail, got=%v", err)
-	}
-}
-
-func TestMessageLifecycle_RotateContextAfterInterruptResetsState(t *testing.T) {
+func TestMessageLifecycle_RotateContextAfterUserSpeakingResetsState(t *testing.T) {
 	l := NewMessageLifecycleWithContext("ctx-old", type_enums.TextMode)
-	if err := l.AssistantGenerating("ctx-old"); err != nil {
-		t.Fatalf("unexpected assistant generating error: %v", err)
-	}
-	if err := l.BeginInterrupt("ctx-old"); err != nil {
-		t.Fatalf("unexpected begin interrupt error: %v", err)
-	}
 	if err := l.UserSpeaking("ctx-old"); err != nil {
 		t.Fatalf("unexpected user speaking error: %v", err)
 	}
@@ -93,12 +65,6 @@ func TestMessageLifecycle_RotateContextAfterInterruptResetsState(t *testing.T) {
 
 func TestMessageLifecycle_UserFlow(t *testing.T) {
 	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
-	if err := l.AssistantGenerating("ctx"); err != nil {
-		t.Fatalf("unexpected assistant generating error: %v", err)
-	}
-	if err := l.BeginInterrupt("ctx"); err != nil {
-		t.Fatalf("unexpected interrupt error: %v", err)
-	}
 	if err := l.UserIdle("ctx"); err != nil {
 		t.Fatalf("unexpected user idle error: %v", err)
 	}
@@ -116,6 +82,22 @@ func TestMessageLifecycle_UserFlow(t *testing.T) {
 	}
 	if got := l.State(); got != MessageStateUserFinished {
 		t.Fatalf("unexpected state, got=%s want=%s", got, MessageStateUserFinished)
+	}
+}
+
+func TestMessageLifecycle_UserFinishedRejectsUserSpeaking(t *testing.T) {
+	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
+	if err := l.UserSpeaking("ctx"); err != nil {
+		t.Fatalf("unexpected user speaking error: %v", err)
+	}
+	if err := l.UserFinished("ctx"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected user speaking finish to fail, got=%v", err)
+	}
+	if err := l.UserListening("ctx"); err != nil {
+		t.Fatalf("unexpected user listening error: %v", err)
+	}
+	if err := l.UserFinished("ctx"); err != nil {
+		t.Fatalf("unexpected user finished error: %v", err)
 	}
 }
 
@@ -146,12 +128,6 @@ func TestMessageLifecycle_AssistantFlow(t *testing.T) {
 
 func TestMessageLifecycle_UserPromptedCountsAndBlocksDuplicate(t *testing.T) {
 	l := NewMessageLifecycleWithContext("ctx", type_enums.TextMode)
-	if err := l.AssistantGenerating("ctx"); err != nil {
-		t.Fatalf("unexpected assistant generating error: %v", err)
-	}
-	if err := l.BeginInterrupt("ctx"); err != nil {
-		t.Fatalf("unexpected interrupt error: %v", err)
-	}
 	if err := l.UserListening("ctx"); err != nil {
 		t.Fatalf("unexpected user listening error: %v", err)
 	}

--- a/api/assistant-api/internal/adapters/router/dispatch.go
+++ b/api/assistant-api/internal/adapters/router/dispatch.go
@@ -20,7 +20,6 @@ type DispatchHandler interface {
 	HandleDenoise(context.Context, internal_type.DenoiseAudioPacket)
 	HandleDenoisedAudio(context.Context, internal_type.DenoisedAudioPacket)
 	HandleVadAudio(context.Context, internal_type.VadAudioPacket)
-	HandleVadSpeechActivity(context.Context, internal_type.VadSpeechActivityPacket)
 	HandleSpeechToText(context.Context, internal_type.SpeechToTextPacket)
 	HandleInterimEndOfSpeech(context.Context, internal_type.InterimEndOfSpeechPacket)
 	HandleEndOfSpeech(context.Context, internal_type.EndOfSpeechPacket)
@@ -120,8 +119,6 @@ func DispatchPacket(ctx context.Context, p internal_type.Packet, handler Dispatc
 		handler.HandleDenoisedAudio(ctx, vl)
 	case internal_type.VadAudioPacket:
 		handler.HandleVadAudio(ctx, vl)
-	case internal_type.VadSpeechActivityPacket:
-		handler.HandleVadSpeechActivity(ctx, vl)
 	case internal_type.SpeechToTextPacket:
 		handler.HandleSpeechToText(ctx, vl)
 	case internal_type.InterimEndOfSpeechPacket:

--- a/api/assistant-api/internal/adapters/router/dispatch_test.go
+++ b/api/assistant-api/internal/adapters/router/dispatch_test.go
@@ -20,9 +20,7 @@ func (s *dispatchHandlerStub) HandleUserAudio(context.Context, internal_type.Use
 func (s *dispatchHandlerStub) HandleDenoise(context.Context, internal_type.DenoiseAudioPacket) {}
 func (s *dispatchHandlerStub) HandleDenoisedAudio(context.Context, internal_type.DenoisedAudioPacket) {
 }
-func (s *dispatchHandlerStub) HandleVadAudio(context.Context, internal_type.VadAudioPacket) {}
-func (s *dispatchHandlerStub) HandleVadSpeechActivity(context.Context, internal_type.VadSpeechActivityPacket) {
-}
+func (s *dispatchHandlerStub) HandleVadAudio(context.Context, internal_type.VadAudioPacket)         {}
 func (s *dispatchHandlerStub) HandleSpeechToText(context.Context, internal_type.SpeechToTextPacket) {}
 func (s *dispatchHandlerStub) HandleInterimEndOfSpeech(context.Context, internal_type.InterimEndOfSpeechPacket) {
 }

--- a/api/assistant-api/internal/adapters/router/router.go
+++ b/api/assistant-api/internal/adapters/router/router.go
@@ -82,7 +82,6 @@ func ClassifyName(name internal_type.PacketName) Route {
 		internal_type.PacketNameDenoiseAudio,
 		internal_type.PacketNameDenoisedAudio,
 		internal_type.PacketNameVadAudio,
-		internal_type.PacketNameVadSpeechActivity,
 		internal_type.PacketNameSpeechToText,
 		internal_type.PacketNameSpeechToTextAudio,
 		internal_type.PacketNameEndOfSpeechAudio,

--- a/api/assistant-api/internal/adapters/router/router_test.go
+++ b/api/assistant-api/internal/adapters/router/router_test.go
@@ -111,7 +111,6 @@ func TestClassifyName_DispatchablePacketNamesAreExplicitlyRouted(t *testing.T) {
 		internal_type.PacketNameDenoiseAudio:                               RouteIngress,
 		internal_type.PacketNameDenoisedAudio:                              RouteIngress,
 		internal_type.PacketNameVadAudio:                                   RouteIngress,
-		internal_type.PacketNameVadSpeechActivity:                          RouteIngress,
 		internal_type.PacketNameSpeechToText:                               RouteIngress,
 		internal_type.PacketNameInterimEndOfSpeech:                         RouteIngress,
 		internal_type.PacketNameEndOfSpeech:                                RouteIngress,

--- a/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go
@@ -50,26 +50,30 @@ const (
 	defaultFallbackTimeout = 500.0
 )
 
+type vadState uint8
+
+const (
+	vadStateIdle vadState = iota
+	vadStateSpeaking
+	vadStateEnded
+)
+
+type transcriptState uint8
+
+const (
+	transcriptStateIdle transcriptState = iota
+	transcriptStateInterimPending
+	transcriptStateFinalized
+	transcriptStateFinalizedWithPendingInterim
+)
+
 type speechSegment struct {
+	Revision  uint64
 	ContextID string
-	Committed string // accumulated final transcripts
-	Pending   string // latest interim transcript (not yet finalized)
-	// Timestamp tracks the last text-bearing update for this segment.
+	FinalText string
+	Text      string
 	Timestamp time.Time
 	Chunks    []internal_type.SpeechToTextPacket
-}
-
-func (segment speechSegment) FullText() string {
-	if segment.Pending == "" {
-		return segment.Committed
-	}
-	if segment.Committed == "" {
-		return segment.Pending
-	}
-	if strings.HasSuffix(segment.Committed, " ") || strings.HasPrefix(segment.Pending, " ") {
-		return segment.Committed + segment.Pending
-	}
-	return segment.Committed + " " + segment.Pending
 }
 
 type workerCommand struct {
@@ -82,9 +86,11 @@ type workerCommand struct {
 
 type endOfSpeechState struct {
 	segment       speechSegment
+	pending       *workerCommand
 	confidence    float64
 	callbackFired bool
-	generation    uint64
+	vadState      vadState
+	transcript    transcriptState
 }
 
 type turnPredictor interface {
@@ -120,6 +126,7 @@ type livekitEndOfSpeech struct {
 	// Worker orchestration
 	commandCh chan workerCommand
 	stopCh    chan struct{}
+	closeOnce sync.Once
 
 	// State
 	mu           sync.RWMutex
@@ -284,89 +291,224 @@ func (endOfSpeech *livekitEndOfSpeech) Execute(ctx context.Context, packet inter
 			return nil
 		}
 		endOfSpeech.mu.Lock()
-		segment := speechSegment{ContextID: packet.ContextId(), Committed: packet.Text, Timestamp: time.Now()}
-		endOfSpeech.state.segment = segment
-		endOfSpeech.state.confidence = 0
-		endOfSpeech.mu.Unlock()
-
-		packets := []internal_type.Packet{internal_type.InterimEndOfSpeechPacket{
-			Speech:    segment.Committed,
-			ContextID: segment.ContextID,
-		}}
-		_ = endOfSpeech.onPacket(ctx, packets...)
-		endOfSpeech.enqueueCommand(workerCommand{
+		segment := speechSegment{
+			Revision:  endOfSpeech.state.segment.Revision + 1,
+			ContextID: packet.ContextId(),
+			FinalText: packet.Text,
+			Text:      packet.Text,
+			Timestamp: time.Now(),
+		}
+		command := workerCommand{
 			ctx:             ctx,
 			segment:         segment,
 			fireImmediately: true,
-		})
+		}
+		endOfSpeech.state.segment = segment
+		endOfSpeech.state.confidence = 0
+		endOfSpeech.state.transcript = transcriptStateFinalized
+		endOfSpeech.mu.Unlock()
+
+		packets := []internal_type.Packet{internal_type.InterimEndOfSpeechPacket{
+			Speech:    command.segment.Text,
+			ContextID: command.segment.ContextID,
+		}}
+		_ = endOfSpeech.onPacket(ctx, packets...)
+		endOfSpeech.enqueueCommand(command)
 
 	case internal_type.EndOfSpeechInterruptionPacket:
 		endOfSpeech.mu.RLock()
-		segment := endOfSpeech.state.segment
-		confidence := endOfSpeech.state.confidence
+		command := workerCommand{
+			ctx:        ctx,
+			segment:    endOfSpeech.state.segment,
+			confidence: endOfSpeech.state.confidence,
+			timeout:    endOfSpeech.silenceTimeout,
+		}
 		endOfSpeech.mu.RUnlock()
-		if segment.FullText() == "" {
+		if command.segment.Text == "" {
 			return nil
 		}
-		endOfSpeech.enqueueCommand(workerCommand{
-			ctx:        ctx,
-			segment:    segment,
-			confidence: confidence,
-			timeout:    endOfSpeech.silenceTimeout,
-		})
+		endOfSpeech.enqueueCommand(command)
 
-	case internal_type.VadSpeechActivityPacket:
-		endOfSpeech.mu.RLock()
-		segment := endOfSpeech.state.segment
-		confidence := endOfSpeech.state.confidence
-		endOfSpeech.mu.RUnlock()
-		if segment.FullText() == "" {
+	case internal_type.InterruptionDetectedPacket:
+		if packet.Source != internal_type.InterruptionSourceVad {
 			return nil
 		}
-		endOfSpeech.enqueueCommand(workerCommand{
-			ctx:        ctx,
-			segment:    segment,
-			confidence: confidence,
-			timeout:    endOfSpeech.silenceTimeout,
-		})
+		endOfSpeech.mu.Lock()
+		switch packet.Event {
+		case internal_type.InterruptionEventStart:
+			// VAD start only marks speech as active. Transcript revision remains
+			// the only token used to reject stale EOS timers.
+			endOfSpeech.state.vadState = vadStateSpeaking
+			endOfSpeech.state.pending = nil
+			endOfSpeech.mu.Unlock()
+			return nil
+		case internal_type.InterruptionEventEnd:
+			endOfSpeech.state.vadState = vadStateEnded
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				(endOfSpeech.state.transcript == transcriptStateFinalized ||
+					endOfSpeech.state.transcript == transcriptStateIdle) {
+				command := workerCommand{
+					ctx:        ctx,
+					segment:    endOfSpeech.state.segment,
+					confidence: endOfSpeech.state.confidence,
+					timeout:    endOfSpeech.quickTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// VAD end is not transcript finalization. It only opens the
+				// flush window after STT has acknowledged with a final packet.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+				command := workerCommand{
+					ctx:        ctx,
+					segment:    endOfSpeech.state.segment,
+					confidence: endOfSpeech.state.confidence,
+					timeout:    endOfSpeech.fallbackTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// A newer interim after a final means STT finalization is still
+				// catching up. Wait longer, then use the best visible transcript.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+		}
+		endOfSpeech.mu.Unlock()
+		return nil
 
 	case internal_type.SpeechToTextPacket:
 		endOfSpeech.mu.Lock()
 		if packet.Interim {
-			// Interim: just reset timer, no text accumulation, no interim packet.
-			// Matches silence-based behavior.
-			segment := endOfSpeech.state.segment
-			confidence := endOfSpeech.state.confidence
-			endOfSpeech.mu.Unlock()
-			if segment.FullText() == "" {
+			if packet.Script == "" {
+				endOfSpeech.mu.Unlock()
 				return nil
 			}
-			endOfSpeech.enqueueCommand(workerCommand{
-				ctx:        ctx,
-				segment:    segment,
-				confidence: confidence,
-				timeout:    endOfSpeech.fallbackTimeout,
+			previous := endOfSpeech.state.segment
+			timestamp := time.Now()
+			if previous.FinalText != "" && !previous.Timestamp.IsZero() {
+				timestamp = previous.Timestamp
+			}
+			segment := speechSegment{
+				Revision:  previous.Revision + 1,
+				ContextID: packet.ContextId(),
+				Timestamp: timestamp,
+				Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
+			}
+			segment.Chunks = append(segment.Chunks, packet)
+			pendingTranscript := ""
+			for _, chunk := range segment.Chunks {
+				if chunk.Script == "" {
+					continue
+				}
+				if chunk.Interim {
+					pendingTranscript = chunk.Script
+					if segment.FinalText != "" {
+						pendingTranscript = chunk.GetConcat() + pendingTranscript
+					}
+					continue
+				}
+				if segment.FinalText != "" {
+					segment.FinalText += chunk.GetConcat()
+				}
+				segment.FinalText += chunk.Script
+				pendingTranscript = ""
+			}
+			segment.Text = segment.FinalText + pendingTranscript
+			if previous.FinalText == "" {
+				endOfSpeech.state.transcript = transcriptStateInterimPending
+			} else {
+				endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+			}
+			endOfSpeech.state.segment = segment
+			if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim ||
+				endOfSpeech.state.vadState == vadStateEnded {
+				command := workerCommand{
+					ctx:        ctx,
+					segment:    segment,
+					confidence: endOfSpeech.state.confidence,
+					timeout:    endOfSpeech.fallbackTimeout,
+				}
+				endOfSpeech.mu.Unlock()
+
+				_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+					Speech:    command.segment.Text,
+					ContextID: command.segment.ContextID,
+				})
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+			endOfSpeech.mu.Unlock()
+
+			_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+				Speech:    segment.Text,
+				ContextID: segment.ContextID,
 			})
 			return nil
 		}
 
 		// Final transcript: accumulate text
+		previous := endOfSpeech.state.segment
 		segment := speechSegment{
+			Revision:  previous.Revision + 1,
 			ContextID: packet.ContextId(),
 			Timestamp: time.Now(),
-			Committed: endOfSpeech.state.segment.Committed,
-			Chunks:    append([]internal_type.SpeechToTextPacket(nil), endOfSpeech.state.segment.Chunks...),
-		}
-		if segment.Committed != "" {
-			segment.Committed += packet.GetConcat()
-			segment.Committed += packet.Script
-		} else {
-			segment.Committed = packet.Script
+			Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
 		}
 		segment.Chunks = append(segment.Chunks, packet)
+		pendingTranscript := ""
+		for _, chunk := range segment.Chunks {
+			if chunk.Script == "" {
+				continue
+			}
+			if chunk.Interim {
+				pendingTranscript = chunk.Script
+				if segment.FinalText != "" {
+					pendingTranscript = chunk.GetConcat() + pendingTranscript
+				}
+				continue
+			}
+			if segment.FinalText != "" {
+				segment.FinalText += chunk.GetConcat()
+			}
+			segment.FinalText += chunk.Script
+			pendingTranscript = ""
+		}
+		segment.Text = segment.FinalText + pendingTranscript
+		endOfSpeech.state.transcript = transcriptStateFinalized
+		if segment.Text != segment.FinalText {
+			endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+		}
 		endOfSpeech.state.segment = segment
 		endOfSpeech.state.confidence = 0
-		fullText := segment.FullText()
+		fullText := segment.Text
+		if endOfSpeech.state.vadState == vadStateEnded {
+			timeout := endOfSpeech.quickTimeout
+			if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+				timeout = endOfSpeech.fallbackTimeout
+			}
+			command := workerCommand{
+				ctx:     ctx,
+				segment: segment,
+				timeout: timeout,
+			}
+			endOfSpeech.mu.Unlock()
+
+			if fullText == "" {
+				return nil
+			}
+			packets := []internal_type.Packet{internal_type.InterimEndOfSpeechPacket{
+				Speech:    fullText,
+				ContextID: command.segment.ContextID,
+			}}
+			_ = endOfSpeech.onPacket(ctx, packets...)
+			endOfSpeech.enqueueCommand(command)
+			return nil
+		}
 		endOfSpeech.mu.Unlock()
 
 		if fullText == "" {
@@ -384,24 +526,38 @@ func (endOfSpeech *livekitEndOfSpeech) Execute(ctx context.Context, packet inter
 		// YES (prob >= threshold) → quick_timeout buffer, then fire.
 		// NO  (prob <  threshold) → keep accumulating, safety timer as fallback.
 		probability := endOfSpeech.predictEOU(fullText)
-		command := workerCommand{
-			ctx:     ctx,
-			segment: segment,
-		}
 		if probability < 0 {
-			command.timeout = endOfSpeech.fallbackTimeout
-		} else {
-			command.confidence = probability
-			endOfSpeech.mu.Lock()
-			endOfSpeech.state.confidence = probability
-			endOfSpeech.mu.Unlock()
-			if probability >= endOfSpeech.threshold {
-				command.timeout = endOfSpeech.quickTimeout
-			} else {
-				command.timeout = endOfSpeech.silenceTimeout
-			}
+			endOfSpeech.enqueueCommand(workerCommand{
+				ctx:     ctx,
+				segment: segment,
+				timeout: endOfSpeech.fallbackTimeout,
+			})
+			return nil
 		}
-		endOfSpeech.enqueueCommand(command)
+
+		endOfSpeech.mu.Lock()
+		if endOfSpeech.state.segment.Revision == segment.Revision {
+			endOfSpeech.state.confidence = probability
+		}
+		endOfSpeech.mu.Unlock()
+
+		if probability >= endOfSpeech.threshold {
+			endOfSpeech.enqueueCommand(workerCommand{
+				ctx:        ctx,
+				segment:    segment,
+				confidence: probability,
+				timeout:    endOfSpeech.quickTimeout,
+			})
+			return nil
+		}
+
+		endOfSpeech.enqueueCommand(workerCommand{
+			ctx:        ctx,
+			segment:    segment,
+			confidence: probability,
+			timeout:    endOfSpeech.silenceTimeout,
+		})
+		return nil
 
 	case internal_type.LLMResponseDonePacket:
 		if packet.Text != "" {
@@ -450,6 +606,10 @@ func (endOfSpeech *livekitEndOfSpeech) predictEOU(currentText string) float64 {
 }
 
 func (endOfSpeech *livekitEndOfSpeech) enqueueCommand(command workerCommand) {
+	if endOfSpeech == nil || endOfSpeech.commandCh == nil || endOfSpeech.stopCh == nil {
+		return
+	}
+
 	select {
 	case <-endOfSpeech.stopCh:
 		return
@@ -467,7 +627,6 @@ func (endOfSpeech *livekitEndOfSpeech) worker() {
 		timer          *time.Timer
 		timerCh        <-chan time.Time
 		timerArmedAt   time.Time
-		generation     uint64
 		currentCommand workerCommand
 	)
 
@@ -481,9 +640,13 @@ func (endOfSpeech *livekitEndOfSpeech) worker() {
 	}
 	resetState := func() {
 		endOfSpeech.state.callbackFired = false
-		endOfSpeech.state.generation++
-		endOfSpeech.state.segment = speechSegment{}
+		// Bump revision after a completed turn so late timer work from the old
+		// message cannot complete against the next user turn.
+		endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision + 1}
+		endOfSpeech.state.pending = nil
 		endOfSpeech.state.confidence = 0
+		endOfSpeech.state.vadState = vadStateIdle
+		endOfSpeech.state.transcript = transcriptStateIdle
 	}
 
 	for {
@@ -499,21 +662,26 @@ func (endOfSpeech *livekitEndOfSpeech) worker() {
 				endOfSpeech.mu.Unlock()
 				continue
 			}
+			// Newer text/STT packets supersede older timer commands. Completing a
+			// stale snapshot can shrink the final user message.
+			if !command.fireImmediately && command.segment.Revision != endOfSpeech.state.segment.Revision {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
 
 			if command.fireImmediately {
 				endOfSpeech.state.callbackFired = true
-				currentCommand = command
+				endOfSpeech.state.pending = nil
 				stopTimer()
 				endOfSpeech.mu.Unlock()
-				endOfSpeech.fire(currentCommand, time.Now())
+				endOfSpeech.fire(command, time.Now())
 				endOfSpeech.mu.Lock()
 				resetState()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
 
-			generation = endOfSpeech.state.generation + 1
-			endOfSpeech.state.generation = generation
+			endOfSpeech.state.pending = nil
 			currentCommand = command
 			stopTimer()
 			timerArmedAt = time.Now()
@@ -523,7 +691,56 @@ func (endOfSpeech *livekitEndOfSpeech) worker() {
 
 		case <-timerCh:
 			endOfSpeech.mu.Lock()
-			if endOfSpeech.state.callbackFired || generation != endOfSpeech.state.generation {
+			if endOfSpeech.state.callbackFired {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+
+			// While VAD says the user is speaking, defer once. The fallback timer
+			// recovers if VAD end is lost because of noise or provider failure.
+			if endOfSpeech.state.vadState == vadStateSpeaking {
+				if endOfSpeech.state.pending == nil {
+					command := currentCommand
+					endOfSpeech.state.pending = &command
+					stopTimer()
+					timerArmedAt = time.Now()
+					timer = time.NewTimer(endOfSpeech.fallbackTimeout)
+					timerCh = timer.C
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				command := *endOfSpeech.state.pending
+				endOfSpeech.state.pending = nil
+				endOfSpeech.state.vadState = vadStateIdle
+				if command.segment.Revision != endOfSpeech.state.segment.Revision {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+				if endOfSpeech.state.transcript == transcriptStateInterimPending {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				endOfSpeech.state.callbackFired = true
+				armedAt := timerArmedAt
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				endOfSpeech.fire(command, armedAt)
+				endOfSpeech.mu.Lock()
+				resetState()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if currentCommand.segment.Revision != endOfSpeech.state.segment.Revision {
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if endOfSpeech.state.transcript == transcriptStateInterimPending {
+				stopTimer()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
@@ -542,10 +759,14 @@ func (endOfSpeech *livekitEndOfSpeech) worker() {
 }
 
 func (endOfSpeech *livekitEndOfSpeech) fire(command workerCommand, timerArmedAt time.Time) {
+	if endOfSpeech == nil {
+		return
+	}
+
 	ctx := command.ctx
 	segment := command.segment
 	confidence := command.confidence
-	speech := segment.FullText()
+	speech := segment.Text
 	if speech == "" {
 		return
 	}
@@ -560,6 +781,9 @@ func (endOfSpeech *livekitEndOfSpeech) fire(command workerCommand, timerArmedAt 
 	}
 	if ctx != nil && ctx.Err() != nil {
 		ctx = context.Background()
+	}
+	if endOfSpeech.onPacket == nil {
+		return
 	}
 
 	wordCount := len(strings.Fields(speech))
@@ -614,38 +838,46 @@ func (endOfSpeech *livekitEndOfSpeech) fire(command workerCommand, timerArmedAt 
 }
 
 func (endOfSpeech *livekitEndOfSpeech) Close(ctx context.Context) error {
-	endOfSpeech.mu.Lock()
-	eosStartedAt := endOfSpeech.eosStartedAt
-	endOfSpeech.eosStartedAt = time.Time{}
-	endOfSpeech.mu.Unlock()
+	if endOfSpeech == nil {
+		return nil
+	}
 
-	if endOfSpeech.onPacket != nil {
-		if !eosStartedAt.IsZero() {
-			endOfSpeech.onPacket(ctx, internal_type.ObservabilityUsageRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
+	endOfSpeech.closeOnce.Do(func() {
+		endOfSpeech.mu.Lock()
+		eosStartedAt := endOfSpeech.eosStartedAt
+		endOfSpeech.eosStartedAt = time.Time{}
+		endOfSpeech.mu.Unlock()
+
+		if endOfSpeech.onPacket != nil {
+			if !eosStartedAt.IsZero() {
+				endOfSpeech.onPacket(ctx, internal_type.ObservabilityUsageRecordPacket{
+					Scope:  internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
+				})
+			}
+			endOfSpeech.onPacket(ctx, internal_type.ObservabilityEventRecordPacket{
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentEOS,
+					Event:     observability.EOSClosed,
+					Attributes: observability.Attributes{
+						"provider": endOfSpeech.Name(),
+					},
+					OccurredAt: time.Now(),
+				},
 			})
 		}
-		endOfSpeech.onPacket(ctx, internal_type.ObservabilityEventRecordPacket{
-			Scope: internal_type.ObservabilityRecordScopeConversation,
-			Record: observability.RecordEvent{
-				Component: observability.ComponentEOS,
-				Event:     observability.EOSClosed,
-				Attributes: observability.Attributes{
-					"provider": endOfSpeech.Name(),
-				},
-				OccurredAt: time.Now(),
-			},
-		})
-	}
 
-	close(endOfSpeech.stopCh)
-	endOfSpeech.predictorMu.Lock()
-	if predictor, ok := endOfSpeech.predictor.(interface{ Destroy() }); ok {
-		predictor.Destroy()
-	}
-	endOfSpeech.predictor = nil
-	endOfSpeech.predictorMu.Unlock()
+		if endOfSpeech.stopCh != nil {
+			close(endOfSpeech.stopCh)
+		}
+		endOfSpeech.predictorMu.Lock()
+		if predictor, ok := endOfSpeech.predictor.(interface{ Destroy() }); ok {
+			predictor.Destroy()
+		}
+		endOfSpeech.predictor = nil
+		endOfSpeech.predictorMu.Unlock()
+	})
 
 	return nil
 }

--- a/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech_test.go
@@ -240,13 +240,13 @@ func TestLivekitEndOfSpeech_EnqueueCommandBlocksUntilChannelHasSpace(t *testing.
 		stopCh:    make(chan struct{}),
 		state:     &endOfSpeechState{segment: speechSegment{}},
 	}
-	endOfSpeech.commandCh <- workerCommand{segment: speechSegment{Committed: "first"}}
+	endOfSpeech.commandCh <- workerCommand{segment: speechSegment{Text: "first", FinalText: "first"}}
 
 	started := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
 		close(started)
-		endOfSpeech.enqueueCommand(workerCommand{segment: speechSegment{Committed: "second"}})
+		endOfSpeech.enqueueCommand(workerCommand{segment: speechSegment{Text: "second", FinalText: "second"}})
 		close(done)
 	}()
 
@@ -258,7 +258,7 @@ func TestLivekitEndOfSpeech_EnqueueCommandBlocksUntilChannelHasSpace(t *testing.
 	}
 
 	first := <-endOfSpeech.commandCh
-	assert.Equal(t, "first", first.segment.FullText())
+	assert.Equal(t, "first", first.segment.Text)
 
 	select {
 	case <-done:
@@ -267,7 +267,7 @@ func TestLivekitEndOfSpeech_EnqueueCommandBlocksUntilChannelHasSpace(t *testing.
 	}
 
 	second := <-endOfSpeech.commandCh
-	assert.Equal(t, "second", second.segment.FullText())
+	assert.Equal(t, "second", second.segment.Text)
 }
 
 func TestLivekitEndOfSpeech_FinalSTTInferenceFailure_UsesFallbackTimeout(t *testing.T) {
@@ -298,33 +298,431 @@ func TestLivekitEndOfSpeech_FinalSTTInferenceFailure_UsesFallbackTimeout(t *test
 	case command := <-endOfSpeech.commandCh:
 		assert.Equal(t, 60*time.Millisecond, command.timeout)
 		assert.Equal(t, 0.0, command.confidence)
-		assert.Equal(t, "fallback path", command.segment.FullText())
+		assert.Equal(t, "fallback path", command.segment.Text)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timeout waiting for fallback command")
 	}
 }
 
-func TestLivekitEndOfSpeech_VadSpeechActivityExtendsCurrentSegment(t *testing.T) {
+func TestLivekitEndOfSpeech_VADEndFlushesCurrentSegment(t *testing.T) {
 	endOfSpeech := &livekitEndOfSpeech{
 		commandCh: make(chan workerCommand, 1),
 		stopCh:    make(chan struct{}),
 		state: &endOfSpeechState{
-			segment:    speechSegment{ContextID: "ctx-vad", Committed: "hello"},
+			segment:    speechSegment{ContextID: "ctx-vad", Text: "hello", FinalText: "hello"},
 			confidence: 0.73,
 		},
+		quickTimeout:   20 * time.Millisecond,
 		silenceTimeout: 250 * time.Millisecond,
 	}
 
-	err := endOfSpeech.Execute(context.Background(), internal_type.VadSpeechActivityPacket{})
+	err := endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	})
 	require.NoError(t, err)
 
 	select {
 	case command := <-endOfSpeech.commandCh:
-		assert.Equal(t, 250*time.Millisecond, command.timeout)
-		assert.Equal(t, "hello", command.segment.FullText())
+		t.Fatalf("unexpected command on VAD start: %+v", command)
+	default:
+	}
+
+	err = endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	})
+	require.NoError(t, err)
+
+	select {
+	case command := <-endOfSpeech.commandCh:
+		assert.False(t, command.fireImmediately)
+		assert.Equal(t, 20*time.Millisecond, command.timeout)
+		assert.Equal(t, "hello", command.segment.Text)
 		assert.InDelta(t, 0.73, command.confidence, 0.0001)
 	case <-time.After(100 * time.Millisecond):
-		t.Fatal("timeout waiting for VAD command")
+		t.Fatal("timeout waiting for VAD end command")
+	}
+}
+
+func TestLivekitEndOfSpeech_FaultyVADRecoversPendingFinal(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					select {
+					case called <- endOfSpeechPacket:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+		predictor: testPredictor{
+			predict: func(string) (float64, error) {
+				return 0, errors.New("predict failed")
+			},
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    20 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 60 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-faulty-vad",
+		Script:    "hello",
+		Interim:   false,
+	}))
+
+	select {
+	case packet := <-called:
+		t.Fatalf("callback fired before stuck VAD recovery elapsed: %+v", packet)
+	case <-time.After(90 * time.Millisecond):
+	}
+
+	select {
+	case packet := <-called:
+		assert.Equal(t, "ctx-faulty-vad", packet.ContextID)
+		assert.Equal(t, "hello", packet.Speech)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for callback after stuck VAD recovery")
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("unexpected duplicate callback after stuck VAD recovery: %+v", packet)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestLivekitEndOfSpeech_VADEndFlushesPendingFinal(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					select {
+					case called <- endOfSpeechPacket:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+		predictor: testPredictor{
+			predict: func(string) (float64, error) {
+				return 0, errors.New("predict failed")
+			},
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    20 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 100 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-vad-success",
+		Script:    "done",
+		Interim:   false,
+	}))
+
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		endOfSpeech.mu.RLock()
+		pending := endOfSpeech.state.pending != nil
+		endOfSpeech.mu.RUnlock()
+		if pending {
+			break
+		}
+		select {
+		case packet := <-called:
+			t.Fatalf("callback fired before VAD end: %+v", packet)
+		case <-deadline:
+			t.Fatal("timeout waiting for pending final")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case packet := <-called:
+		assert.Equal(t, "ctx-vad-success", packet.ContextID)
+		assert.Equal(t, "done", packet.Speech)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for callback after VAD end")
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("unexpected duplicate callback after VAD end: %+v", packet)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestLivekitEndOfSpeech_VADEndFlushWindowUsesLateFinalSTT(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					select {
+					case called <- endOfSpeechPacket:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+		predictor: testPredictor{
+			predict: func(string) (float64, error) {
+				return 0, errors.New("predict failed")
+			},
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    40 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 200 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "Rightly?",
+		Interim:   false,
+	}))
+
+	select {
+	case packet := <-called:
+		assert.Equal(t, "me an idea about the how how do I do things? Rightly?", packet.Speech)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for late final callback")
+	}
+}
+
+func TestLivekitEndOfSpeech_VADEndCompleteClearsPendingInterimWhenFinalIsShorter(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					select {
+					case called <- endOfSpeechPacket:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+		predictor: testPredictor{
+			predict: func(string) (float64, error) {
+				return 0, errors.New("predict failed")
+			},
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    20 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 70 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	ctx := context.Background()
+	require.NoError(t, endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, endOfSpeech.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things? Rightly?",
+		Interim:   true,
+	}))
+	require.NoError(t, endOfSpeech.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}))
+	require.NoError(t, endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case packet := <-called:
+		assert.Equal(t, "me an idea about the how how do I do things?", packet.Speech)
+		require.Len(t, packet.Speechs, 2)
+		assert.True(t, packet.Speechs[0].Interim)
+		assert.False(t, packet.Speechs[1].Interim)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for final transcript")
+	}
+}
+
+func TestLivekitEndOfSpeech_StaleTimerCompletionDoesNotShrinkLatestSegment(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					called <- endOfSpeechPacket
+				}
+			}
+			return nil
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    20 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 100 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	endOfSpeech.mu.Lock()
+	endOfSpeech.state.segment = speechSegment{
+		Revision:  1,
+		ContextID: "ctx-stale",
+		Text:      "me an idea about the how how do I do things?",
+		FinalText: "me an idea about the how how do I do things?",
+		Timestamp: time.Now(),
+	}
+	oldSegment := endOfSpeech.state.segment
+	endOfSpeech.mu.Unlock()
+
+	endOfSpeech.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: oldSegment,
+		timeout: 30 * time.Millisecond,
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	latestSegment := speechSegment{
+		Revision:  2,
+		ContextID: "ctx-stale",
+		Text:      "me an idea about the how how do I do things? Rightly?",
+		FinalText: "me an idea about the how how do I do things? Rightly?",
+		Timestamp: time.Now(),
+	}
+	endOfSpeech.mu.Lock()
+	endOfSpeech.state.segment = latestSegment
+	endOfSpeech.mu.Unlock()
+
+	select {
+	case packet := <-called:
+		t.Fatalf("stale completion fired: %q", packet.Speech)
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	endOfSpeech.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: latestSegment,
+		timeout: 10 * time.Millisecond,
+	})
+
+	select {
+	case packet := <-called:
+		assert.Equal(t, latestSegment.Text, packet.Speech)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for latest completion")
+	}
+}
+
+func TestLivekitEndOfSpeech_OnlyInterimWithVADDoesNotComplete(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 1)
+	endOfSpeech := &livekitEndOfSpeech{
+		onPacket: func(ctx context.Context, packets ...internal_type.Packet) error {
+			for _, packet := range packets {
+				if endOfSpeechPacket, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+					select {
+					case called <- endOfSpeechPacket:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+		threshold:       defaultThreshold,
+		quickTimeout:    20 * time.Millisecond,
+		silenceTimeout:  900 * time.Millisecond,
+		fallbackTimeout: 60 * time.Millisecond,
+		maxHistory:      int(defaultMaxHistory),
+		commandCh:       make(chan workerCommand, 8),
+		stopCh:          make(chan struct{}),
+		state:           &endOfSpeechState{segment: speechSegment{}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-interim-only",
+		Script:    "interim only",
+		Interim:   true,
+	}))
+	require.NoError(t, endOfSpeech.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case packet := <-called:
+		t.Fatalf("callback should not fire for interim-only VAD input: %+v", packet)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
@@ -588,6 +986,8 @@ func TestLivekitEndOfSpeech_ObservabilityLifecycleEvents(t *testing.T) {
 			t.Fatal("timeout waiting for closed eos event")
 		}
 	}
+
+	require.NoError(t, executor.Close(context.Background()))
 }
 
 func TestLivekitEndOfSpeech_KeepsMetrics(t *testing.T) {

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
@@ -38,9 +38,27 @@ const (
 	maxAudioSamples = whisperMaxSamples
 )
 
+type vadState uint8
+
+const (
+	vadStateIdle vadState = iota
+	vadStateSpeaking
+	vadStateEnded
+)
+
+type transcriptState uint8
+
+const (
+	transcriptStateIdle transcriptState = iota
+	transcriptStateInterimPending
+	transcriptStateFinalized
+	transcriptStateFinalizedWithPendingInterim
+)
+
 type speechSegment struct {
 	Revision  uint64
 	ContextID string
+	FinalText string
 	Text      string
 	// Timestamp tracks the last text-bearing update for this segment.
 	Timestamp time.Time
@@ -57,9 +75,11 @@ type workerCommand struct {
 
 type endOfSpeechState struct {
 	segment       speechSegment
+	pending       *workerCommand
 	confidence    float64
 	callbackFired bool
-	generation    uint64
+	vadState      vadState
+	transcript    transcriptState
 }
 
 type turnPredictor interface {
@@ -88,6 +108,7 @@ type pipecatEndOfSpeech struct {
 
 	commandCh chan workerCommand
 	stopCh    chan struct{}
+	closeOnce sync.Once
 
 	mu           sync.RWMutex
 	state        *endOfSpeechState
@@ -244,8 +265,57 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 		return endOfSpeech.handleUserTextPacket(ctx, packet)
 	case internal_type.EndOfSpeechInterruptionPacket:
 		return endOfSpeech.handleInterruptionPacket(ctx)
-	case internal_type.VadSpeechActivityPacket:
-		return endOfSpeech.handleSpeechActivityPacket(ctx)
+	case internal_type.InterruptionDetectedPacket:
+		if packet.Source != internal_type.InterruptionSourceVad {
+			return nil
+		}
+		endOfSpeech.mu.Lock()
+		switch packet.Event {
+		case internal_type.InterruptionEventStart:
+			// VAD start only marks speech as active. Transcript revision remains
+			// the only token used to reject stale EOS timers.
+			endOfSpeech.state.vadState = vadStateSpeaking
+			endOfSpeech.state.pending = nil
+			endOfSpeech.mu.Unlock()
+			return nil
+		case internal_type.InterruptionEventEnd:
+			endOfSpeech.state.vadState = vadStateEnded
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				(endOfSpeech.state.transcript == transcriptStateFinalized ||
+					endOfSpeech.state.transcript == transcriptStateIdle) {
+				command := workerCommand{
+					ctx:        ctx,
+					segment:    endOfSpeech.state.segment,
+					confidence: endOfSpeech.state.confidence,
+					timeout:    endOfSpeech.quickTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// VAD end is not transcript finalization. It only opens the
+				// flush window after STT has acknowledged with a final packet.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+				command := workerCommand{
+					ctx:        ctx,
+					segment:    endOfSpeech.state.segment,
+					confidence: endOfSpeech.state.confidence,
+					timeout:    endOfSpeech.fallbackTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// A newer interim after a final means STT finalization is still
+				// catching up. Wait longer, then use the best visible transcript.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+		}
+		endOfSpeech.mu.Unlock()
+		return nil
 	case internal_type.SpeechToTextPacket:
 		return endOfSpeech.handleSpeechToTextPacket(ctx, packet)
 	}
@@ -266,19 +336,22 @@ func (endOfSpeech *pipecatEndOfSpeech) handleUserTextPacket(ctx context.Context,
 	segment := speechSegment{
 		Revision:  endOfSpeech.state.segment.Revision + 1,
 		ContextID: packet.ContextId(),
+		FinalText: packet.Text,
 		Text:      packet.Text,
 		Timestamp: time.Now(),
 	}
-	endOfSpeech.state.segment = segment
-	endOfSpeech.state.confidence = 0
-	endOfSpeech.mu.Unlock()
-
-	endOfSpeech.emitInterimSpeech(ctx, segment)
-	endOfSpeech.enqueueCommand(workerCommand{
+	command := workerCommand{
 		ctx:             ctx,
 		segment:         segment,
 		fireImmediately: true,
-	})
+	}
+	endOfSpeech.state.segment = segment
+	endOfSpeech.state.confidence = 0
+	endOfSpeech.state.transcript = transcriptStateFinalized
+	endOfSpeech.mu.Unlock()
+
+	endOfSpeech.emitInterimSpeech(ctx, command.segment)
+	endOfSpeech.enqueueCommand(command)
 
 	return nil
 }
@@ -287,45 +360,123 @@ func (endOfSpeech *pipecatEndOfSpeech) handleInterruptionPacket(ctx context.Cont
 	return endOfSpeech.extendCurrentSegment(ctx, endOfSpeech.extendedTimeout)
 }
 
-func (endOfSpeech *pipecatEndOfSpeech) handleSpeechActivityPacket(ctx context.Context) error {
-	return endOfSpeech.extendCurrentSegment(ctx, endOfSpeech.extendedTimeout)
-}
-
 func (endOfSpeech *pipecatEndOfSpeech) handleSpeechToTextPacket(ctx context.Context, packet internal_type.SpeechToTextPacket) error {
 	endOfSpeech.mu.Lock()
 	if packet.Interim {
-		segment := endOfSpeech.state.segment
-		confidence := endOfSpeech.state.confidence
-		endOfSpeech.mu.Unlock()
-		if segment.Text == "" {
+		previous := endOfSpeech.state.segment
+		if packet.Script == "" {
+			endOfSpeech.mu.Unlock()
 			return nil
 		}
+		timestamp := time.Now()
+		if previous.FinalText != "" && !previous.Timestamp.IsZero() {
+			timestamp = previous.Timestamp
+		}
+		segment := speechSegment{
+			Revision:  previous.Revision + 1,
+			ContextID: packet.ContextId(),
+			Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
+			Timestamp: timestamp,
+		}
+		segment.Chunks = append(segment.Chunks, packet)
+		pendingTranscript := ""
+		for _, chunk := range segment.Chunks {
+			if chunk.Script == "" {
+				continue
+			}
+			if chunk.Interim {
+				pendingTranscript = chunk.Script
+				if segment.FinalText != "" {
+					pendingTranscript = chunk.GetConcat() + pendingTranscript
+				}
+				continue
+			}
+			if segment.FinalText != "" {
+				segment.FinalText += chunk.GetConcat()
+			}
+			segment.FinalText += chunk.Script
+			pendingTranscript = ""
+		}
+		segment.Text = segment.FinalText + pendingTranscript
+		if previous.FinalText == "" {
+			endOfSpeech.state.transcript = transcriptStateInterimPending
+		} else {
+			endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+		}
+		endOfSpeech.state.segment = segment
+		if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim ||
+			endOfSpeech.state.vadState == vadStateEnded {
+			command := workerCommand{
+				ctx:        ctx,
+				segment:    segment,
+				confidence: endOfSpeech.state.confidence,
+				timeout:    endOfSpeech.fallbackTimeout,
+			}
+			endOfSpeech.mu.Unlock()
 
-		endOfSpeech.enqueueCommand(workerCommand{
-			ctx:        ctx,
-			segment:    segment,
-			confidence: confidence,
-			timeout:    endOfSpeech.fallbackTimeout,
-		})
+			endOfSpeech.emitInterimSpeech(ctx, command.segment)
+			endOfSpeech.enqueueCommand(command)
+			return nil
+		}
+		endOfSpeech.mu.Unlock()
+
+		endOfSpeech.emitInterimSpeech(ctx, segment)
 		return nil
 	}
 
+	previous := endOfSpeech.state.segment
 	segment := speechSegment{
-		Revision:  endOfSpeech.state.segment.Revision + 1,
+		Revision:  previous.Revision + 1,
 		ContextID: packet.ContextId(),
 		Timestamp: time.Now(),
-		Text:      endOfSpeech.state.segment.Text,
-		Chunks:    append([]internal_type.SpeechToTextPacket(nil), endOfSpeech.state.segment.Chunks...),
-	}
-	if segment.Text != "" {
-		segment.Text += packet.GetConcat()
-		segment.Text += packet.Script
-	} else {
-		segment.Text = packet.Script
+		Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
 	}
 	segment.Chunks = append(segment.Chunks, packet)
+	pendingTranscript := ""
+	for _, chunk := range segment.Chunks {
+		if chunk.Script == "" {
+			continue
+		}
+		if chunk.Interim {
+			pendingTranscript = chunk.Script
+			if segment.FinalText != "" {
+				pendingTranscript = chunk.GetConcat() + pendingTranscript
+			}
+			continue
+		}
+		if segment.FinalText != "" {
+			segment.FinalText += chunk.GetConcat()
+		}
+		segment.FinalText += chunk.Script
+		pendingTranscript = ""
+	}
+	segment.Text = segment.FinalText + pendingTranscript
+	endOfSpeech.state.transcript = transcriptStateFinalized
+	if segment.Text != segment.FinalText {
+		endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+	}
 	endOfSpeech.state.segment = segment
 	endOfSpeech.state.confidence = 0
+	if endOfSpeech.state.vadState == vadStateEnded {
+		timeout := endOfSpeech.quickTimeout
+		if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+			timeout = endOfSpeech.fallbackTimeout
+		}
+		command := workerCommand{
+			ctx:        ctx,
+			segment:    segment,
+			confidence: 0,
+			timeout:    timeout,
+		}
+		endOfSpeech.mu.Unlock()
+
+		if command.segment.Text == "" {
+			return nil
+		}
+		endOfSpeech.emitInterimSpeech(ctx, command.segment)
+		endOfSpeech.enqueueCommand(command)
+		return nil
+	}
 	endOfSpeech.mu.Unlock()
 
 	if segment.Text == "" {
@@ -374,20 +525,19 @@ func (endOfSpeech *pipecatEndOfSpeech) handleSpeechToTextPacket(ctx context.Cont
 
 func (endOfSpeech *pipecatEndOfSpeech) extendCurrentSegment(ctx context.Context, timeout time.Duration) error {
 	endOfSpeech.mu.RLock()
-	segment := endOfSpeech.state.segment
-	confidence := endOfSpeech.state.confidence
+	command := workerCommand{
+		ctx:        ctx,
+		segment:    endOfSpeech.state.segment,
+		confidence: endOfSpeech.state.confidence,
+		timeout:    timeout,
+	}
 	endOfSpeech.mu.RUnlock()
 
-	if segment.Text == "" {
+	if command.segment.Text == "" {
 		return nil
 	}
 
-	endOfSpeech.enqueueCommand(workerCommand{
-		ctx:        ctx,
-		segment:    segment,
-		confidence: confidence,
-		timeout:    timeout,
-	})
+	endOfSpeech.enqueueCommand(command)
 
 	return nil
 }
@@ -479,6 +629,10 @@ func (endOfSpeech *pipecatEndOfSpeech) debugf(format string, args ...interface{}
 }
 
 func (endOfSpeech *pipecatEndOfSpeech) enqueueCommand(command workerCommand) {
+	if endOfSpeech == nil || endOfSpeech.commandCh == nil || endOfSpeech.stopCh == nil {
+		return
+	}
+
 	select {
 	case <-endOfSpeech.stopCh:
 		return
@@ -496,7 +650,6 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 		timer          *time.Timer
 		timerCh        <-chan time.Time
 		timerArmedAt   time.Time
-		generation     uint64
 		currentCommand workerCommand
 	)
 
@@ -510,9 +663,13 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 	}
 	resetState := func() {
 		endOfSpeech.state.callbackFired = false
-		endOfSpeech.state.generation++
-		endOfSpeech.state.segment = speechSegment{}
+		// Bump revision after a completed turn so late timer work from the old
+		// message cannot complete against the next user turn.
+		endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision + 1}
+		endOfSpeech.state.pending = nil
 		endOfSpeech.state.confidence = 0
+		endOfSpeech.state.vadState = vadStateIdle
+		endOfSpeech.state.transcript = transcriptStateIdle
 		endOfSpeech.audioBuffer = endOfSpeech.audioBuffer[:0]
 		endOfSpeech.audioGeneration++
 		endOfSpeech.predictedGeneration = 0
@@ -533,21 +690,26 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 				endOfSpeech.mu.Unlock()
 				continue
 			}
+			// Newer text/STT packets supersede older timer commands. Completing a
+			// stale snapshot can shrink the final user message.
+			if !command.fireImmediately && command.segment.Revision != endOfSpeech.state.segment.Revision {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
 
 			if command.fireImmediately {
 				endOfSpeech.state.callbackFired = true
-				currentCommand = command
+				endOfSpeech.state.pending = nil
 				stopTimer()
 				endOfSpeech.mu.Unlock()
-				endOfSpeech.emitEndOfSpeech(currentCommand, time.Now())
+				endOfSpeech.emitEndOfSpeech(command, time.Now())
 				endOfSpeech.mu.Lock()
 				resetState()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
 
-			generation = endOfSpeech.state.generation + 1
-			endOfSpeech.state.generation = generation
+			endOfSpeech.state.pending = nil
 			currentCommand = command
 			stopTimer()
 			timerArmedAt = time.Now()
@@ -557,7 +719,56 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 
 		case <-timerCh:
 			endOfSpeech.mu.Lock()
-			if endOfSpeech.state.callbackFired || generation != endOfSpeech.state.generation {
+			if endOfSpeech.state.callbackFired {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+
+			// While VAD says the user is speaking, defer once. The fallback timer
+			// recovers if VAD end is lost because of noise or provider failure.
+			if endOfSpeech.state.vadState == vadStateSpeaking {
+				if endOfSpeech.state.pending == nil {
+					command := currentCommand
+					endOfSpeech.state.pending = &command
+					stopTimer()
+					timerArmedAt = time.Now()
+					timer = time.NewTimer(endOfSpeech.fallbackTimeout)
+					timerCh = timer.C
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				command := *endOfSpeech.state.pending
+				endOfSpeech.state.pending = nil
+				endOfSpeech.state.vadState = vadStateIdle
+				if command.segment.Revision != endOfSpeech.state.segment.Revision {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+				if endOfSpeech.state.transcript == transcriptStateInterimPending {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				endOfSpeech.state.callbackFired = true
+				armedAt := timerArmedAt
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				endOfSpeech.emitEndOfSpeech(command, armedAt)
+				endOfSpeech.mu.Lock()
+				resetState()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if currentCommand.segment.Revision != endOfSpeech.state.segment.Revision {
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if endOfSpeech.state.transcript == transcriptStateInterimPending {
+				stopTimer()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
@@ -576,6 +787,10 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 }
 
 func (endOfSpeech *pipecatEndOfSpeech) emitEndOfSpeech(command workerCommand, timerArmedAt time.Time) {
+	if endOfSpeech == nil || endOfSpeech.onPacket == nil {
+		return
+	}
+
 	ctx := command.ctx
 	segment := command.segment
 	if ctx != nil && ctx.Err() != nil {
@@ -635,39 +850,47 @@ func (endOfSpeech *pipecatEndOfSpeech) emitEndOfSpeech(command workerCommand, ti
 }
 
 func (endOfSpeech *pipecatEndOfSpeech) Close(ctx context.Context) error {
-	endOfSpeech.mu.Lock()
-	eosStartedAt := endOfSpeech.eosStartedAt
-	endOfSpeech.eosStartedAt = time.Time{}
-	endOfSpeech.mu.Unlock()
+	if endOfSpeech == nil {
+		return nil
+	}
 
-	if endOfSpeech.onPacket != nil {
-		packets := []internal_type.Packet{}
-		if !eosStartedAt.IsZero() {
-			packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
-			})
-		}
-		packets = append(packets, internal_type.ObservabilityEventRecordPacket{
-			Scope: internal_type.ObservabilityRecordScopeConversation,
-			Record: observability.RecordEvent{
-				Component: observability.ComponentEOS,
-				Event:     observability.EOSClosed,
-				Attributes: observability.Attributes{
-					"provider": endOfSpeech.Name(),
+	endOfSpeech.closeOnce.Do(func() {
+		endOfSpeech.mu.Lock()
+		eosStartedAt := endOfSpeech.eosStartedAt
+		endOfSpeech.eosStartedAt = time.Time{}
+		endOfSpeech.mu.Unlock()
+
+		if endOfSpeech.onPacket != nil {
+			packets := []internal_type.Packet{}
+			if !eosStartedAt.IsZero() {
+				packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
+					Scope:  internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
+				})
+			}
+			packets = append(packets, internal_type.ObservabilityEventRecordPacket{
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentEOS,
+					Event:     observability.EOSClosed,
+					Attributes: observability.Attributes{
+						"provider": endOfSpeech.Name(),
+					},
+					OccurredAt: time.Now(),
 				},
-				OccurredAt: time.Now(),
-			},
-		})
-		_ = endOfSpeech.onPacket(ctx, packets...)
-	}
-	close(endOfSpeech.stopCh)
-	endOfSpeech.predictorMu.Lock()
-	if predictor, ok := endOfSpeech.predictor.(interface{ Destroy() }); ok {
-		predictor.Destroy()
-	}
-	endOfSpeech.predictor = nil
-	endOfSpeech.predictorMu.Unlock()
+			})
+			_ = endOfSpeech.onPacket(ctx, packets...)
+		}
+		if endOfSpeech.stopCh != nil {
+			close(endOfSpeech.stopCh)
+		}
+		endOfSpeech.predictorMu.Lock()
+		if predictor, ok := endOfSpeech.predictor.(interface{ Destroy() }); ok {
+			predictor.Destroy()
+		}
+		endOfSpeech.predictor = nil
+		endOfSpeech.predictorMu.Unlock()
+	})
 
 	return nil
 }

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_bench_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_bench_test.go
@@ -424,7 +424,7 @@ func BenchmarkExecute_HighThroughput(b *testing.B) {
 	}
 }
 
-// BenchmarkExecute_RapidFireInputs measures generation counter efficiency.
+// BenchmarkExecute_RapidFireInputs measures stale timer invalidation efficiency.
 func BenchmarkExecute_RapidFireInputs(b *testing.B) {
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
 	eos := newTestEOS(callback, newTestOpts(map[string]any{"microphone.eos.fallback_timeout": 100.0}))

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_test.go
@@ -915,7 +915,7 @@ func TestEOS_InterruptionWithNoTextIgnored(t *testing.T) {
 	assert.Equal(t, int64(0), atomic.LoadInt64(&callCount))
 }
 
-func TestEOS_VadSpeechActivityExtendsTimer(t *testing.T) {
+func TestEOS_VADStartDefersFinalUntilRecoveryTimeout(t *testing.T) {
 	called := make(chan internal_type.EndOfSpeechPacket, 1)
 	callback := func(ctx context.Context, res ...internal_type.Packet) error {
 		for _, r := range res {
@@ -935,21 +935,292 @@ func TestEOS_VadSpeechActivityExtendsTimer(t *testing.T) {
 	}))
 	defer closeTestEndOfSpeech(eos)
 
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
 	require.NoError(t, eos.Execute(context.Background(), sttInput("hello", true)))
-	time.Sleep(40 * time.Millisecond)
-	require.NoError(t, eos.Execute(context.Background(), internal_type.VadSpeechActivityPacket{}))
 
 	select {
 	case <-called:
-		t.Fatal("callback fired before vad speech activity extension elapsed")
-	case <-time.After(50 * time.Millisecond):
+		t.Fatal("callback fired before stuck VAD recovery elapsed")
+	case <-time.After(90 * time.Millisecond):
 	}
 
 	select {
 	case p := <-called:
 		assert.Equal(t, "hello", p.Speech)
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timeout waiting for callback after vad speech activity extension")
+		t.Fatal("timeout waiting for callback after stuck VAD recovery")
+	}
+
+	select {
+	case p := <-called:
+		t.Fatalf("unexpected duplicate callback after stuck VAD recovery: %+v", p)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestEOS_VADEndFlushesPendingFinal(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			if p, ok := r.(internal_type.EndOfSpeechPacket); ok {
+				select {
+				case called <- p:
+				default:
+				}
+			}
+		}
+		return nil
+	}
+
+	eos := newTestEOS(callback, newTestOpts(map[string]any{
+		"microphone.eos.fallback_timeout": 100.0,
+		"microphone.eos.quick_timeout":    40.0,
+	}))
+	defer closeTestEndOfSpeech(eos)
+
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, eos.Execute(context.Background(), sttInput("hello", true)))
+
+	select {
+	case <-called:
+		t.Fatal("callback fired before VAD end")
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		eos.mu.RLock()
+		pending := eos.state.pending != nil
+		eos.mu.RUnlock()
+		if pending {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for pending final")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case p := <-called:
+		assert.Equal(t, "hello", p.Speech)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for callback after VAD end")
+	}
+
+	select {
+	case p := <-called:
+		t.Fatalf("unexpected duplicate callback after VAD end: %+v", p)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestEOS_VADEndFlushWindowUsesLateFinalSTT(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			if p, ok := r.(internal_type.EndOfSpeechPacket); ok {
+				select {
+				case called <- p:
+				default:
+				}
+			}
+		}
+		return nil
+	}
+
+	eos := newTestEOS(callback, newTestOpts(map[string]any{
+		"microphone.eos.fallback_timeout": 200.0,
+		"microphone.eos.quick_timeout":    40.0,
+	}))
+	defer closeTestEndOfSpeech(eos)
+
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, eos.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}))
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, eos.Execute(context.Background(), internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "Rightly?",
+		Interim:   false,
+	}))
+
+	select {
+	case p := <-called:
+		assert.Equal(t, "me an idea about the how how do I do things? Rightly?", p.Speech)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for late final callback")
+	}
+}
+
+func TestEOS_VADEndCompleteClearsPendingInterimWhenFinalIsShorter(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			if p, ok := r.(internal_type.EndOfSpeechPacket); ok {
+				select {
+				case called <- p:
+				default:
+				}
+			}
+		}
+		return nil
+	}
+
+	eos := newTestEOS(callback, newTestOpts(map[string]any{
+		"microphone.eos.fallback_timeout": 70.0,
+		"microphone.eos.quick_timeout":    20.0,
+	}))
+	defer closeTestEndOfSpeech(eos)
+
+	ctx := context.Background()
+	require.NoError(t, eos.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, eos.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things? Rightly?",
+		Interim:   true,
+	}))
+	require.NoError(t, eos.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}))
+	require.NoError(t, eos.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case p := <-called:
+		assert.Equal(t, "me an idea about the how how do I do things?", p.Speech)
+		require.Len(t, p.Speechs, 2)
+		assert.True(t, p.Speechs[0].Interim)
+		assert.False(t, p.Speechs[1].Interim)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for final transcript")
+	}
+}
+
+func TestEOS_StaleTimerCompletionDoesNotShrinkLatestSegment(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			if p, ok := r.(internal_type.EndOfSpeechPacket); ok {
+				called <- p
+			}
+		}
+		return nil
+	}
+
+	eos := newTestEOS(callback, newTestOpts(map[string]any{}))
+	defer closeTestEndOfSpeech(eos)
+
+	eos.mu.Lock()
+	eos.state.segment = speechSegment{
+		Revision:  1,
+		ContextID: "ctx-stale",
+		Text:      "me an idea about the how how do I do things?",
+		Timestamp: time.Now(),
+	}
+	oldSegment := eos.state.segment
+	eos.mu.Unlock()
+
+	eos.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: oldSegment,
+		timeout: 30 * time.Millisecond,
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	latestSegment := speechSegment{
+		Revision:  2,
+		ContextID: "ctx-stale",
+		Text:      "me an idea about the how how do I do things? Rightly?",
+		Timestamp: time.Now(),
+	}
+	eos.mu.Lock()
+	eos.state.segment = latestSegment
+	eos.mu.Unlock()
+
+	select {
+	case p := <-called:
+		t.Fatalf("stale completion fired: %q", p.Speech)
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	eos.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: latestSegment,
+		timeout: 10 * time.Millisecond,
+	})
+
+	select {
+	case p := <-called:
+		assert.Equal(t, latestSegment.Text, p.Speech)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for latest completion")
+	}
+}
+
+func TestEOS_OnlyInterimWithVADDoesNotComplete(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 1)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			if p, ok := r.(internal_type.EndOfSpeechPacket); ok {
+				select {
+				case called <- p:
+				default:
+				}
+			}
+		}
+		return nil
+	}
+
+	eos := newTestEOS(callback, newTestOpts(map[string]any{
+		"microphone.eos.fallback_timeout": 60.0,
+	}))
+	defer closeTestEndOfSpeech(eos)
+
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}))
+	require.NoError(t, eos.Execute(context.Background(), sttInput("interim only", false)))
+	require.NoError(t, eos.Execute(context.Background(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}))
+
+	select {
+	case p := <-called:
+		t.Fatalf("callback should not fire for interim-only VAD input: %+v", p)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
@@ -1447,6 +1718,8 @@ func TestEOS_CloseStopsWorker(t *testing.T) {
 	eos := newTestEOS(func(context.Context, ...internal_type.Packet) error { return nil },
 		newTestOpts(map[string]any{}))
 	err := eos.Close(context.Background())
+	assert.NoError(t, err)
+	err = eos.Close(context.Background())
 	assert.NoError(t, err)
 }
 

--- a/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech.go
@@ -23,10 +23,30 @@ const (
 	silenceBasedEndOfSpeechName = "silenceBasedEndOfSpeech"
 	optSilenceTimeout           = "microphone.eos.timeout"
 	defaultSilenceTimeout       = 1000 * time.Millisecond
+	defaultVadEndTimeout        = 250 * time.Millisecond
+)
+
+type vadState uint8
+
+const (
+	vadStateIdle vadState = iota
+	vadStateSpeaking
+	vadStateEnded
+)
+
+type transcriptState uint8
+
+const (
+	transcriptStateIdle transcriptState = iota
+	transcriptStateInterimPending
+	transcriptStateFinalized
+	transcriptStateFinalizedWithPendingInterim
 )
 
 type speechSegment struct {
+	Revision  uint64
 	ContextID string
+	FinalText string
 	Text      string
 	Chunks    []internal_type.SpeechToTextPacket
 	Timestamp time.Time
@@ -41,17 +61,21 @@ type workerCommand struct {
 
 type endOfSpeechState struct {
 	segment       speechSegment
+	pending       *workerCommand
 	callbackFired bool
-	generation    uint64
+	vadState      vadState
+	transcript    transcriptState
 }
 
 type silenceBasedEndOfSpeech struct {
 	onPacket       func(context.Context, ...internal_type.Packet) error
 	opts           utils.Option
 	silenceTimeout time.Duration
+	vadEndTimeout  time.Duration
 
 	commandCh chan workerCommand
 	stopCh    chan struct{}
+	closeOnce sync.Once
 
 	mu    sync.RWMutex
 	state *endOfSpeechState
@@ -115,6 +139,7 @@ func New(opts ...Option) (internal_type.EndOfSpeechExecutor, error) {
 		onPacket:       options.onPacket,
 		opts:           options.options,
 		silenceTimeout: silenceTimeout,
+		vadEndTimeout:  defaultVadEndTimeout,
 		commandCh:      make(chan workerCommand, 32),
 		stopCh:         make(chan struct{}),
 		state:          &endOfSpeechState{segment: speechSegment{}},
@@ -162,8 +187,55 @@ func (endOfSpeech *silenceBasedEndOfSpeech) Execute(ctx context.Context, packet 
 		return endOfSpeech.handleUserTextPacket(ctx, packet)
 	case internal_type.EndOfSpeechInterruptionPacket:
 		return endOfSpeech.handleInterruptionPacket(ctx)
-	case internal_type.VadSpeechActivityPacket:
-		return endOfSpeech.handleSpeechActivityPacket(ctx)
+	case internal_type.InterruptionDetectedPacket:
+		if packet.Source != internal_type.InterruptionSourceVad {
+			return nil
+		}
+		endOfSpeech.mu.Lock()
+		switch packet.Event {
+		case internal_type.InterruptionEventStart:
+			// VAD start only marks speech as active. Transcript revision remains
+			// the only token used to reject stale EOS timers.
+			endOfSpeech.state.vadState = vadStateSpeaking
+			endOfSpeech.state.pending = nil
+			endOfSpeech.mu.Unlock()
+			return nil
+		case internal_type.InterruptionEventEnd:
+			endOfSpeech.state.vadState = vadStateEnded
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				(endOfSpeech.state.transcript == transcriptStateFinalized ||
+					endOfSpeech.state.transcript == transcriptStateIdle) {
+				command := workerCommand{
+					ctx:     ctx,
+					segment: endOfSpeech.state.segment,
+					timeout: endOfSpeech.vadEndTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// VAD end is not transcript finalization. It only opens the
+				// flush window after STT has acknowledged with a final packet.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+			if endOfSpeech.state.segment.Text != "" &&
+				!endOfSpeech.state.callbackFired &&
+				endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+				command := workerCommand{
+					ctx:     ctx,
+					segment: endOfSpeech.state.segment,
+					timeout: endOfSpeech.silenceTimeout,
+				}
+				endOfSpeech.state.pending = nil
+				endOfSpeech.mu.Unlock()
+				// A newer interim after a final means STT finalization is still
+				// catching up. Wait longer, then use the best visible transcript.
+				endOfSpeech.enqueueCommand(command)
+				return nil
+			}
+		}
+		endOfSpeech.mu.Unlock()
+		return nil
 	case internal_type.SpeechToTextPacket:
 		return endOfSpeech.handleSpeechToTextPacket(ctx, packet)
 	}
@@ -181,31 +253,31 @@ func (endOfSpeech *silenceBasedEndOfSpeech) handleUserTextPacket(
 
 	endOfSpeech.mu.Lock()
 	segment := speechSegment{
+		Revision:  endOfSpeech.state.segment.Revision + 1,
 		ContextID: packet.ContextId(),
+		FinalText: packet.Text,
 		Text:      packet.Text,
 		Timestamp: time.Now(),
 	}
-	endOfSpeech.state.segment = segment
-	endOfSpeech.mu.Unlock()
-
-	_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
-		Speech:    segment.Text,
-		ContextID: segment.ContextID,
-	})
-	endOfSpeech.enqueueCommand(workerCommand{
+	command := workerCommand{
 		ctx:             ctx,
 		segment:         segment,
 		fireImmediately: true,
+	}
+	endOfSpeech.state.segment = segment
+	endOfSpeech.state.transcript = transcriptStateFinalized
+	endOfSpeech.mu.Unlock()
+
+	_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+		Speech:    command.segment.Text,
+		ContextID: command.segment.ContextID,
 	})
+	endOfSpeech.enqueueCommand(command)
 
 	return nil
 }
 
 func (endOfSpeech *silenceBasedEndOfSpeech) handleInterruptionPacket(ctx context.Context) error {
-	return endOfSpeech.extendCurrentSegment(ctx, endOfSpeech.silenceTimeout)
-}
-
-func (endOfSpeech *silenceBasedEndOfSpeech) handleSpeechActivityPacket(ctx context.Context) error {
 	return endOfSpeech.extendCurrentSegment(ctx, endOfSpeech.silenceTimeout)
 }
 
@@ -215,46 +287,135 @@ func (endOfSpeech *silenceBasedEndOfSpeech) handleSpeechToTextPacket(
 ) error {
 	endOfSpeech.mu.Lock()
 	if packet.Interim {
-		segment := endOfSpeech.state.segment
-		endOfSpeech.mu.Unlock()
-		if segment.Text == "" {
+		previous := endOfSpeech.state.segment
+		if packet.Script == "" {
+			endOfSpeech.mu.Unlock()
 			return nil
 		}
+		timestamp := time.Now()
+		if previous.FinalText != "" && !previous.Timestamp.IsZero() {
+			timestamp = previous.Timestamp
+		}
+		segment := speechSegment{
+			Revision:  previous.Revision + 1,
+			ContextID: packet.ContextId(),
+			Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
+			Timestamp: timestamp,
+		}
+		segment.Chunks = append(segment.Chunks, packet)
+		pendingTranscript := ""
+		for _, chunk := range segment.Chunks {
+			if chunk.Script == "" {
+				continue
+			}
+			if chunk.Interim {
+				pendingTranscript = chunk.Script
+				if segment.FinalText != "" {
+					pendingTranscript = chunk.GetConcat() + pendingTranscript
+				}
+				continue
+			}
+			if segment.FinalText != "" {
+				segment.FinalText += chunk.GetConcat()
+			}
+			segment.FinalText += chunk.Script
+			pendingTranscript = ""
+		}
+		segment.Text = segment.FinalText + pendingTranscript
+		if previous.FinalText == "" {
+			endOfSpeech.state.transcript = transcriptStateInterimPending
+		} else {
+			endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+		}
+		endOfSpeech.state.segment = segment
+		if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim ||
+			endOfSpeech.state.vadState == vadStateEnded {
+			command := workerCommand{
+				ctx:     ctx,
+				segment: segment,
+				timeout: endOfSpeech.silenceTimeout,
+			}
+			endOfSpeech.mu.Unlock()
 
-		endOfSpeech.enqueueCommand(workerCommand{
-			ctx:     ctx,
-			segment: segment,
-			timeout: endOfSpeech.silenceTimeout,
+			_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+				Speech:    command.segment.Text,
+				ContextID: command.segment.ContextID,
+			})
+			endOfSpeech.enqueueCommand(command)
+			return nil
+		}
+		endOfSpeech.mu.Unlock()
+
+		_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+			Speech:    segment.Text,
+			ContextID: segment.ContextID,
 		})
-
 		return nil
 	}
 
+	previous := endOfSpeech.state.segment
 	segment := speechSegment{
+		Revision:  previous.Revision + 1,
 		ContextID: packet.ContextId(),
 		Timestamp: time.Now(),
-		Text:      endOfSpeech.state.segment.Text,
-		Chunks:    append([]internal_type.SpeechToTextPacket(nil), endOfSpeech.state.segment.Chunks...),
-	}
-	if segment.Text != "" {
-		segment.Text += packet.GetConcat()
-		segment.Text += packet.Script
-	} else {
-		segment.Text = packet.Script
+		Chunks:    append([]internal_type.SpeechToTextPacket(nil), previous.Chunks...),
 	}
 	segment.Chunks = append(segment.Chunks, packet)
+	pendingTranscript := ""
+	for _, chunk := range segment.Chunks {
+		if chunk.Script == "" {
+			continue
+		}
+		if chunk.Interim {
+			pendingTranscript = chunk.Script
+			if segment.FinalText != "" {
+				pendingTranscript = chunk.GetConcat() + pendingTranscript
+			}
+			continue
+		}
+		if segment.FinalText != "" {
+			segment.FinalText += chunk.GetConcat()
+		}
+		segment.FinalText += chunk.Script
+		pendingTranscript = ""
+	}
+	segment.Text = segment.FinalText + pendingTranscript
+	endOfSpeech.state.transcript = transcriptStateFinalized
+	if segment.Text != segment.FinalText {
+		endOfSpeech.state.transcript = transcriptStateFinalizedWithPendingInterim
+	}
 	endOfSpeech.state.segment = segment
-	endOfSpeech.mu.Unlock()
+	if endOfSpeech.state.vadState == vadStateEnded {
+		timeout := endOfSpeech.vadEndTimeout
+		if endOfSpeech.state.transcript == transcriptStateFinalizedWithPendingInterim {
+			timeout = endOfSpeech.silenceTimeout
+		}
+		command := workerCommand{
+			ctx:     ctx,
+			segment: segment,
+			timeout: timeout,
+		}
+		endOfSpeech.mu.Unlock()
 
-	_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
-		Speech:    segment.Text,
-		ContextID: segment.ContextID,
-	})
-	endOfSpeech.enqueueCommand(workerCommand{
+		_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+			Speech:    command.segment.Text,
+			ContextID: command.segment.ContextID,
+		})
+		endOfSpeech.enqueueCommand(command)
+		return nil
+	}
+	command := workerCommand{
 		ctx:     ctx,
 		segment: segment,
 		timeout: endOfSpeech.silenceTimeout,
+	}
+	endOfSpeech.mu.Unlock()
+
+	_ = endOfSpeech.onPacket(ctx, internal_type.InterimEndOfSpeechPacket{
+		Speech:    command.segment.Text,
+		ContextID: command.segment.ContextID,
 	})
+	endOfSpeech.enqueueCommand(command)
 
 	return nil
 }
@@ -264,23 +425,27 @@ func (endOfSpeech *silenceBasedEndOfSpeech) extendCurrentSegment(
 	timeout time.Duration,
 ) error {
 	endOfSpeech.mu.RLock()
-	segment := endOfSpeech.state.segment
+	command := workerCommand{
+		ctx:     ctx,
+		segment: endOfSpeech.state.segment,
+		timeout: timeout,
+	}
 	endOfSpeech.mu.RUnlock()
 
-	if segment.Text == "" {
+	if command.segment.Text == "" {
 		return nil
 	}
 
-	endOfSpeech.enqueueCommand(workerCommand{
-		ctx:     ctx,
-		segment: segment,
-		timeout: timeout,
-	})
+	endOfSpeech.enqueueCommand(command)
 
 	return nil
 }
 
 func (endOfSpeech *silenceBasedEndOfSpeech) enqueueCommand(command workerCommand) {
+	if endOfSpeech == nil || endOfSpeech.commandCh == nil || endOfSpeech.stopCh == nil {
+		return
+	}
+
 	select {
 	case <-endOfSpeech.stopCh:
 		return
@@ -298,7 +463,6 @@ func (endOfSpeech *silenceBasedEndOfSpeech) worker() {
 		timer          *time.Timer
 		timerCh        <-chan time.Time
 		timerArmedAt   time.Time
-		generation     uint64
 		currentCommand workerCommand
 	)
 
@@ -312,8 +476,12 @@ func (endOfSpeech *silenceBasedEndOfSpeech) worker() {
 	}
 	resetState := func() {
 		endOfSpeech.state.callbackFired = false
-		endOfSpeech.state.generation++
-		endOfSpeech.state.segment = speechSegment{}
+		// Bump revision after a completed turn so late timer work from the old
+		// message cannot complete against the next user turn.
+		endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision + 1}
+		endOfSpeech.state.pending = nil
+		endOfSpeech.state.vadState = vadStateIdle
+		endOfSpeech.state.transcript = transcriptStateIdle
 	}
 
 	for {
@@ -329,21 +497,26 @@ func (endOfSpeech *silenceBasedEndOfSpeech) worker() {
 				endOfSpeech.mu.Unlock()
 				continue
 			}
+			// Newer text/STT packets supersede older timer commands. Completing a
+			// stale snapshot can shrink the final user message.
+			if !command.fireImmediately && command.segment.Revision != endOfSpeech.state.segment.Revision {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
 
 			if command.fireImmediately {
 				endOfSpeech.state.callbackFired = true
-				currentCommand = command
+				endOfSpeech.state.pending = nil
 				stopTimer()
 				endOfSpeech.mu.Unlock()
-				endOfSpeech.emitEndOfSpeech(currentCommand, time.Now())
+				endOfSpeech.emitEndOfSpeech(command, time.Now())
 				endOfSpeech.mu.Lock()
 				resetState()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
 
-			generation = endOfSpeech.state.generation + 1
-			endOfSpeech.state.generation = generation
+			endOfSpeech.state.pending = nil
 			currentCommand = command
 			stopTimer()
 			timerArmedAt = time.Now()
@@ -353,7 +526,56 @@ func (endOfSpeech *silenceBasedEndOfSpeech) worker() {
 
 		case <-timerCh:
 			endOfSpeech.mu.Lock()
-			if endOfSpeech.state.callbackFired || generation != endOfSpeech.state.generation {
+			if endOfSpeech.state.callbackFired {
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+
+			// While VAD says the user is speaking, defer once. The fallback timer
+			// recovers if VAD end is lost because of noise or provider failure.
+			if endOfSpeech.state.vadState == vadStateSpeaking {
+				if endOfSpeech.state.pending == nil {
+					command := currentCommand
+					endOfSpeech.state.pending = &command
+					stopTimer()
+					timerArmedAt = time.Now()
+					timer = time.NewTimer(endOfSpeech.silenceTimeout)
+					timerCh = timer.C
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				command := *endOfSpeech.state.pending
+				endOfSpeech.state.pending = nil
+				endOfSpeech.state.vadState = vadStateIdle
+				if command.segment.Revision != endOfSpeech.state.segment.Revision {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+				if endOfSpeech.state.transcript == transcriptStateInterimPending {
+					stopTimer()
+					endOfSpeech.mu.Unlock()
+					continue
+				}
+
+				endOfSpeech.state.callbackFired = true
+				armedAt := timerArmedAt
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				endOfSpeech.emitEndOfSpeech(command, armedAt)
+				endOfSpeech.mu.Lock()
+				resetState()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if currentCommand.segment.Revision != endOfSpeech.state.segment.Revision {
+				stopTimer()
+				endOfSpeech.mu.Unlock()
+				continue
+			}
+			if endOfSpeech.state.transcript == transcriptStateInterimPending {
+				stopTimer()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
@@ -372,6 +594,10 @@ func (endOfSpeech *silenceBasedEndOfSpeech) worker() {
 }
 
 func (endOfSpeech *silenceBasedEndOfSpeech) emitEndOfSpeech(command workerCommand, timerArmedAt time.Time) {
+	if endOfSpeech == nil || endOfSpeech.onPacket == nil {
+		return
+	}
+
 	ctx := command.ctx
 	segment := command.segment
 	if segment.Text == "" {
@@ -434,32 +660,40 @@ func (endOfSpeech *silenceBasedEndOfSpeech) emitEndOfSpeech(command workerComman
 }
 
 func (endOfSpeech *silenceBasedEndOfSpeech) Close(ctx context.Context) error {
-	endOfSpeech.mu.Lock()
-	eosStartedAt := endOfSpeech.eosStartedAt
-	endOfSpeech.eosStartedAt = time.Time{}
-	endOfSpeech.mu.Unlock()
-
-	if endOfSpeech.onPacket != nil {
-		packets := []internal_type.Packet{}
-		if !eosStartedAt.IsZero() {
-			packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
-			})
-		}
-		packets = append(packets, internal_type.ObservabilityEventRecordPacket{
-			Scope: internal_type.ObservabilityRecordScopeConversation,
-			Record: observability.RecordEvent{
-				Component: observability.ComponentEOS,
-				Event:     observability.EOSClosed,
-				Attributes: observability.Attributes{
-					"provider": endOfSpeech.Name(),
-				},
-				OccurredAt: time.Now(),
-			},
-		})
-		_ = endOfSpeech.onPacket(ctx, packets...)
+	if endOfSpeech == nil {
+		return nil
 	}
-	close(endOfSpeech.stopCh)
+
+	endOfSpeech.closeOnce.Do(func() {
+		endOfSpeech.mu.Lock()
+		eosStartedAt := endOfSpeech.eosStartedAt
+		endOfSpeech.eosStartedAt = time.Time{}
+		endOfSpeech.mu.Unlock()
+
+		if endOfSpeech.onPacket != nil {
+			packets := []internal_type.Packet{}
+			if !eosStartedAt.IsZero() {
+				packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
+					Scope:  internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.NewEOSDurationUsageRecord(endOfSpeech.Name(), time.Since(eosStartedAt), observability.Attributes{}),
+				})
+			}
+			packets = append(packets, internal_type.ObservabilityEventRecordPacket{
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentEOS,
+					Event:     observability.EOSClosed,
+					Attributes: observability.Attributes{
+						"provider": endOfSpeech.Name(),
+					},
+					OccurredAt: time.Now(),
+				},
+			})
+			_ = endOfSpeech.onPacket(ctx, packets...)
+		}
+		if endOfSpeech.stopCh != nil {
+			close(endOfSpeech.stopCh)
+		}
+	})
 	return nil
 }

--- a/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech_bench_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech_bench_test.go
@@ -236,7 +236,7 @@ func BenchmarkAnalyze_STTHighFrequency(b *testing.B) {
 // ============================================================================
 
 // BenchmarkAnalyze_RapidFireInputs measures performance with rapid sequential inputs.
-// Each new input invalidates the previous, testing generation counter efficiency.
+// Each new input invalidates the previous transcript revision.
 func BenchmarkAnalyze_RapidFireInputs(b *testing.B) {
 	logger, _ := commons.NewApplicationLogger()
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
@@ -308,9 +308,9 @@ func BenchmarkAnalyze_ContextCancellation(b *testing.B) {
 	}
 }
 
-// BenchmarkAnalyze_GenerationInvalidation measures performance under generation counter updates.
-// Tests cost of incrementing generation and invalidating old timers.
-func BenchmarkAnalyze_GenerationInvalidation(b *testing.B) {
+// BenchmarkAnalyze_RevisionInvalidation measures performance under transcript revision updates.
+// Tests cost of invalidating old timers.
+func BenchmarkAnalyze_RevisionInvalidation(b *testing.B) {
 	logger, _ := commons.NewApplicationLogger()
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
 	svcIface, _ := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, newTestOpts(map[string]any{"microphone.eos.timeout": 100.0}))
@@ -321,7 +321,7 @@ func BenchmarkAnalyze_GenerationInvalidation(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		// Each input increments generation counter
+		// Each input increments transcript revision.
 		_ = svcIface.Execute(ctx, systemInput(fmt.Sprintf("gen %d", i)))
 	}
 }

--- a/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/silence_based/silence_based_end_of_speech_test.go
@@ -1066,7 +1066,7 @@ func TestNewInputInvalidatesPreviousCallback(t *testing.T) {
 	}
 
 	// Send system input - starts 300ms timer
-	// here the timer is started for generation 1
+	// here the timer is started for the current transcript revision
 	if err := svcIface.Execute(ctx, sttInput("activity1.", true)); err != nil {
 		t.Fatalf("analyze 1: %v", err)
 	}
@@ -1302,8 +1302,8 @@ func TestSTTInputExtendsTimer(t *testing.T) {
 	}
 }
 
-// TestGenerationInvalidation verifies old callbacks don't fire after new input
-func TestGenerationInvalidation(t *testing.T) {
+// TestRevisionInvalidation verifies old callbacks don't fire after new input.
+func TestRevisionInvalidation(t *testing.T) {
 	logger, _ := commons.NewApplicationLogger()
 	callCount := 0
 	var mu sync.Mutex
@@ -1329,12 +1329,12 @@ func TestGenerationInvalidation(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Send first system input - starts timer for generation 1
+	// Send first system input - starts timer for the current transcript revision.
 	if err := svcIface.Execute(ctx, sttInput("activity1", true)); err != nil {
 		t.Fatalf("analyze 1: %v", err)
 	}
 
-	// Wait 200ms and send second input - increments generation, invalidates gen1 timer
+	// Wait 200ms and send second input - increments transcript revision, invalidates the old timer.
 	time.Sleep(200 * time.Millisecond)
 	if err := svcIface.Execute(ctx, sttInput("activity2", true)); err != nil {
 		t.Fatalf("analyze 2: %v", err)
@@ -1348,7 +1348,7 @@ func TestGenerationInvalidation(t *testing.T) {
 	mu.Unlock()
 
 	if count != 0 {
-		t.Fatalf("old generation timer should not fire, expected 0 callbacks, got %d", count)
+		t.Fatalf("old revision timer should not fire, expected 0 callbacks, got %d", count)
 	}
 
 	// Wait for second input timer to fire (500ms total from second input)
@@ -1359,7 +1359,7 @@ func TestGenerationInvalidation(t *testing.T) {
 	mu.Unlock()
 
 	if count != 1 {
-		t.Fatalf("current generation timer should fire, expected 1 callback, got %d", count)
+		t.Fatalf("current revision timer should fire, expected 1 callback, got %d", count)
 	}
 }
 
@@ -1525,6 +1525,9 @@ func TestServiceClose(t *testing.T) {
 	// Close should not panic
 	if err := svcIface.Close(context.Background()); err != nil {
 		t.Fatalf("close failed: %v", err)
+	}
+	if err := svcIface.Close(context.Background()); err != nil {
+		t.Fatalf("second close failed: %v", err)
 	}
 }
 
@@ -2160,9 +2163,9 @@ func TestFormattedTextOptimizationUnderConcurrency(t *testing.T) {
 	}
 }
 
-// TestGenerationCounterPreventsStaleCallbacks validates that generation counter
-// prevents stale callbacks even under extreme timing variations
-func TestGenerationCounterPreventsStaleCallbacks(t *testing.T) {
+// TestRevisionPreventsStaleCallbacks validates that transcript revision prevents
+// stale callbacks even under extreme timing variations.
+func TestRevisionPreventsStaleCallbacks(t *testing.T) {
 	logger, _ := commons.NewApplicationLogger()
 	callCount := 0
 	callMu := sync.Mutex{}
@@ -2196,20 +2199,20 @@ func TestGenerationCounterPreventsStaleCallbacks(t *testing.T) {
 	// Wait 30ms
 	time.Sleep(30 * time.Millisecond)
 
-	// Before old timer fires, send new input (invalidates old generation)
+	// Before old timer fires, send new input (invalidates old revision).
 	_ = svcIface.Execute(ctx, sttInput("gen2", true))
 
 	// Wait 30ms more (total 60ms from first, 30ms from second)
 	time.Sleep(30 * time.Millisecond)
 
 	// At this point, gen1 timer would fire (100ms total from first input)
-	// But generation should be incremented, so it should be ignored
+	// But revision should be incremented, so it should be ignored.
 	callMu.Lock()
 	countAt60ms := callCount
 	callMu.Unlock()
 
 	if countAt60ms != 0 {
-		t.Fatalf("old generation timer should be ignored, but got %d callbacks at 60ms", countAt60ms)
+		t.Fatalf("old revision timer should be ignored, but got %d callbacks at 60ms", countAt60ms)
 	}
 
 	// Wait for gen2 to fire
@@ -2443,6 +2446,408 @@ func TestInterimPacketsOnlyExtendTimer(t *testing.T) {
 		t.Fatal("callback should not be called for interim-only packet")
 	case <-time.After(400 * time.Millisecond):
 		// success: no callback received
+	}
+}
+
+func TestFaultyVADRecoversPendingFinal(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			switch packet := r.(type) {
+			case internal_type.EndOfSpeechPacket:
+				select {
+				case called <- packet:
+				default:
+				}
+			case internal_type.InterimEndOfSpeechPacket:
+			}
+		}
+		return nil
+	}
+
+	opts := newTestOpts(map[string]any{"microphone.eos.timeout": 60.0})
+	svcIface, err := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, opts)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer svcIface.Close(context.Background())
+
+	ctx := context.Background()
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}); err != nil {
+		t.Fatalf("vad start: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-faulty-vad",
+		Script:    "hello",
+		Interim:   false,
+	}); err != nil {
+		t.Fatalf("stt final: %v", err)
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("callback fired before stuck VAD recovery elapsed: %+v", packet)
+	case <-time.After(90 * time.Millisecond):
+	}
+
+	select {
+	case packet := <-called:
+		if packet.ContextID != "ctx-faulty-vad" {
+			t.Fatalf("unexpected context id: %q", packet.ContextID)
+		}
+		if packet.Speech != "hello" {
+			t.Fatalf("unexpected speech: %q", packet.Speech)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for callback after stuck VAD recovery")
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("unexpected duplicate callback after stuck VAD recovery: %+v", packet)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestStaleTimerCompletionDoesNotShrinkLatestSegment(t *testing.T) {
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	endOfSpeech := &silenceBasedEndOfSpeech{
+		onPacket: func(ctx context.Context, res ...internal_type.Packet) error {
+			for _, r := range res {
+				if packet, ok := r.(internal_type.EndOfSpeechPacket); ok {
+					called <- packet
+				}
+			}
+			return nil
+		},
+		silenceTimeout: 30 * time.Millisecond,
+		commandCh:      make(chan workerCommand, 4),
+		stopCh:         make(chan struct{}),
+		state: &endOfSpeechState{segment: speechSegment{
+			Revision:  1,
+			ContextID: "ctx-stale",
+			Text:      "me an idea about the how how do I do things?",
+			Timestamp: time.Now(),
+		}},
+	}
+	go endOfSpeech.worker()
+	defer func() { _ = endOfSpeech.Close(context.Background()) }()
+
+	oldSegment := endOfSpeech.state.segment
+	endOfSpeech.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: oldSegment,
+		timeout: 30 * time.Millisecond,
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	latestSegment := speechSegment{
+		Revision:  2,
+		ContextID: "ctx-stale",
+		Text:      "me an idea about the how how do I do things? Rightly?",
+		Timestamp: time.Now(),
+	}
+	endOfSpeech.mu.Lock()
+	endOfSpeech.state.segment = latestSegment
+	endOfSpeech.mu.Unlock()
+
+	select {
+	case packet := <-called:
+		t.Fatalf("stale completion fired: %q", packet.Speech)
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	endOfSpeech.enqueueCommand(workerCommand{
+		ctx:     context.Background(),
+		segment: latestSegment,
+		timeout: 10 * time.Millisecond,
+	})
+
+	select {
+	case packet := <-called:
+		if packet.Speech != latestSegment.Text {
+			t.Fatalf("expected latest speech %q, got %q", latestSegment.Text, packet.Speech)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for latest completion")
+	}
+}
+
+func TestVADEndFlushesPendingFinal(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			switch packet := r.(type) {
+			case internal_type.EndOfSpeechPacket:
+				select {
+				case called <- packet:
+				default:
+				}
+			case internal_type.InterimEndOfSpeechPacket:
+			}
+		}
+		return nil
+	}
+
+	opts := newTestOpts(map[string]any{"microphone.eos.timeout": 100.0})
+	svcIface, err := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, opts)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer svcIface.Close(context.Background())
+	svc := svcIface.(*silenceBasedEndOfSpeech)
+	svc.vadEndTimeout = 40 * time.Millisecond
+
+	ctx := context.Background()
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}); err != nil {
+		t.Fatalf("vad start: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-vad-success",
+		Script:    "done",
+		Interim:   false,
+	}); err != nil {
+		t.Fatalf("stt final: %v", err)
+	}
+
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		svc.mu.RLock()
+		pending := svc.state.pending != nil
+		svc.mu.RUnlock()
+		if pending {
+			break
+		}
+		select {
+		case packet := <-called:
+			t.Fatalf("callback fired before VAD end: %+v", packet)
+		case <-deadline:
+			t.Fatal("timeout waiting for pending final")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}); err != nil {
+		t.Fatalf("vad end: %v", err)
+	}
+
+	select {
+	case packet := <-called:
+		if packet.ContextID != "ctx-vad-success" {
+			t.Fatalf("unexpected context id: %q", packet.ContextID)
+		}
+		if packet.Speech != "done" {
+			t.Fatalf("unexpected speech: %q", packet.Speech)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for callback after VAD end")
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("unexpected duplicate callback after VAD end: %+v", packet)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestVADEndFlushWindowUsesLateFinalSTT(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			switch packet := r.(type) {
+			case internal_type.EndOfSpeechPacket:
+				select {
+				case called <- packet:
+				default:
+				}
+			case internal_type.InterimEndOfSpeechPacket:
+			}
+		}
+		return nil
+	}
+
+	opts := newTestOpts(map[string]any{"microphone.eos.timeout": 200.0})
+	svcIface, err := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, opts)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer svcIface.Close(context.Background())
+	svc := svcIface.(*silenceBasedEndOfSpeech)
+	svc.vadEndTimeout = 40 * time.Millisecond
+
+	ctx := context.Background()
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}); err != nil {
+		t.Fatalf("vad start: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}); err != nil {
+		t.Fatalf("first final: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}); err != nil {
+		t.Fatalf("vad end: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-late-final",
+		Script:    "Rightly?",
+		Interim:   false,
+	}); err != nil {
+		t.Fatalf("late final: %v", err)
+	}
+
+	select {
+	case packet := <-called:
+		expected := "me an idea about the how how do I do things? Rightly?"
+		if packet.Speech != expected {
+			t.Fatalf("expected latest speech %q, got %q", expected, packet.Speech)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for late final callback")
+	}
+}
+
+func TestVADEndCompleteClearsPendingInterimWhenFinalIsShorter(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	called := make(chan internal_type.EndOfSpeechPacket, 2)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			switch packet := r.(type) {
+			case internal_type.EndOfSpeechPacket:
+				select {
+				case called <- packet:
+				default:
+				}
+			case internal_type.InterimEndOfSpeechPacket:
+			}
+		}
+		return nil
+	}
+
+	opts := newTestOpts(map[string]any{"microphone.eos.timeout": 70.0})
+	svcIface, err := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, opts)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer svcIface.Close(context.Background())
+	svc := svcIface.(*silenceBasedEndOfSpeech)
+	svc.vadEndTimeout = 20 * time.Millisecond
+
+	ctx := context.Background()
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}); err != nil {
+		t.Fatalf("vad start: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things? Rightly?",
+		Interim:   true,
+	}); err != nil {
+		t.Fatalf("stt interim: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-short-final",
+		Script:    "me an idea about the how how do I do things?",
+		Interim:   false,
+	}); err != nil {
+		t.Fatalf("stt final: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}); err != nil {
+		t.Fatalf("vad end: %v", err)
+	}
+
+	select {
+	case packet := <-called:
+		expected := "me an idea about the how how do I do things?"
+		if packet.Speech != expected {
+			t.Fatalf("expected final transcript %q, got %q", expected, packet.Speech)
+		}
+		if len(packet.Speechs) != 2 {
+			t.Fatalf("expected interim and final chunks, got %+v", packet.Speechs)
+		}
+		if !packet.Speechs[0].Interim || packet.Speechs[1].Interim {
+			t.Fatalf("unexpected chunk lifecycle: %+v", packet.Speechs)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for final transcript")
+	}
+}
+
+func TestOnlyInterimWithVADDoesNotComplete(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	called := make(chan internal_type.EndOfSpeechPacket, 1)
+	callback := func(ctx context.Context, res ...internal_type.Packet) error {
+		for _, r := range res {
+			switch packet := r.(type) {
+			case internal_type.EndOfSpeechPacket:
+				select {
+				case called <- packet:
+				default:
+				}
+			case internal_type.InterimEndOfSpeechPacket:
+			}
+		}
+		return nil
+	}
+
+	opts := newTestOpts(map[string]any{"microphone.eos.timeout": 60.0})
+	svcIface, err := newSilenceBasedEndOfSpeechForTest(context.Background(), logger, callback, opts)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer svcIface.Close(context.Background())
+
+	ctx := context.Background()
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventStart,
+	}); err != nil {
+		t.Fatalf("vad start: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.SpeechToTextPacket{
+		ContextID: "ctx-interim-only",
+		Script:    "interim only",
+		Interim:   true,
+	}); err != nil {
+		t.Fatalf("stt interim: %v", err)
+	}
+	if err := svcIface.Execute(ctx, internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad,
+		Event:  internal_type.InterruptionEventEnd,
+	}); err != nil {
+		t.Fatalf("vad end: %v", err)
+	}
+
+	select {
+	case packet := <-called:
+		t.Fatalf("callback should not fire for interim-only VAD input: %+v", packet)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/api/assistant-api/internal/llm/agentkit/agentkit.go
+++ b/api/assistant-api/internal/llm/agentkit/agentkit.go
@@ -23,13 +23,14 @@ import (
 )
 
 type agentkitExecutor struct {
-	logger           commons.Logger
-	ctx              context.Context
-	cancel           context.CancelCauseFunc
-	connection       *AgentkitConnection
-	stateMu          sync.RWMutex
-	activeContextID  string
-	requestStartedAt time.Time
+	logger                  commons.Logger
+	ctx                     context.Context
+	cancel                  context.CancelCauseFunc
+	connection              *AgentkitConnection
+	stateMu                 sync.RWMutex
+	activeContextID         string
+	requestStartedAt        time.Time
+	waitingForFirstResponse bool
 }
 
 type options struct {

--- a/api/assistant-api/internal/llm/agentkit/agentkit_execute.go
+++ b/api/assistant-api/internal/llm/agentkit/agentkit_execute.go
@@ -131,6 +131,7 @@ func (e *agentkitExecutor) handleUserTurn(ctx context.Context, comm internal_typ
 	e.stateMu.Lock()
 	e.activeContextID = contextID
 	e.requestStartedAt = time.Now()
+	e.waitingForFirstResponse = true
 	e.stateMu.Unlock()
 
 	comm.OnPacket(ctx,

--- a/api/assistant-api/internal/llm/agentkit/agentkit_stream.go
+++ b/api/assistant-api/internal/llm/agentkit/agentkit_stream.go
@@ -387,6 +387,7 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 		)
 
 	case *protos.TalkOutput_Observability:
+		e.logger.Debugf("agentkit observability record received: %v", data.Observability)
 		switch record := data.Observability.GetRecord().(type) {
 		case *protos.ObservabilityRecord_Log:
 			occurredAt := time.Now()

--- a/api/assistant-api/internal/llm/agentkit/agentkit_stream.go
+++ b/api/assistant-api/internal/llm/agentkit/agentkit_stream.go
@@ -135,15 +135,30 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 							Target: internal_type.PacketNameUserAudioReceived,
 							Action: internal_type.DispatchActionIgnore,
 						},
-					})
+					},
+						internal_type.DispatchPolicyPacket{
+							ContextID: data.Control.GetId(),
+							Policy: internal_type.DispatchPolicy{
+								Target: internal_type.PacketNameInterruptionDetected,
+								Action: internal_type.DispatchActionIgnore,
+							},
+						})
 				case protos.ConversationControl_CONTROL_TYPE_USER_TEXT:
-					comm.OnPacket(ctx, internal_type.DispatchPolicyPacket{
-						ContextID: data.Control.GetId(),
-						Policy: internal_type.DispatchPolicy{
-							Target: internal_type.PacketNameUserTextReceived,
-							Action: internal_type.DispatchActionIgnore,
+					comm.OnPacket(ctx,
+						internal_type.DispatchPolicyPacket{
+							ContextID: data.Control.GetId(),
+							Policy: internal_type.DispatchPolicy{
+								Target: internal_type.PacketNameUserTextReceived,
+								Action: internal_type.DispatchActionIgnore,
+							},
 						},
-					})
+						internal_type.DispatchPolicyPacket{
+							ContextID: data.Control.GetId(),
+							Policy: internal_type.DispatchPolicy{
+								Target: internal_type.PacketNameInterruptionDetected,
+								Action: internal_type.DispatchActionIgnore,
+							},
+						})
 				case protos.ConversationControl_CONTROL_TYPE_BARGE_IN:
 					comm.OnPacket(ctx, internal_type.DispatchPolicyPacket{
 						ContextID: data.Control.GetId(),
@@ -192,11 +207,34 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 
 		switch msg := data.Assistant.GetMessage().(type) {
 		case *protos.ConversationAssistantMessage_Text:
+			now := time.Now()
 			if data.Assistant.GetCompleted() {
 				e.stateMu.Lock()
 				requestStartedAt := e.requestStartedAt
+				publishTTFT := e.waitingForFirstResponse
+				e.waitingForFirstResponse = false
 				e.requestStartedAt = time.Time{}
 				e.stateMu.Unlock()
+
+				metrics := []*protos.Metric{{
+					Name:        "llm_response_char_count",
+					Value:       fmt.Sprintf("%d", len(msg.Text)),
+					Description: "AgentKit response character count",
+				}}
+				if !requestStartedAt.IsZero() {
+					if publishTTFT {
+						metrics = append(metrics, &protos.Metric{
+							Name:        observability.MetricAgentTTFTMs,
+							Value:       fmt.Sprintf("%d", now.Sub(requestStartedAt).Milliseconds()),
+							Description: "AgentKit time to first token in milliseconds",
+						})
+					}
+					metrics = append(metrics, &protos.Metric{
+						Name:        observability.MetricAgentTRTMs,
+						Value:       fmt.Sprintf("%d", now.Sub(requestStartedAt).Milliseconds()),
+						Description: "AgentKit total response time in milliseconds",
+					})
+				}
 
 				packets := []internal_type.Packet{
 					internal_type.LLMResponseDonePacket{ContextID: data.Assistant.GetId(), Text: msg.Text},
@@ -214,11 +252,7 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 						Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
 						Record: observability.RecordMetric{
 							Attributes: observability.Attributes{"provider": e.Name()},
-							Metrics: []*protos.Metric{{
-								Name:        "llm_response_char_count",
-								Value:       fmt.Sprintf("%d", len(msg.Text)),
-								Description: "AgentKit response character count",
-							}},
+							Metrics:    metrics,
 						},
 					},
 				}
@@ -226,7 +260,7 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 					packets = append(packets, internal_type.ObservabilityUsageRecordPacket{
 						ContextID: data.Assistant.GetId(),
 						Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
-						Record: observability.NewLLMDurationUsageRecord(e.Name(), time.Since(requestStartedAt), observability.Attributes{
+						Record: observability.NewLLMDurationUsageRecord(e.Name(), now.Sub(requestStartedAt), observability.Attributes{
 							"context_id":          data.Assistant.GetId(),
 							"response_char_count": fmt.Sprintf("%d", len(msg.Text)),
 						}),
@@ -234,7 +268,31 @@ func (e *agentkitExecutor) Write(ctx context.Context, comm internal_type.Communi
 				}
 				comm.OnPacket(ctx, packets...)
 			} else {
-				comm.OnPacket(ctx, internal_type.LLMResponseDeltaPacket{ContextID: data.Assistant.GetId(), Text: msg.Text})
+				e.stateMu.Lock()
+				requestStartedAt := e.requestStartedAt
+				publishTTFT := e.waitingForFirstResponse
+				e.waitingForFirstResponse = false
+				e.stateMu.Unlock()
+
+				if publishTTFT && !requestStartedAt.IsZero() {
+					comm.OnPacket(ctx,
+						internal_type.LLMResponseDeltaPacket{ContextID: data.Assistant.GetId(), Text: msg.Text},
+						internal_type.ObservabilityMetricRecordPacket{
+							ContextID: data.Assistant.GetId(),
+							Scope:     internal_type.ObservabilityRecordScopeAssistantMessage,
+							Record: observability.RecordMetric{
+								Attributes: observability.Attributes{"provider": e.Name()},
+								Metrics: []*protos.Metric{{
+									Name:        observability.MetricAgentTTFTMs,
+									Value:       fmt.Sprintf("%d", now.Sub(requestStartedAt).Milliseconds()),
+									Description: "AgentKit time to first token in milliseconds",
+								}},
+							},
+						},
+					)
+				} else {
+					comm.OnPacket(ctx, internal_type.LLMResponseDeltaPacket{ContextID: data.Assistant.GetId(), Text: msg.Text})
+				}
 			}
 		}
 

--- a/api/assistant-api/internal/llm/agentkit/agentkit_stream_test.go
+++ b/api/assistant-api/internal/llm/agentkit/agentkit_stream_test.go
@@ -3,6 +3,7 @@ package internal_llm_agentkit
 import (
 	"context"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -661,6 +662,80 @@ func TestWrite_CompletedTextContextID(t *testing.T) {
 	ev, ok := findPacket[internal_type.ObservabilityEventRecordPacket](pkts)
 	require.True(t, ok)
 	assert.Equal(t, "unique-ctx", ev.ContextID)
+}
+
+func TestWrite_FirstDeltaAddsTTFTAndCompletedAddsTRT(t *testing.T) {
+	e := newTestExecutor()
+	e.requestStartedAt = time.Now().Add(-25 * time.Millisecond)
+	e.waitingForFirstResponse = true
+	comm, collector := newTestComm()
+
+	e.Write(context.Background(), comm, &protos.TalkOutput{
+		Data: &protos.TalkOutput_Assistant{
+			Assistant: &protos.ConversationAssistantMessage{
+				Id:        "ctx-latency",
+				Completed: false,
+				Message:   &protos.ConversationAssistantMessage_Text{Text: "he"},
+			},
+		},
+	})
+	pkts := collector.all()
+	require.Len(t, pkts, 2)
+	delta, ok := pkts[0].(internal_type.LLMResponseDeltaPacket)
+	require.True(t, ok)
+	assert.Equal(t, "he", delta.Text)
+	ttftMetric, ok := pkts[1].(internal_type.ObservabilityMetricRecordPacket)
+	require.True(t, ok)
+	require.Len(t, ttftMetric.Record.Metrics, 1)
+	assert.Equal(t, observability.MetricAgentTTFTMs, ttftMetric.Record.Metrics[0].Name)
+	ttftMs, err := strconv.ParseInt(ttftMetric.Record.Metrics[0].Value, 10, 64)
+	require.NoError(t, err)
+	assert.Positive(t, ttftMs)
+
+	collector.reset()
+
+	e.Write(context.Background(), comm, &protos.TalkOutput{
+		Data: &protos.TalkOutput_Assistant{
+			Assistant: &protos.ConversationAssistantMessage{
+				Id:        "ctx-latency",
+				Completed: true,
+				Message:   &protos.ConversationAssistantMessage_Text{Text: "hello"},
+			},
+		},
+	})
+
+	metrics := findPackets[internal_type.ObservabilityMetricRecordPacket](collector.all())
+	require.Len(t, metrics, 1)
+	require.Len(t, metrics[0].Record.Metrics, 2)
+	assert.Equal(t, "llm_response_char_count", metrics[0].Record.Metrics[0].Name)
+	assert.Equal(t, observability.MetricAgentTRTMs, metrics[0].Record.Metrics[1].Name)
+	ms, err := strconv.ParseInt(metrics[0].Record.Metrics[1].Value, 10, 64)
+	require.NoError(t, err)
+	assert.Positive(t, ms)
+}
+
+func TestWrite_CompletedTextFirstPacketAddsTTFTAndTRT(t *testing.T) {
+	e := newTestExecutor()
+	e.requestStartedAt = time.Now().Add(-25 * time.Millisecond)
+	e.waitingForFirstResponse = true
+	comm, collector := newTestComm()
+
+	e.Write(context.Background(), comm, &protos.TalkOutput{
+		Data: &protos.TalkOutput_Assistant{
+			Assistant: &protos.ConversationAssistantMessage{
+				Id:        "ctx-completed-latency",
+				Completed: true,
+				Message:   &protos.ConversationAssistantMessage_Text{Text: "hello"},
+			},
+		},
+	})
+
+	metrics := findPackets[internal_type.ObservabilityMetricRecordPacket](collector.all())
+	require.Len(t, metrics, 1)
+	require.Len(t, metrics[0].Record.Metrics, 3)
+	assert.Equal(t, "llm_response_char_count", metrics[0].Record.Metrics[0].Name)
+	assert.Equal(t, observability.MetricAgentTTFTMs, metrics[0].Record.Metrics[1].Name)
+	assert.Equal(t, observability.MetricAgentTRTMs, metrics[0].Record.Metrics[2].Name)
 }
 
 func TestWrite_ToolResultFailed(t *testing.T) {

--- a/api/assistant-api/internal/observability/metric.go
+++ b/api/assistant-api/internal/observability/metric.go
@@ -63,6 +63,8 @@ const (
 	MetricDenoiseInitLatencyMs        = "denoise_init_ms"
 	MetricLLMInitLatencyMs            = "llm_init_ms"
 	MetricLLMLatencyMs                = "llm_latency_ms"
+	MetricAgentTTFTMs                 = "agent.ttft_ms"
+	MetricAgentTRTMs                  = "agent.trt_ms"
 	MetricStorageInitLatencyMs        = "storage_init_ms"
 	MetricAnalysisInitLatencyMs       = "analysis_init_ms"
 	MetricAuthenticationInitLatencyMs = "authentication_init_ms"

--- a/api/assistant-api/internal/observability/metric_test.go
+++ b/api/assistant-api/internal/observability/metric_test.go
@@ -50,6 +50,8 @@ func TestMetricNames_MirrorCurrentImplementation(t *testing.T) {
 		{MetricDenoiseInitLatencyMs, "denoise_init_ms"},
 		{MetricLLMInitLatencyMs, "llm_init_ms"},
 		{MetricLLMLatencyMs, "llm_latency_ms"},
+		{MetricAgentTTFTMs, "agent.ttft_ms"},
+		{MetricAgentTRTMs, "agent.trt_ms"},
 		{MetricKnowledgeLatencyMs, "knowledge_latency_ms"},
 		{MetricLLMError, "llm_error"},
 		{MetricSTTError, "stt_error"},

--- a/api/assistant-api/internal/options/audio.go
+++ b/api/assistant-api/internal/options/audio.go
@@ -38,7 +38,8 @@ const (
 )
 
 const (
-	MicrophoneVADOptionBargeInTrigger = "microphone.vad.barge_in_trigger"
+	MicrophoneOptionBargeInTrigger          = "microphone.barge_in_trigger"
+	MicrophoneLegacyVADOptionBargeInTrigger = "microphone.vad.barge_in_trigger"
 )
 
 const (

--- a/api/assistant-api/internal/services/assistant/message.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/message.impl.service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	internal_message_gorm "github.com/rapidaai/api/assistant-api/internal/entity/messages"
+	"github.com/rapidaai/api/assistant-api/internal/observability"
 	internal_services "github.com/rapidaai/api/assistant-api/internal/services"
 	gorm_models "github.com/rapidaai/pkg/models/gorm"
 	"github.com/rapidaai/pkg/types"
@@ -281,7 +282,7 @@ func (conversationService *assistantConversationService) GetAllMessage(
 			case "=":
 				qry = qry.Where("assistant_conversation_messages.status = ?", ct.GetValue())
 			}
-		case "stt_latency_ms", "llm_latency_ms", "agent_time_to_first_token", "tts_latency_ms", "eos_latency_ms", "agent_total_token":
+		case "stt_latency_ms", "llm_latency_ms", "agent_time_to_first_token", observability.MetricAgentTTFTMs, observability.MetricAgentTRTMs, "tts_latency_ms", "eos_latency_ms", "agent_total_token":
 			switch ct.GetLogic() {
 			case "=":
 				qry = qry.Where(

--- a/api/assistant-api/internal/type/packet.go
+++ b/api/assistant-api/internal/type/packet.go
@@ -41,7 +41,6 @@ const (
 	PacketNameDenoiseAudio                               PacketName = "DenoiseAudioPacket"
 	PacketNameDenoisedAudio                              PacketName = "DenoisedAudioPacket"
 	PacketNameVadAudio                                   PacketName = "VadAudioPacket"
-	PacketNameVadSpeechActivity                          PacketName = "VadSpeechActivityPacket"
 	PacketNameSpeechToText                               PacketName = "SpeechToTextPacket"
 	PacketNameEndOfSpeechAudio                           PacketName = "EndOfSpeechAudioPacket"
 	PacketNameEndOfSpeechInterruption                    PacketName = "EndOfSpeechInterruptionPacket"
@@ -267,16 +266,6 @@ type VadAudioPacket struct {
 
 func (f VadAudioPacket) ContextId() string      { return f.ContextID }
 func (f VadAudioPacket) PacketName() PacketName { return PacketNameVadAudio }
-
-// VadSpeechActivityPacket is a lightweight heartbeat emitted by the VAD on every
-// audio chunk where the user is actively speaking. The EOS detector uses it to
-// keep extending the silence timer during sustained speech.
-type VadSpeechActivityPacket struct {
-	ContextID string
-}
-
-func (f VadSpeechActivityPacket) ContextId() string      { return f.ContextID }
-func (f VadSpeechActivityPacket) PacketName() PacketName { return PacketNameVadSpeechActivity }
 
 // SpeechToTextPacket carries a transcript result from the STT provider.
 type SpeechToTextPacket struct {

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
@@ -202,7 +202,6 @@ func (v *FireRedVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRec
 	v.audioBuf = append(v.audioBuf, samples...)
 
 	// Process complete frames (400 samples each, 160-sample shift)
-	hasSpeech := false
 	var speechStartAt, speechEndAt float64
 	hasSpeechStart := false
 	hasSpeechEnd := false
@@ -288,25 +287,10 @@ func (v *FireRedVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRec
 			hasSpeechEnd = true
 		}
 
-		// Only treat as speech when the postprocessor has confirmed onset
-		// (past MinSpeechFrame). Frames in statePossibleSpeech are
-		// unconfirmed and likely noise — skip them.
-		if v.postprocessor.InSpeech() {
-			hasSpeech = true
-		}
-
 		// Shift by frameShiftSamp (160 samples)
 		v.audioBuf = v.audioBuf[frameShiftSamp:]
 	}
 	v.mu.Unlock()
-
-	// Emit a heartbeat while in confirmed speech so the EOS silence
-	// timer keeps extending during sustained speech.
-	if hasSpeech && v.onPacket != nil {
-		_ = v.onPacket(ctx,
-			internal_type.VadSpeechActivityPacket{},
-		)
-	}
 
 	// Emit explicit interruption lifecycle events from VAD transitions.
 	if hasSpeechStart {

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
@@ -277,7 +277,7 @@ func (s *SileroVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRece
 	}
 
 	// Perform detection with CGO safety
-	segments, isSpeaking, err := s.detectSafely(samples)
+	segments, _, err := s.detectSafely(samples)
 	if err != nil {
 		if s.onPacket != nil {
 			_ = s.onPacket(ctx,
@@ -330,14 +330,6 @@ func (s *SileroVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRece
 			speechEndAt = seg.SpeechEndAt
 			hasSpeechEnd = true
 		}
-	}
-
-	// Emit a heartbeat while the user is actively speaking so the EOS
-	// silence timer keeps extending during sustained speech.
-	if isSpeaking && s.onPacket != nil {
-		_ = s.onPacket(ctx,
-			internal_type.VadSpeechActivityPacket{},
-		)
 	}
 
 	// Emit explicit interruption lifecycle events from VAD transitions.

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
@@ -267,17 +267,6 @@ func (t *TenVAD) Execute(ctx context.Context, pkt internal_type.UserAudioReceive
 		}
 	}
 
-	// Emit a heartbeat while the user is actively speaking so the EOS
-	// silence timer keeps extending during sustained speech.
-	t.mu.RLock()
-	isSpeaking := t.triggered
-	t.mu.RUnlock()
-	if isSpeaking && t.onPacket != nil {
-		_ = t.onPacket(ctx,
-			internal_type.VadSpeechActivityPacket{},
-		)
-	}
-
 	// Emit explicit interruption lifecycle events from VAD transitions.
 	if hasSpeechStart {
 		t.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventStart, speechStartAt, len(segments))

--- a/openapi/artifacts/assistant-api.yaml
+++ b/openapi/artifacts/assistant-api.yaml
@@ -1004,8 +1004,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1047,8 +1047,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1095,8 +1095,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1137,8 +1137,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1184,8 +1184,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1555,8 +1555,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1599,8 +1599,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1649,8 +1649,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1693,8 +1693,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500
@@ -1741,8 +1741,8 @@ components:
         unclearInputTimeout:
           type: number
           format: double
-          minimum: 0.5
-          maximum: 5
+          minimum: 2
+          maximum: 10
         unclearInputMessage:
           type: string
           maxLength: 500

--- a/pkg/clients/workflow/assistant_client.go
+++ b/pkg/clients/workflow/assistant_client.go
@@ -135,7 +135,6 @@ func NewAssistantServiceClientGRPC(config *config.AppConfig, logger commons.Logg
 }
 
 func (client *assistantServiceClient) GetAllAssistant(c context.Context, auth types.SimplePrinciple, criteria []*protos.Criteria, paginate *protos.Paginate) (*protos.Paginated, []*protos.Assistant, error) {
-	client.logger.Debugf("get all assistant request")
 	res, err := client.assistantClient.GetAllAssistant(client.WithAuth(c, auth), &protos.GetAllAssistantRequest{
 		Paginate:  paginate,
 		Criterias: criteria,

--- a/pkg/errors/create_assistant_deployment.go
+++ b/pkg/errors/create_assistant_deployment.go
@@ -167,7 +167,7 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 		Code:           CreateAssistantDebuggerDeploymentInvalidUnclearTimeoutCode,
 		Error:          "invalid unclear_input_timeout parameter",
-		ErrorMessage:   "Please provide unclearInputTimeout between 0.5 and 5 seconds.",
+		ErrorMessage:   "Please provide unclearInputTimeout between 2 and 10 seconds.",
 	}
 	CreateAssistantDebuggerDeploymentInvalidTimeoutBackoff = PlatformError{
 		HTTPStatusCode: http.StatusBadRequest,
@@ -227,7 +227,7 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 		Code:           CreateAssistantPhoneDeploymentInvalidUnclearTimeoutCode,
 		Error:          "invalid unclear_input_timeout parameter",
-		ErrorMessage:   "Please provide unclearInputTimeout between 0.5 and 5 seconds.",
+		ErrorMessage:   "Please provide unclearInputTimeout between 2 and 10 seconds.",
 	}
 	CreateAssistantPhoneDeploymentInvalidTimeoutBackoff = PlatformError{
 		HTTPStatusCode: http.StatusBadRequest,
@@ -293,7 +293,7 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 		Code:           CreateAssistantApiDeploymentInvalidUnclearTimeoutCode,
 		Error:          "invalid unclear_input_timeout parameter",
-		ErrorMessage:   "Please provide unclearInputTimeout between 0.5 and 5 seconds.",
+		ErrorMessage:   "Please provide unclearInputTimeout between 2 and 10 seconds.",
 	}
 	CreateAssistantApiDeploymentInvalidTimeoutBackoff = PlatformError{
 		HTTPStatusCode: http.StatusBadRequest,
@@ -353,7 +353,7 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 		Code:           CreateAssistantWebpluginDeploymentInvalidUnclearTimeoutCode,
 		Error:          "invalid unclear_input_timeout parameter",
-		ErrorMessage:   "Please provide unclearInputTimeout between 0.5 and 5 seconds.",
+		ErrorMessage:   "Please provide unclearInputTimeout between 2 and 10 seconds.",
 	}
 	CreateAssistantWebpluginDeploymentInvalidTimeoutBackoff = PlatformError{
 		HTTPStatusCode: http.StatusBadRequest,
@@ -407,7 +407,7 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 		Code:           CreateAssistantWhatsappDeploymentInvalidUnclearTimeoutCode,
 		Error:          "invalid unclear_input_timeout parameter",
-		ErrorMessage:   "Please provide unclearInputTimeout between 0.5 and 5 seconds.",
+		ErrorMessage:   "Please provide unclearInputTimeout between 2 and 10 seconds.",
 	}
 	CreateAssistantWhatsappDeploymentInvalidTimeoutBackoff = PlatformError{
 		HTTPStatusCode: http.StatusBadRequest,

--- a/ui/package.json
+++ b/ui/package.json
@@ -87,7 +87,7 @@
         "@popperjs/core": "2.11.8",
         "@protobuf-ts/plugin": "2.9.4",
         "@protobuf-ts/runtime": "2.9.4",
-        "@rapidaai/react": "1.1.87",
+        "@rapidaai/react": "1.1.88",
         "@rapidaai/react-widget": "1.0.0",
         "@reduxjs/toolkit": "1.8.5",
         "@sentry/react": "7.101.1",

--- a/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-audio-input-form.tsx
+++ b/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-audio-input-form.tsx
@@ -14,6 +14,10 @@ import { GetDefaultVADConfig } from '@/app/components/providers/vad/provider';
 import { VADProvider } from '@/app/components/providers/vad';
 import { ChevronDown } from '@carbon/icons-react';
 import { cn } from '@/utils';
+import {
+  BargeInTriggerControl,
+  MICROPHONE_BARGE_IN_TRIGGER_KEY,
+} from '@/app/components/providers/microphone/barge-in-trigger-control';
 
 interface ConfigureAudioInputModalFormProps {
   audioInputConfig: { provider: string; parameters: Metadata[] };
@@ -33,6 +37,7 @@ export const ConfigureAudioInputModalForm: React.FC<
       const key = p.getKey();
       return (
         key.startsWith('microphone.eos.') ||
+        key === MICROPHONE_BARGE_IN_TRIGGER_KEY ||
         key.startsWith('microphone.vad.') ||
         key.startsWith('microphone.denoising.')
       );
@@ -90,6 +95,13 @@ export const ConfigureAudioInputModalForm: React.FC<
 
           {showAdvanced && (
             <div className="space-y-6 pt-6 border-t border-gray-200 dark:border-gray-800">
+              <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
+                Barge-in Control
+              </p>
+              <BargeInTriggerControl
+                parameters={audioInputConfig.parameters}
+                onChangeParameter={onChangeAudioInputParameter}
+              />
               <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
                 Voice Activity Detection
               </p>

--- a/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-experience-form.tsx
+++ b/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-experience-form.tsx
@@ -58,8 +58,8 @@ export const ConfigureExperienceModalForm: FC<{
               <Slider
                 id="experience-unclear-input-timeout"
                 labelText="Unclear Speech Wait (Seconds)"
-                min={0.5}
-                max={5}
+                min={2}
+                max={10}
                 step={0.1}
                 value={parseFloat(
                   experienceConfig.unclearInputTimeout ||

--- a/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-web-experience-form.tsx
+++ b/ui/src/app/components/base/modal/assistant-debugger-edit-section-modal/configure-web-experience-form.tsx
@@ -70,8 +70,8 @@ export const ConfigureWebExperienceModalForm: FC<{
             <Slider
               id="widget-unclear-input-timeout"
               labelText="Unclear Speech Wait (Seconds)"
-              min={0.5}
-              max={5}
+              min={2}
+              max={10}
               step={0.1}
               value={parseFloat(
                 experienceConfig.unclearInputTimeout ||

--- a/ui/src/app/components/carbon/record-status-indicator/index.test.tsx
+++ b/ui/src/app/components/carbon/record-status-indicator/index.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  RecordStatusIndicator,
+  recordStatusToShapeIndicator,
+} from '.';
+
+jest.mock('@carbon/react', () => ({
+  preview__ShapeIndicator: ({ kind, label, textSize }: any) => (
+    <span data-kind={kind} data-text-size={textSize}>
+      {label}
+    </span>
+  ),
+}));
+
+describe('RecordStatusIndicator', () => {
+  it('maps active records to stable', () => {
+    expect(recordStatusToShapeIndicator('ACTIVE')).toEqual({
+      kind: 'stable',
+      label: 'Active',
+    });
+
+    render(<RecordStatusIndicator state="ACTIVE" textSize={14} />);
+
+    expect(screen.getByText('Active')).toHaveAttribute('data-kind', 'stable');
+    expect(screen.getByText('Active')).toHaveAttribute('data-text-size', '14');
+  });
+
+  it('maps inactive records to undefined', () => {
+    expect(recordStatusToShapeIndicator('INACTIVE')).toEqual({
+      kind: 'undefined',
+      label: 'Inactive',
+    });
+
+    render(<RecordStatusIndicator state="INACTIVE" />);
+
+    expect(screen.getByText('Inactive')).toHaveAttribute(
+      'data-kind',
+      'undefined',
+    );
+  });
+
+  it('maps any other record status to draft', () => {
+    expect(recordStatusToShapeIndicator('PENDING')).toEqual({
+      kind: 'draft',
+      label: 'Draft',
+    });
+    expect(recordStatusToShapeIndicator('active')).toEqual({
+      kind: 'draft',
+      label: 'Draft',
+    });
+
+    render(<RecordStatusIndicator state="PENDING" />);
+
+    expect(screen.getByText('Draft')).toHaveAttribute('data-kind', 'draft');
+  });
+});

--- a/ui/src/app/components/carbon/record-status-indicator/index.tsx
+++ b/ui/src/app/components/carbon/record-status-indicator/index.tsx
@@ -1,0 +1,51 @@
+import { FC } from 'react';
+import { preview__ShapeIndicator as ShapeIndicator } from '@carbon/react';
+
+export type RecordStatusIndicatorKind =
+  | 'failed'
+  | 'critical'
+  | 'high'
+  | 'medium'
+  | 'low'
+  | 'cautious'
+  | 'undefined'
+  | 'stable'
+  | 'informative'
+  | 'incomplete'
+  | 'draft';
+
+export interface RecordStatusIndicatorProps {
+  state?: string | null;
+  label?: string;
+  textSize?: 12 | 14;
+}
+
+export const recordStatusToShapeIndicator = (
+  state?: string | null,
+): { kind: RecordStatusIndicatorKind; label: string } => {
+  if (state === 'ACTIVE') {
+    return { kind: 'stable', label: 'Active' };
+  }
+
+  if (state === 'INACTIVE') {
+    return { kind: 'undefined', label: 'Inactive' };
+  }
+
+  return { kind: 'draft', label: 'Draft' };
+};
+
+export const RecordStatusIndicator: FC<RecordStatusIndicatorProps> = ({
+  state,
+  label,
+  textSize = 12,
+}) => {
+  const resolved = recordStatusToShapeIndicator(state);
+
+  return (
+    <ShapeIndicator
+      kind={resolved.kind as any}
+      label={label || resolved.label}
+      textSize={textSize}
+    />
+  );
+};

--- a/ui/src/app/components/providers/__tests__/audio-input-advanced-defaults-parity.test.ts
+++ b/ui/src/app/components/providers/__tests__/audio-input-advanced-defaults-parity.test.ts
@@ -21,24 +21,21 @@ const {
   GetDefaultNoiseCancellationConfig,
 } = require('@/app/components/providers/noise-removal/provider');
 
-const legacyVadDefaults: Record<string, Record<string, string>> = {
+const backendVadDefaults: Record<string, Record<string, string>> = {
   silero_vad: {
-    'microphone.vad.barge_in_trigger': 'vad',
     'microphone.vad.threshold': '0.5',
     'microphone.vad.min_silence_frame': '20',
     'microphone.vad.min_speech_frame': '8',
   },
   ten_vad: {
-    'microphone.vad.barge_in_trigger': 'vad',
     'microphone.vad.threshold': '0.5',
     'microphone.vad.min_silence_frame': '20',
     'microphone.vad.min_speech_frame': '8',
   },
   firered_vad: {
-    'microphone.vad.barge_in_trigger': 'vad',
-    'microphone.vad.threshold': '0.5',
-    'microphone.vad.min_silence_frame': '10',
-    'microphone.vad.min_speech_frame': '3',
+    'microphone.vad.threshold': '0.4',
+    'microphone.vad.min_silence_frame': '20',
+    'microphone.vad.min_speech_frame': '8',
   },
 };
 
@@ -81,12 +78,14 @@ const getMetadataValue = (source: Metadata[], key: string): string => {
   return value === undefined || value === null ? '' : String(value);
 };
 
-const legacyGetDefaultVADConfig = (
+const expectedGetDefaultVADConfig = (
   provider: string,
   current: Metadata[],
 ): Metadata[] => {
-  const defaults = legacyVadDefaults[provider] || {};
-  const nonVad = current.filter(m => !m.getKey().startsWith('microphone.vad.'));
+  const defaults = backendVadDefaults[provider] || {};
+  const nonVad = current.filter(
+    m => !m.getKey().startsWith('microphone.vad.'),
+  );
 
   const vadParams: Metadata[] = [];
   const providerMeta = new Metadata();
@@ -131,6 +130,19 @@ describe('Audio input advanced defaults parity', () => {
     }
   });
 
+  it('all active VAD parameters include toggletip help text', () => {
+    expect(VAD().length).toBeGreaterThan(0);
+    for (const provider of VAD()) {
+      const params = loadProviderConfig(provider.code)?.vad?.parameters ?? [];
+      expect(params.length).toBeGreaterThan(0);
+      for (const param of params) {
+        expect(param.helpText).toEqual(expect.any(String));
+        expect(param.helpText?.trim()).not.toHaveLength(0);
+        expect(param.helpTextDisplay).toBe('toggletip');
+      }
+    }
+  });
+
   it('all active end-of-speech providers are config-driven', () => {
     expect(EndOfSpeech().length).toBeGreaterThan(0);
     for (const provider of EndOfSpeech()) {
@@ -139,7 +151,7 @@ describe('Audio input advanced defaults parity', () => {
   });
 
   it.each(['silero_vad', 'ten_vad', 'firered_vad'])(
-    '%s VAD defaults stay parity with legacy behavior',
+    '%s VAD defaults stay in parity with backend defaults',
     provider => {
       const seed = [
         createMetadata('rapida.credential_id', 'cred'),
@@ -150,9 +162,12 @@ describe('Audio input advanced defaults parity', () => {
         createMetadata('microphone.vad.min_speech_frame', '4'),
       ];
 
-      const legacy = legacyGetDefaultVADConfig(provider, cloneMetadata(seed));
+      const expected = expectedGetDefaultVADConfig(
+        provider,
+        cloneMetadata(seed),
+      );
       const current = GetDefaultVADConfig(provider, cloneMetadata(seed));
-      expect(normalizeMetadata(current)).toEqual(normalizeMetadata(legacy));
+      expect(normalizeMetadata(current)).toEqual(normalizeMetadata(expected));
     },
   );
 
@@ -235,9 +250,10 @@ describe('Audio input advanced defaults parity', () => {
 
   it('microphone defaults use pipecat eos provider', () => {
     const defaults = GetDefaultMicrophoneConfig([]);
-    expect(getMetadataValue(defaults, 'microphone.vad.barge_in_trigger')).toBe(
+    expect(getMetadataValue(defaults, 'microphone.barge_in_trigger')).toBe(
       'vad',
     );
+    expect(getMetadataValue(defaults, 'microphone.vad.threshold')).toBe('0.5');
     expect(getMetadataValue(defaults, 'microphone.eos.provider')).toBe(
       'pipecat_smart_turn_eos',
     );
@@ -274,6 +290,19 @@ describe('Audio input advanced defaults parity', () => {
       '3000',
     );
     expect(getMetadataValue(defaults, 'microphone.eos.model')).toBe('en');
+  });
+
+  it('microphone defaults migrate legacy VAD barge-in trigger to microphone scope', () => {
+    const defaults = GetDefaultMicrophoneConfig([
+      createMetadata('microphone.vad.barge_in_trigger', 'word'),
+    ]);
+
+    expect(getMetadataValue(defaults, 'microphone.barge_in_trigger')).toBe(
+      'word',
+    );
+    expect(
+      getMetadataValue(defaults, 'microphone.vad.barge_in_trigger'),
+    ).toBe('');
   });
 
   it('noise provider update clears stale denoising params and keeps only provider', () => {

--- a/ui/src/app/components/providers/__tests__/voice-advanced-provider-runtime.test.ts
+++ b/ui/src/app/components/providers/__tests__/voice-advanced-provider-runtime.test.ts
@@ -27,7 +27,9 @@ describe('Voice advanced provider runtime parity', () => {
         meta('listen.model', 'nova-3'),
       ]);
       expect(getValue(defaults, 'microphone.vad.provider')).toBe(provider.code);
-      expect(getValue(defaults, 'microphone.vad.barge_in_trigger')).toBe('vad');
+      expect(
+        getValue(defaults, 'microphone.vad.barge_in_trigger'),
+      ).toBeUndefined();
       expect(getValue(defaults, 'listen.model')).toBe('nova-3');
     }
   });

--- a/ui/src/app/components/providers/microphone/barge-in-trigger-control.tsx
+++ b/ui/src/app/components/providers/microphone/barge-in-trigger-control.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Metadata } from '@rapidaai/react';
+import { Select as CarbonSelect, SelectItem } from '@carbon/react';
+import { FormLabel } from '@/app/components/form-label';
+import { HelpToggletip } from '@/app/components/providers/help-label';
+
+export const MICROPHONE_BARGE_IN_TRIGGER_KEY = 'microphone.barge_in_trigger';
+export const LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY =
+  'microphone.vad.barge_in_trigger';
+
+const BARGE_IN_TRIGGER_HELP_TEXT =
+  'Controls when dispatch allows user barge-in. VAD interrupts on speech start from the VAD detector. Word waits for a recognized word/STT interruption signal before interrupting.';
+
+const BARGE_IN_TRIGGER_CHOICES = [
+  { label: 'VAD', value: 'vad' },
+  { label: 'Word', value: 'word' },
+];
+
+export const BargeInTriggerControl: React.FC<{
+  parameters: Metadata[];
+  onChangeParameter: (parameters: Metadata[]) => void;
+}> = ({ parameters, onChangeParameter }) => {
+  const value =
+    parameters.find(p => p.getKey() === MICROPHONE_BARGE_IN_TRIGGER_KEY)
+      ?.getValue() ??
+    parameters
+      .find(p => p.getKey() === LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY)
+      ?.getValue() ??
+    'vad';
+
+  const updateValue = (nextValue: string) => {
+    const nextParam = new Metadata();
+    nextParam.setKey(MICROPHONE_BARGE_IN_TRIGGER_KEY);
+    nextParam.setValue(nextValue);
+
+    onChangeParameter([
+      ...parameters.filter(
+        p =>
+          p.getKey() !== MICROPHONE_BARGE_IN_TRIGGER_KEY &&
+          p.getKey() !== LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY,
+      ),
+      nextParam,
+    ]);
+  };
+
+  return (
+    <div className="min-w-0">
+      <span className="inline-flex items-center gap-1">
+        <FormLabel htmlFor="microphone-barge-in-trigger">
+          Barge-in Trigger
+        </FormLabel>
+        <HelpToggletip
+          label="Barge-in Trigger"
+          helpText={BARGE_IN_TRIGGER_HELP_TEXT}
+        />
+      </span>
+      <CarbonSelect
+        id="microphone-barge-in-trigger"
+        labelText=""
+        value={value}
+        onChange={e => updateValue(e.target.value)}
+      >
+        {BARGE_IN_TRIGGER_CHOICES.map(choice => (
+          <SelectItem
+            key={choice.value}
+            value={choice.value}
+            text={choice.label}
+          />
+        ))}
+      </CarbonSelect>
+    </div>
+  );
+};

--- a/ui/src/app/components/providers/speech-to-text/provider.tsx
+++ b/ui/src/app/components/providers/speech-to-text/provider.tsx
@@ -12,6 +12,10 @@ import {
 } from '@/providers/custom-stt/contract';
 import { ConfigRenderer } from '@/app/components/providers/config-renderer';
 import { FC } from 'react';
+import {
+  LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY,
+  MICROPHONE_BARGE_IN_TRIGGER_KEY,
+} from '@/app/components/providers/microphone/barge-in-trigger-control';
 
 type ProviderCredentialRef = string | VaultCredential;
 
@@ -159,6 +163,7 @@ export const GetDefaultMicrophoneConfig = (
     'microphone.eos.model'?: string;
     'microphone.eos.provider'?: string;
     'microphone.denoising.provider'?: string;
+    'microphone.barge_in_trigger'?: string;
     'microphone.vad.provider'?: string;
     'microphone.vad.barge_in_trigger'?: string;
     'microphone.vad.threshold'?: string;
@@ -195,23 +200,38 @@ export const GetDefaultMicrophoneConfig = (
       value: defaults?.['microphone.vad.provider'] ?? 'silero_vad',
     },
     {
-      key: 'microphone.vad.barge_in_trigger',
-      value: defaults?.['microphone.vad.barge_in_trigger'] ?? 'vad',
+      key: MICROPHONE_BARGE_IN_TRIGGER_KEY,
+      value:
+        defaults?.[MICROPHONE_BARGE_IN_TRIGGER_KEY] ??
+        defaults?.[LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY] ??
+        'vad',
     },
     {
       key: 'microphone.vad.threshold',
-      value: defaults?.['microphone.vad.threshold'] ?? '0.6',
+      value: defaults?.['microphone.vad.threshold'] ?? '0.5',
     },
   ];
 
-  const existingKeys = new Set(existing.map(m => m.getKey()));
+  const legacyBargeInValue = existing.find(
+    m => m.getKey() === LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY,
+  )?.getValue();
+  const existingWithoutLegacyBargeIn = existing.filter(
+    m => m.getKey() !== LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY,
+  );
+  const existingKeys = new Set(
+    existingWithoutLegacyBargeIn.map(m => m.getKey()),
+  );
 
   const newConfigs = defaultConfig
     .filter(({ key }) => !existingKeys.has(key))
     .map(({ key, value }) => {
       const metadata = new Metadata();
       metadata.setKey(key);
-      metadata.setValue(value);
+      metadata.setValue(
+        key === MICROPHONE_BARGE_IN_TRIGGER_KEY && legacyBargeInValue
+          ? legacyBargeInValue
+          : value,
+      );
       return metadata;
     });
 
@@ -220,9 +240,13 @@ export const GetDefaultMicrophoneConfig = (
     existing.find(m => m.getKey() === 'microphone.eos.provider')?.getValue() ??
     'pipecat_smart_turn_eos';
 
-  let hydrated = GetDefaultEOSConfig(eosProvider, [...existing, ...newConfigs]);
+  let hydrated = GetDefaultEOSConfig(eosProvider, [
+    ...existingWithoutLegacyBargeIn,
+    ...newConfigs,
+  ]);
 
   for (const [key, value] of Object.entries(defaults ?? {})) {
+    if (key === LEGACY_MICROPHONE_VAD_BARGE_IN_TRIGGER_KEY) continue;
     if (!value || existingKeys.has(key)) continue;
     hydrated = upsertMetadata(hydrated, key, value);
   }

--- a/ui/src/app/pages/assistant/actions/configure-assistant-analysis/index.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-analysis/index.tsx
@@ -12,7 +12,7 @@ import { CreateAssistantAnalysis } from '@/app/pages/assistant/actions/configure
 import { useAssistantAnalysisPageStore } from '@/app/pages/assistant/actions/store/use-analysis-page-store';
 import { UpdateAssistantAnalysis } from '@/app/pages/assistant/actions/configure-assistant-analysis/update-assistant-analysis';
 import { IconOnlyButton, PrimaryButton } from '@/app/components/carbon/button';
-import { CarbonShapeIndicator } from '@/app/components/carbon/shape-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import { Pagination } from '@/app/components/carbon/pagination';
 import {
   Breadcrumb,
@@ -319,9 +319,8 @@ const ConfigureAssistantAnalysis: FC<{ assistantId: string }> = ({
                         {getAnalysisPriority(row)}
                       </TableCell>
                       <TableCell className="text-sm whitespace-nowrap">
-                        <CarbonShapeIndicator
-                          kind={row.getEnabled() ? 'stable' : 'draft'}
-                          label={row.getEnabled() ? 'Enabled' : 'Disabled'}
+                        <RecordStatusIndicator
+                          state={row.getStatus()}
                           textSize={14}
                         />
                       </TableCell>

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
@@ -312,8 +312,16 @@ jest.mock('@carbon/react', () => ({
   Tooltip: ({ children }: any) => <span>{children}</span>,
 }));
 
-jest.mock('@/app/components/carbon/shape-indicator', () => ({
-  CarbonShapeIndicator: ({ label }: any) => <span>{label}</span>,
+jest.mock('@/app/components/carbon/record-status-indicator', () => ({
+  RecordStatusIndicator: ({ state }: any) => (
+    <span>
+      {state === 'ACTIVE'
+        ? 'Active'
+        : state === 'INACTIVE'
+          ? 'Inactive'
+          : 'Draft'}
+    </span>
+  ),
 }));
 
 jest.mock('@/app/components/carbon/url-table-cell', () => ({
@@ -333,7 +341,7 @@ describe('CreateAssistantAuthenticationPage', () => {
         getId: () => 'auth-config-1',
         getProvider: () => 'http',
         getEnabled: () => enabled,
-        getStatus: () => 'ACTIVE',
+        getStatus: () => (enabled ? 'ACTIVE' : 'INACTIVE'),
         getCreateddate: () => undefined,
         getOptionsList: () => [
           makeOption('http_method', 'POST'),
@@ -654,7 +662,7 @@ describe('CreateAssistantAuthenticationPage', () => {
       expect(GetAllAssistantConfiguration).toHaveBeenCalledTimes(2),
     );
     await waitFor(() =>
-      expect(screen.getByText('Disabled')).toBeInTheDocument(),
+      expect(screen.getByText('Inactive')).toBeInTheDocument(),
     );
     await waitFor(() =>
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
@@ -682,7 +690,7 @@ describe('CreateAssistantAuthenticationPage', () => {
     render(<ConfigureAssistantAuthenticationPage />);
 
     await waitFor(() =>
-      expect(screen.getByText('Disabled')).toBeInTheDocument(),
+      expect(screen.getByText('Inactive')).toBeInTheDocument(),
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Enable' }));
@@ -706,9 +714,7 @@ describe('CreateAssistantAuthenticationPage', () => {
     await waitFor(() =>
       expect(GetAllAssistantConfiguration).toHaveBeenCalledTimes(2),
     );
-    await waitFor(() =>
-      expect(screen.getByText('Enabled')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Active')).toBeInTheDocument());
     await waitFor(() =>
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
     );

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/configure-authentication-list.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/configure-authentication-list.tsx
@@ -39,7 +39,7 @@ import { UrlTableCell } from '@/app/components/carbon/url-table-cell';
 import { SectionLoader } from '@/app/components/loader/section-loader';
 import { TableSection } from '@/app/components/sections/table-section';
 import { EmptyState } from '@/app/components/carbon/empty-state';
-import { CarbonShapeIndicator } from '@/app/components/carbon/shape-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import { toHumanReadableDateTime } from '@/utils/date';
 
 import {
@@ -321,9 +321,8 @@ export const ConfigureAuthenticationList: FC<
                 </TableCell>
                 <UrlTableCell url={optionMap[AUTH_OPTION_ENDPOINT]} />
                 <TableCell className="text-sm whitespace-nowrap">
-                  <CarbonShapeIndicator
-                    kind={authenticationEnabled ? 'stable' : 'draft'}
-                    label={authenticationEnabled ? 'Enabled' : 'Disabled'}
+                  <RecordStatusIndicator
+                    state={authentication.getStatus()}
                     textSize={14}
                   />
                 </TableCell>

--- a/ui/src/app/pages/assistant/actions/configure-assistant-storage/index.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-storage/index.tsx
@@ -13,7 +13,7 @@ import { UpdateAssistantStorage } from './update-assistant-storage';
 import { useAssistantStoragePageStore } from '@/app/pages/assistant/actions/store/use-storage-page-store';
 import { STORAGE_PROVIDER } from '@/providers';
 import { IconOnlyButton, PrimaryButton } from '@/app/components/carbon/button';
-import { CarbonShapeIndicator } from '@/app/components/carbon/shape-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -320,9 +320,8 @@ const ConfigureAssistantStorage: FC<{ assistantId: string }> = ({
                           {getStorageTarget(row)}
                         </TableCell>
                         <TableCell className="text-sm whitespace-nowrap">
-                          <CarbonShapeIndicator
-                            kind={row.getEnabled() ? 'stable' : 'draft'}
-                            label={row.getEnabled() ? 'Enabled' : 'Disabled'}
+                          <RecordStatusIndicator
+                            state={row.getStatus()}
                             textSize={14}
                           />
                         </TableCell>

--- a/ui/src/app/pages/assistant/actions/configure-assistant-webhook/index.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-webhook/index.tsx
@@ -11,7 +11,7 @@ import { EmptyState } from '@/app/components/carbon/empty-state';
 import { UpdateAssistantWebhook } from '@/app/pages/assistant/actions/configure-assistant-webhook/update-assistant-webhook';
 import { useAssistantWebhookPageStore } from '@/app/pages/assistant/actions/store/use-webhook-page-store';
 import { IconOnlyButton, PrimaryButton } from '@/app/components/carbon/button';
-import { CarbonShapeIndicator } from '@/app/components/carbon/shape-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import { UrlTableCell } from '@/app/components/carbon/url-table-cell';
 import { Pagination } from '@/app/components/carbon/pagination';
 import { Add, Renew, Webhook } from '@carbon/icons-react';
@@ -358,9 +358,8 @@ const ConfigureAssistantWebhook: FC<{ assistantId: string }> = ({
                           {getWebhookPriority(row)}
                         </TableCell>
                         <TableCell className="text-sm whitespace-nowrap">
-                          <CarbonShapeIndicator
-                            kind={row.getEnabled() ? 'stable' : 'draft'}
-                            label={row.getEnabled() ? 'Enabled' : 'Disabled'}
+                          <RecordStatusIndicator
+                            state={row.getStatus()}
                             textSize={14}
                           />
                         </TableCell>

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-audio-input.design.test.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-audio-input.design.test.tsx
@@ -45,6 +45,11 @@ jest.mock('@/app/components/providers/vad', () => ({
   ),
 }));
 
+jest.mock('@/app/components/providers/microphone/barge-in-trigger-control', () => ({
+  MICROPHONE_BARGE_IN_TRIGGER_KEY: 'microphone.barge_in_trigger',
+  BargeInTriggerControl: () => <div>barge-in control</div>,
+}));
+
 jest.mock('@/app/components/providers/end-of-speech', () => ({
   EndOfSpeechProvider: ({
     onChangeProvider,
@@ -108,6 +113,7 @@ describe('ConfigureAudioInputProvider design integration', () => {
     const inputParameters = [
       createMetadata('listen.model', 'nova-3'),
       createMetadata('microphone.eos.fallback_timeout', '900'),
+      createMetadata('microphone.barge_in_trigger', 'word'),
       createMetadata('microphone.vad.threshold', '0.7'),
       createMetadata('microphone.denoising.provider', 'rn_noise'),
       createMetadata('speaker.model', 'sonic'),
@@ -137,6 +143,7 @@ describe('ConfigureAudioInputProvider design integration', () => {
     expect(microphoneOnly.map(m => m.getKey()).sort()).toEqual(
       [
         'microphone.eos.fallback_timeout',
+        'microphone.barge_in_trigger',
         'microphone.vad.threshold',
         'microphone.denoising.provider',
       ].sort(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-audio-input.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-audio-input.tsx
@@ -13,6 +13,10 @@ import { GetDefaultVADConfig } from '@/app/components/providers/vad/provider';
 import { VADProvider } from '@/app/components/providers/vad';
 import { ChevronDown } from '@carbon/icons-react';
 import { cn } from '@/utils';
+import {
+  BargeInTriggerControl,
+  MICROPHONE_BARGE_IN_TRIGGER_KEY,
+} from '@/app/components/providers/microphone/barge-in-trigger-control';
 
 interface ConfigureAudioInputProviderProps {
   audioInputConfig: { provider: string; parameters: Metadata[] };
@@ -32,6 +36,7 @@ export const ConfigureAudioInputProvider: React.FC<
       const key = p.getKey();
       return (
         key.startsWith('microphone.eos.') ||
+        key === MICROPHONE_BARGE_IN_TRIGGER_KEY ||
         key.startsWith('microphone.vad.') ||
         key.startsWith('microphone.denoising.')
       );
@@ -90,6 +95,13 @@ export const ConfigureAudioInputProvider: React.FC<
 
           {showAdvanced && (
             <div className="flex flex-col gap-6 pt-6 border-t border-gray-200 dark:border-gray-800">
+              <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
+                Barge-in Control
+              </p>
+              <BargeInTriggerControl
+                parameters={audioInputConfig.parameters}
+                onChangeParameter={onChangeAudioInputParameter}
+              />
               <p className="text-[10px] font-semibold tracking-[0.12em] uppercase text-gray-500 dark:text-gray-400">
                 Voice Activity Detection
               </p>

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-experience.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-experience.tsx
@@ -37,7 +37,7 @@ const ERROR_MESSAGE_OPTIONS = [
   'I’m sorry, I ran into an issue. Let’s try again.',
 ];
 
-export const DEFAULT_UNCLEAR_INPUT_TIMEOUT = '0.5';
+export const DEFAULT_UNCLEAR_INPUT_TIMEOUT = '2';
 export const DEFAULT_UNCLEAR_INPUT_MESSAGE =
   "I didn't catch that. Could you repeat that?";
 
@@ -175,8 +175,8 @@ export const ConfigureExperience: FC<{
             id="experience-unclear-input-timeout"
             labelText="Unclear Speech Wait (Seconds)"
             hideLabel
-            min={0.5}
-            max={5}
+            min={2}
+            max={10}
             step={0.1}
             value={parseFloat(
               experienceConfig.unclearInputTimeout ||

--- a/ui/src/app/pages/assistant/actions/create-deployment/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/index.tsx
@@ -47,7 +47,7 @@ import {
   AssistantDeploymentVersionsModal,
 } from '@/app/components/base/modal/assistant-deployment-versions-modal';
 import SourceIndicator from '@/app/components/indicators/source';
-import { CarbonStatusIndicator } from '@/app/components/carbon/status-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import {
   OverflowMenu,
   OverflowMenuItem,
@@ -525,7 +525,7 @@ export const ConfigureAssistantDeploymentPage = () => {
                         )}
                       </TableCell>
                       <TableCell className="text-sm">
-                        <CarbonStatusIndicator state={row.status} />
+                        <RecordStatusIndicator state={row.status} />
                       </TableCell>
                       <TableCell className="text-sm">
                         <AudioProviderTag

--- a/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/configure-experience.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/configure-experience.tsx
@@ -75,8 +75,8 @@ export const ConfigureExperience: FC<{
               <Slider
                 id="widget-unclear-input-timeout"
                 labelText="Unclear Speech Wait (Seconds)"
-                min={0.5}
-                max={5}
+                min={2}
+                max={10}
                 step={0.1}
                 value={parseFloat(
                   experienceConfig.unclearInputTimeout ||

--- a/ui/src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx
+++ b/ui/src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx
@@ -38,8 +38,8 @@ jest.mock('@/app/components/indicators/source', () => ({
   default: ({ source }: any) => <span>Deployment: {source}</span>,
 }));
 
-jest.mock('@/app/components/carbon/status-indicator', () => ({
-  CarbonStatusIndicator: ({ state }: any) => <span>Status: {state}</span>,
+jest.mock('@/app/components/carbon/record-status-indicator', () => ({
+  RecordStatusIndicator: ({ state }: any) => <span>Status: {state}</span>,
 }));
 
 jest.mock('@/app/components/carbon/button/copy-button', () => ({

--- a/ui/src/app/pages/assistant/listing/single-assistant.tsx
+++ b/ui/src/app/pages/assistant/listing/single-assistant.tsx
@@ -5,7 +5,7 @@ import SourceIndicator from '@/app/components/indicators/source';
 import { useGlobalNavigation } from '@/hooks/use-global-navigator';
 import { Launch, Rocket, SourceControl, View } from '@carbon/icons-react';
 import { Link, TableRow, TableCell, Tag } from '@carbon/react';
-import { CarbonStatusIndicator } from '@/app/components/carbon/status-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import { IconOnlyButton } from '@/app/components/carbon/button';
 import { CopyButton } from '@/app/components/carbon/button/copy-button';
 import { VersionIndicator } from '@/app/components/indicators/version';
@@ -57,7 +57,7 @@ const SingleAssistant: FC<{ assistant: Assistant }> = ({ assistant }) => {
 
       <TableCell className="text-sm">
         {status ? (
-          <CarbonStatusIndicator state={status} />
+          <RecordStatusIndicator state={status} />
         ) : (
           <span className="text-sm text-gray-400">-</span>
         )}

--- a/ui/src/app/pages/endpoint/listing/__tests__/endpoint-table-ux.test.tsx
+++ b/ui/src/app/pages/endpoint/listing/__tests__/endpoint-table-ux.test.tsx
@@ -30,8 +30,8 @@ jest.mock('@carbon/react', () => ({
   ),
 }));
 
-jest.mock('@/app/components/carbon/status-indicator', () => ({
-  CarbonStatusIndicator: ({ state }: any) => <span>Status: {state}</span>,
+jest.mock('@/app/components/carbon/record-status-indicator', () => ({
+  RecordStatusIndicator: ({ state }: any) => <span>Status: {state}</span>,
 }));
 
 jest.mock('@/app/components/carbon/provider-tag', () => ({

--- a/ui/src/app/pages/endpoint/listing/single-endpoint.tsx
+++ b/ui/src/app/pages/endpoint/listing/single-endpoint.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { TableRow, TableCell, Tag, Link } from '@carbon/react';
 import { ProviderTag } from '@/app/components/carbon/provider-tag';
 import { Launch, View, SourceControl } from '@carbon/icons-react';
-import { CarbonStatusIndicator } from '@/app/components/carbon/status-indicator';
+import { RecordStatusIndicator } from '@/app/components/carbon/record-status-indicator';
 import { VersionIndicator } from '@/app/components/indicators/version';
 import { IconOnlyButton } from '@/app/components/carbon/button';
 import { CopyButton } from '@/app/components/carbon/button/copy-button';
@@ -62,7 +62,7 @@ export const SingleEndpoint: FC<SingleEndpointProps> = ({ endpoint }) => {
       )}
       {endpointAction.visibleColumn('getStatus') && (
         <TableCell className="text-sm">
-          <CarbonStatusIndicator state={status} />
+          <RecordStatusIndicator state={status} />
         </TableCell>
       )}
       {endpointAction.visibleColumn('getCurrentModel') && (

--- a/ui/src/hooks/__tests__/use-global-navigator.test.ts
+++ b/ui/src/hooks/__tests__/use-global-navigator.test.ts
@@ -151,7 +151,7 @@ describe('useGlobalNavigation', () => {
 
     expect(mockNavigate).toHaveBeenNthCalledWith(
       1,
-      '/logs/traces?query=scopeAttributes.assistantConversationId%3A2340105440068632576',
+      '/logs/traces?query=conversation%3A2340105440068632576',
     );
     expect(mockNavigate).toHaveBeenNthCalledWith(
       2,

--- a/ui/src/hooks/use-global-navigator.ts
+++ b/ui/src/hooks/use-global-navigator.ts
@@ -168,7 +168,7 @@ export const useGlobalNavigation = () => {
 
   const goToConversationTelemetry = (conversationId: string) => {
     const params = new URLSearchParams({
-      query: `scopeAttributes.assistantConversationId:${conversationId}`,
+      query: `conversation:${conversationId}`,
     });
     navigate(`/logs/traces?${params.toString()}`);
   };

--- a/ui/src/providers/firered_vad/vad.json
+++ b/ui/src/providers/firered_vad/vad.json
@@ -1,47 +1,37 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.barge_in_trigger",
-      "label": "Barge-in Trigger",
-      "type": "select",
-      "default": "vad",
-      "choices": [
-        {
-          "label": "VAD",
-          "value": "vad"
-        },
-        {
-          "label": "Word",
-          "value": "word"
-        }
-      ]
-    },
-    {
       "key": "microphone.vad.threshold",
       "label": "Speech Threshold",
       "type": "slider",
-      "default": "0.5",
-      "min": 0.3,
+      "default": "0.4",
+      "min": 0,
       "max": 1,
-      "step": 0.05
+      "step": 0.05,
+      "helpText": "Speech probability threshold used by FireRed VAD post-processing. Higher values are less sensitive; lower values detect quieter speech. Backend default is 0.4.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_silence_frame",
       "label": "Min Silence Frames",
       "type": "slider",
-      "default": "10",
+      "default": "20",
       "min": 1,
-      "max": 30,
-      "step": 1
+      "max": 50,
+      "step": 1,
+      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_speech_frame",
       "label": "Min Speech Frames",
       "type": "slider",
-      "default": "3",
+      "default": "8",
       "min": 1,
       "max": 20,
-      "step": 1
+      "step": 1,
+      "helpText": "Number of speech frames FireRed requires before confirming speech start. One frame is 10ms, so the default 8 frames is 80ms.",
+      "helpTextDisplay": "toggletip"
     }
   ]
 }

--- a/ui/src/providers/silero_vad/vad.json
+++ b/ui/src/providers/silero_vad/vad.json
@@ -1,29 +1,15 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.barge_in_trigger",
-      "label": "Barge-in Trigger",
-      "type": "select",
-      "default": "vad",
-      "choices": [
-        {
-          "label": "VAD",
-          "value": "vad"
-        },
-        {
-          "label": "Word",
-          "value": "word"
-        }
-      ]
-    },
-    {
       "key": "microphone.vad.threshold",
       "label": "Speech Threshold",
       "type": "slider",
       "default": "0.5",
-      "min": 0.3,
-      "max": 1,
-      "step": 0.05
+      "min": 0.05,
+      "max": 0.95,
+      "step": 0.05,
+      "helpText": "Speech probability threshold used by Silero VAD. Higher values are less sensitive; lower values detect quieter speech. Backend valid range is greater than 0 and less than 1.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_silence_frame",
@@ -33,7 +19,8 @@
       "min": 1,
       "max": 50,
       "step": 1,
-      "helpText": "Frames of silence before speech ends (1 frame = 10ms)"
+      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_speech_frame",
@@ -43,7 +30,8 @@
       "min": 1,
       "max": 20,
       "step": 1,
-      "helpText": "Frames of padding around speech (1 frame = 10ms)"
+      "helpText": "Speech padding applied around detected speech boundaries. One frame is 10ms, so the default 8 frames is 80ms.",
+      "helpTextDisplay": "toggletip"
     }
   ]
 }

--- a/ui/src/providers/ten_vad/vad.json
+++ b/ui/src/providers/ten_vad/vad.json
@@ -1,29 +1,15 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.barge_in_trigger",
-      "label": "Barge-in Trigger",
-      "type": "select",
-      "default": "vad",
-      "choices": [
-        {
-          "label": "VAD",
-          "value": "vad"
-        },
-        {
-          "label": "Word",
-          "value": "word"
-        }
-      ]
-    },
-    {
       "key": "microphone.vad.threshold",
       "label": "Speech Threshold",
       "type": "slider",
       "default": "0.5",
-      "min": 0.3,
+      "min": 0,
       "max": 1,
-      "step": 0.05
+      "step": 0.05,
+      "helpText": "Speech probability threshold used by TEN VAD. Higher values are less sensitive; lower values detect quieter speech. Backend valid range is 0 through 1.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_silence_frame",
@@ -33,7 +19,8 @@
       "min": 1,
       "max": 50,
       "step": 1,
-      "helpText": "Frames of silence before speech ends (1 frame = 10ms)"
+      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "helpTextDisplay": "toggletip"
     },
     {
       "key": "microphone.vad.min_speech_frame",
@@ -43,7 +30,8 @@
       "min": 1,
       "max": 20,
       "step": 1,
-      "helpText": "Frames of padding around speech (1 frame = 10ms)"
+      "helpText": "Speech padding applied around detected speech boundaries. One frame is 10ms, so the default 8 frames is 80ms.",
+      "helpTextDisplay": "toggletip"
     }
   ]
 }

--- a/ui/src/styles/generated/tailwindcss.css
+++ b/ui/src/styles/generated/tailwindcss.css
@@ -72,7 +72,6 @@
     --color-teal-900: oklch(38.6% 0.063 188.416);
     --color-cyan-100: oklch(95.6% 0.045 203.388);
     --color-cyan-400: oklch(78.9% 0.154 211.53);
-    --color-cyan-500: oklch(71.5% 0.143 215.221);
     --color-cyan-600: oklch(60.9% 0.126 221.723);
     --color-cyan-800: oklch(45% 0.085 224.283);
     --color-cyan-900: oklch(39.8% 0.07 227.392);
@@ -99,12 +98,10 @@
     --color-indigo-700: oklch(45.7% 0.24 277.023);
     --color-indigo-800: oklch(39.8% 0.195 277.366);
     --color-indigo-900: oklch(35.9% 0.144 278.697);
-    --color-violet-50: oklch(96.9% 0.016 293.756);
     --color-violet-100: oklch(94.3% 0.029 294.588);
     --color-violet-400: oklch(70.2% 0.183 293.541);
     --color-violet-500: oklch(60.6% 0.25 292.717);
     --color-violet-600: oklch(54.1% 0.281 293.009);
-    --color-violet-700: oklch(49.1% 0.27 292.581);
     --color-violet-800: oklch(43.2% 0.232 292.759);
     --color-violet-900: oklch(38% 0.189 293.745);
     --color-violet-950: oklch(28.3% 0.141 291.089);
@@ -416,9 +413,6 @@
   }
   .inset-0 {
     inset: calc(var(--spacing) * 0);
-  }
-  .inset-auto {
-    inset: auto;
   }
   .inset-auto\! {
     inset: auto !important;
@@ -2134,205 +2128,6 @@
       margin-bottom: 0;
     }
   }
-  .prose-sm {
-    font-size: 0.875rem;
-    line-height: 1.7142857;
-    :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-      margin-bottom: 1.1428571em;
-    }
-    :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 1.2857143em;
-      line-height: 1.5555556;
-      margin-top: 0.8888889em;
-      margin-bottom: 0.8888889em;
-    }
-    :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.3333333em;
-      margin-bottom: 1.3333333em;
-      padding-left: 1.1111111em;
-    }
-    :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 2.1428571em;
-      margin-top: 0;
-      margin-bottom: 0.8em;
-      line-height: 1.2;
-    }
-    :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 1.4285714em;
-      margin-top: 1.6em;
-      margin-bottom: 0.8em;
-      line-height: 1.4;
-    }
-    :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 1.2857143em;
-      margin-top: 1.5555556em;
-      margin-bottom: 0.4444444em;
-      line-height: 1.5555556;
-    }
-    :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.4285714em;
-      margin-bottom: 0.5714286em;
-      line-height: 1.4285714;
-    }
-    :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.7142857em;
-      margin-bottom: 1.7142857em;
-    }
-    :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.7142857em;
-      margin-bottom: 1.7142857em;
-    }
-    :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-    :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.7142857em;
-      margin-bottom: 1.7142857em;
-    }
-    :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8571429em;
-      border-radius: 0.3125rem;
-      padding-top: 0.1428571em;
-      padding-right: 0.3571429em;
-      padding-bottom: 0.1428571em;
-      padding-left: 0.3571429em;
-    }
-    :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8571429em;
-    }
-    :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.9em;
-    }
-    :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8888889em;
-    }
-    :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8571429em;
-      line-height: 1.6666667;
-      margin-top: 1.6666667em;
-      margin-bottom: 1.6666667em;
-      border-radius: 0.25rem;
-      padding-top: 0.6666667em;
-      padding-right: 1em;
-      padding-bottom: 0.6666667em;
-      padding-left: 1em;
-    }
-    :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-      margin-bottom: 1.1428571em;
-      padding-left: 1.5714286em;
-    }
-    :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-      margin-bottom: 1.1428571em;
-      padding-left: 1.5714286em;
-    }
-    :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0.2857143em;
-      margin-bottom: 0.2857143em;
-    }
-    :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-left: 0.4285714em;
-    }
-    :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-left: 0.4285714em;
-    }
-    :where(.prose-sm > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0.5714286em;
-      margin-bottom: 0.5714286em;
-    }
-    :where(.prose-sm > ul > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-    }
-    :where(.prose-sm > ul > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-bottom: 1.1428571em;
-    }
-    :where(.prose-sm > ol > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-    }
-    :where(.prose-sm > ol > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-bottom: 1.1428571em;
-    }
-    :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0.5714286em;
-      margin-bottom: 0.5714286em;
-    }
-    :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-      margin-bottom: 1.1428571em;
-    }
-    :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.1428571em;
-    }
-    :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0.2857143em;
-      padding-left: 1.5714286em;
-    }
-    :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 2.8571429em;
-      margin-bottom: 2.8571429em;
-    }
-    :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-    }
-    :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-    }
-    :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-    }
-    :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-    }
-    :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8571429em;
-      line-height: 1.5;
-    }
-    :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-right: 1em;
-      padding-bottom: 0.6666667em;
-      padding-left: 1em;
-    }
-    :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-left: 0;
-    }
-    :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-right: 0;
-    }
-    :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-top: 0.6666667em;
-      padding-right: 1em;
-      padding-bottom: 0.6666667em;
-      padding-left: 1em;
-    }
-    :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-left: 0;
-    }
-    :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      padding-right: 0;
-    }
-    :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 1.7142857em;
-      margin-bottom: 1.7142857em;
-    }
-    :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-    :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      font-size: 0.8571429em;
-      line-height: 1.3333333;
-      margin-top: 0.6666667em;
-    }
-    :where(.prose-sm > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-top: 0;
-    }
-    :where(.prose-sm > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-      margin-bottom: 0;
-    }
-  }
   .prose-sm\! {
     font-size: 0.875rem !important;
     line-height: 1.7142857 !important;
@@ -2580,9 +2375,6 @@
   .mt-auto {
     margin-top: auto;
   }
-  .mr-1 {
-    margin-right: calc(var(--spacing) * 1);
-  }
   .mr-1\.5 {
     margin-right: calc(var(--spacing) * 1.5);
   }
@@ -2612,9 +2404,6 @@
   }
   .\!mb-6 {
     margin-bottom: calc(var(--spacing) * 6) !important;
-  }
-  .mb-0 {
-    margin-bottom: calc(var(--spacing) * 0);
   }
   .mb-0\! {
     margin-bottom: calc(var(--spacing) * 0) !important;
@@ -2940,9 +2729,6 @@
   }
   .h-\[calc\(100vh-48px\)\] {
     height: calc(100vh - 48px);
-  }
-  .h-auto {
-    height: auto;
   }
   .h-auto\! {
     height: auto !important;
@@ -3334,9 +3120,6 @@
   .w-\[min\(360px\,calc\(100vw-2rem\)\)\] {
     width: min(360px, calc(100vw - 2rem));
   }
-  .w-\[min\(420px\,calc\(100vw-2rem\)\)\] {
-    width: min(420px, calc(100vw - 2rem));
-  }
   .w-\[min\(760px\,calc\(100vw-2rem\)\)\] {
     width: min(760px, calc(100vw - 2rem));
   }
@@ -3502,9 +3285,6 @@
   .\!min-w-0 {
     min-width: calc(var(--spacing) * 0) !important;
   }
-  .\!min-w-8 {
-    min-width: calc(var(--spacing) * 8) !important;
-  }
   .\!min-w-12 {
     min-width: calc(var(--spacing) * 12) !important;
   }
@@ -3562,9 +3342,6 @@
   .min-w-\[30vw\]\! {
     min-width: 30vw !important;
   }
-  .min-w-\[80px\] {
-    min-width: 80px;
-  }
   .min-w-\[130px\] {
     min-width: 130px;
   }
@@ -3607,9 +3384,6 @@
   .flex-none {
     flex: none;
   }
-  .flex-shrink {
-    flex-shrink: 1;
-  }
   .flex-shrink-0 {
     flex-shrink: 0;
   }
@@ -3618,9 +3392,6 @@
   }
   .shrink-0 {
     flex-shrink: 0;
-  }
-  .flex-grow {
-    flex-grow: 1;
   }
   .grow {
     flex-grow: 1;
@@ -3636,10 +3407,6 @@
   }
   .translate-x-full {
     --tw-translate-x: 100%;
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -3936,13 +3703,6 @@
   .gap-16 {
     gap: calc(var(--spacing) * 16);
   }
-  .space-y-0 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
   .space-y-0\.5 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -4047,9 +3807,6 @@
   }
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
-  }
-  .gap-y-2 {
-    row-gap: calc(var(--spacing) * 2);
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
@@ -4411,9 +4168,6 @@
   .border-gray-500 {
     border-color: var(--color-gray-500);
   }
-  .border-green-600 {
-    border-color: var(--color-green-600);
-  }
   .border-green-600\/30 {
     border-color: color-mix(in srgb, oklch(62.7% 0.194 149.214) 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4422,9 +4176,6 @@
   }
   .border-primary {
     border-color: var(--color-primary);
-  }
-  .border-red-200 {
-    border-color: var(--color-red-200);
   }
   .border-red-600 {
     border-color: var(--color-red-600);
@@ -4444,17 +4195,11 @@
   .border-transparent\! {
     border-color: transparent !important;
   }
-  .border-white {
-    border-color: var(--color-white);
-  }
   .border-white\/80 {
     border-color: color-mix(in srgb, #fff 80%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--color-white) 80%, transparent);
     }
-  }
-  .border-yellow-600 {
-    border-color: var(--color-yellow-600);
   }
   .border-yellow-600\/20 {
     border-color: color-mix(in srgb, oklch(68.1% 0.162 75.834) 20%, transparent);
@@ -4534,17 +4279,11 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
-  .bg-blue-200 {
-    background-color: var(--color-blue-200);
-  }
   .bg-blue-200\/30 {
     background-color: color-mix(in srgb, oklch(88.2% 0.059 254.128) 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-blue-200) 30%, transparent);
     }
-  }
-  .bg-blue-300 {
-    background-color: var(--color-blue-300);
   }
   .bg-blue-300\/10 {
     background-color: color-mix(in srgb, oklch(80.9% 0.105 251.813) 10%, transparent);
@@ -4624,9 +4363,6 @@
   .bg-gray-500 {
     background-color: var(--color-gray-500);
   }
-  .bg-gray-800 {
-    background-color: var(--color-gray-800);
-  }
   .bg-gray-800\/10 {
     background-color: color-mix(in srgb, #333333 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4642,17 +4378,11 @@
   .bg-green-100 {
     background-color: var(--color-green-100);
   }
-  .bg-green-400 {
-    background-color: var(--color-green-400);
-  }
   .bg-green-400\/20 {
     background-color: color-mix(in srgb, oklch(79.2% 0.209 151.711) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-green-400) 20%, transparent);
     }
-  }
-  .bg-green-600 {
-    background-color: var(--color-green-600);
   }
   .bg-green-600\/10 {
     background-color: color-mix(in srgb, oklch(62.7% 0.194 149.214) 10%, transparent);
@@ -4674,9 +4404,6 @@
   }
   .bg-lime-800 {
     background-color: var(--color-lime-800);
-  }
-  .bg-neutral-950 {
-    background-color: var(--color-neutral-950);
   }
   .bg-neutral-950\/70 {
     background-color: color-mix(in srgb, oklch(14.5% 0 0) 70%, transparent);
@@ -4726,9 +4453,6 @@
   .bg-red-100 {
     background-color: var(--color-red-100);
   }
-  .bg-red-400 {
-    background-color: var(--color-red-400);
-  }
   .bg-red-400\/50 {
     background-color: color-mix(in srgb, oklch(70.4% 0.191 22.216) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4753,9 +4477,6 @@
   .bg-red-800 {
     background-color: var(--color-red-800);
   }
-  .bg-rose-400 {
-    background-color: var(--color-rose-400);
-  }
   .bg-rose-400\/20 {
     background-color: color-mix(in srgb, oklch(71.2% 0.194 13.428) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4771,17 +4492,11 @@
   .bg-slate-300 {
     background-color: var(--color-slate-300);
   }
-  .bg-slate-900 {
-    background-color: var(--color-slate-900);
-  }
   .bg-slate-900\/20 {
     background-color: color-mix(in srgb, #1a1a1a 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-slate-900) 20%, transparent);
     }
-  }
-  .bg-stone-400 {
-    background-color: var(--color-stone-400);
   }
   .bg-stone-400\/10 {
     background-color: color-mix(in srgb, oklch(70.9% 0.01 56.259) 10%, transparent);
@@ -4822,17 +4537,11 @@
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
-  .bg-yellow-400 {
-    background-color: var(--color-yellow-400);
-  }
   .bg-yellow-400\/20 {
     background-color: color-mix(in srgb, oklch(85.2% 0.199 91.936) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-yellow-400) 20%, transparent);
     }
-  }
-  .bg-yellow-600 {
-    background-color: var(--color-yellow-600);
   }
   .bg-yellow-600\/5 {
     background-color: color-mix(in srgb, oklch(68.1% 0.162 75.834) 5%, transparent);
@@ -4890,10 +4599,6 @@
   }
   .to-pink-500 {
     --tw-gradient-to: var(--color-pink-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
-  .to-violet-500 {
-    --tw-gradient-to: var(--color-violet-500);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-violet-500\/5 {
@@ -4977,9 +4682,6 @@
   }
   .p-8\! {
     padding: calc(var(--spacing) * 8) !important;
-  }
-  .p-10 {
-    padding: calc(var(--spacing) * 10);
   }
   .p-10\! {
     padding: calc(var(--spacing) * 10) !important;
@@ -5107,9 +4809,6 @@
   .pe-4 {
     padding-inline-end: calc(var(--spacing) * 4);
   }
-  .pt-0 {
-    padding-top: calc(var(--spacing) * 0);
-  }
   .pt-0\.5 {
     padding-top: calc(var(--spacing) * 0.5);
   }
@@ -5220,9 +4919,6 @@
   }
   .pl-8 {
     padding-left: calc(var(--spacing) * 8);
-  }
-  .pl-9 {
-    padding-left: calc(var(--spacing) * 9);
   }
   .pl-9\! {
     padding-left: calc(var(--spacing) * 9) !important;
@@ -5507,9 +5203,6 @@
   .text-pretty {
     text-wrap: pretty;
   }
-  .text-wrap {
-    text-wrap: wrap;
-  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -5674,9 +5367,6 @@
   }
   .text-lime-600 {
     color: var(--color-lime-600);
-  }
-  .text-neutral-700 {
-    color: var(--color-neutral-700);
   }
   .text-neutral-700\! {
     color: var(--color-neutral-700) !important;
@@ -5852,10 +5542,6 @@
     --tw-shadow: -2px -2px 3px var(--tw-shadow-color, rgba(0,0,0,0.12));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-\[0_0_0_1px_var\(--cds-border-interactive\)\] {
-    --tw-shadow: 0 0 0 1px var(--tw-shadow-color, var(--cds-border-interactive));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
   .shadow-\[0_2px_6px_rgba\(0\,0\,0\,0\.3\)\] {
     --tw-shadow: 0 2px 6px var(--tw-shadow-color, rgba(0,0,0,0.3));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -5910,9 +5596,6 @@
   .ring-blue-200 {
     --tw-ring-color: var(--color-blue-200);
   }
-  .ring-emerald-200 {
-    --tw-ring-color: var(--color-emerald-200);
-  }
   .ring-emerald-200\/10 {
     --tw-ring-color: color-mix(in srgb, oklch(90.5% 0.093 164.15) 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -5921,9 +5604,6 @@
   }
   .ring-gray-200 {
     --tw-ring-color: var(--color-gray-200);
-  }
-  .ring-gray-700 {
-    --tw-ring-color: var(--color-gray-700);
   }
   .ring-gray-700\/20 {
     --tw-ring-color: color-mix(in srgb, #4d4d4d 20%, transparent);
@@ -5939,9 +5619,6 @@
   }
   .ring-orange-200 {
     --tw-ring-color: var(--color-orange-200);
-  }
-  .ring-primary {
-    --tw-ring-color: var(--color-primary);
   }
   .ring-primary\/10 {
     --tw-ring-color: color-mix(in srgb, #0353e9 10%, transparent);
@@ -5961,17 +5638,11 @@
   .ring-red-200 {
     --tw-ring-color: var(--color-red-200);
   }
-  .ring-red-500 {
-    --tw-ring-color: var(--color-red-500);
-  }
   .ring-red-500\/20 {
     --tw-ring-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       --tw-ring-color: color-mix(in oklab, var(--color-red-500) 20%, transparent);
     }
-  }
-  .ring-stone-500 {
-    --tw-ring-color: var(--color-stone-500);
   }
   .ring-stone-500\/30 {
     --tw-ring-color: color-mix(in srgb, oklch(55.3% 0.013 58.071) 30%, transparent);
@@ -6046,10 +5717,6 @@
   }
   .backdrop-blur-xs {
     --tw-backdrop-blur: blur(var(--blur-xs));
-    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-  }
-  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
@@ -7400,11 +7067,6 @@
       align-items: center;
     }
   }
-  .sm\:justify-between {
-    @media (width >= 40rem) {
-      justify-content: space-between;
-    }
-  }
   .sm\:justify-start {
     @media (width >= 40rem) {
       justify-content: flex-start;
@@ -7959,22 +7621,6 @@
       border-color: color-mix(in srgb, oklch(50.5% 0.213 27.518) 30%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         border-color: color-mix(in oklab, var(--color-red-700) 30%, transparent);
-      }
-    }
-  }
-  .dark\:border-red-900\/60 {
-    @media (prefers-color-scheme: dark) {
-      &:not(.light *) {
-        border-color: color-mix(in srgb, oklch(39.6% 0.141 25.723) 60%, transparent);
-        @supports (color: color-mix(in lab, red, red)) {
-          border-color: color-mix(in oklab, var(--color-red-900) 60%, transparent);
-        }
-      }
-    }
-    &:is(.dark *) {
-      border-color: color-mix(in srgb, oklch(39.6% 0.141 25.723) 60%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-red-900) 60%, transparent);
       }
     }
   }
@@ -8744,22 +8390,6 @@
       }
     }
   }
-  .dark\:bg-red-950\/30 {
-    @media (prefers-color-scheme: dark) {
-      &:not(.light *) {
-        background-color: color-mix(in srgb, oklch(25.8% 0.092 26.042) 30%, transparent);
-        @supports (color: color-mix(in lab, red, red)) {
-          background-color: color-mix(in oklab, var(--color-red-950) 30%, transparent);
-        }
-      }
-    }
-    &:is(.dark *) {
-      background-color: color-mix(in srgb, oklch(25.8% 0.092 26.042) 30%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-red-950) 30%, transparent);
-      }
-    }
-  }
   .dark\:bg-rose-400 {
     @media (prefers-color-scheme: dark) {
       &:not(.light *) {
@@ -9480,16 +9110,6 @@
     }
     &:is(.dark *) {
       color: var(--color-purple-900);
-    }
-  }
-  .dark\:text-red-200 {
-    @media (prefers-color-scheme: dark) {
-      &:not(.light *) {
-        color: var(--color-red-200);
-      }
-    }
-    &:is(.dark *) {
-      color: var(--color-red-200);
     }
   }
   .dark\:text-red-400 {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2705,10 +2705,10 @@
     uuid "^10.0.0"
     zustand "^4.5.5"
 
-"@rapidaai/react@1.1.87":
-  version "1.1.87"
-  resolved "https://registry.yarnpkg.com/@rapidaai/react/-/react-1.1.87.tgz#9818f4a591a07fda0f9e70661e0a8521672e77ad"
-  integrity sha512-TkqwWbZskd+zGEGpG+KSSScgtHynCKeyurWvWD4141piQi4bcOISHQRN3Tl/R7FXs27lN8vJadYvJmkOfN+uzA==
+"@rapidaai/react@1.1.88":
+  version "1.1.88"
+  resolved "https://registry.yarnpkg.com/@rapidaai/react/-/react-1.1.88.tgz#c35b1f71fcff42a5f8eaa3fa3a842210cfcf1847"
+  integrity sha512-ln47JTn5qWpzYNZz3rUnbHL9gkgDkxRZPpC0Lcy8KzWLDOT+TcVTeqjqaXkKTBNB8YFIqveBrY0LZbsjEiuSiw==
   dependencies:
     "@emotion/is-prop-valid" "^1.3.1"
     "@grpc/grpc-js" "^1.13.4"


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces context-aware packet control and message lifecycle handling for AgentKit conversations, while revising end-of-speech coordination, interruption behavior, audio configuration, timeout validation, telemetry, and related UI controls.
- Adds lifecycle-based context rotation, packet filtering, and barge-in policy handling.
- Coordinates VAD, STT, and EOS state using transcript revisions and guarded timers.
- Moves barge-in configuration to microphone scope and aligns VAD defaults.
- Updates deployment timeout validation, status indicators, telemetry navigation, and AgentKit metrics.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking need to add the repository-required same-package tests for several backend behavior changes.

The investigated packet-control, lifecycle, AgentKit, and EOS paths did not yield a concrete blocking failure, but some changed backend packages lack mandated regression-test updates.

**Files Needing Attention:** api/assistant-api/internal/options/audio.go and other backend production files without corresponding same-package test updates
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/adapters/internal/dispatch_handler.go | Reworks interruption, context rotation, lifecycle transitions, watchdogs, and packet gating across the conversation pipeline. |
| api/assistant-api/internal/adapters/lifecycle/message_lifecycle.go | Introduces strict context-bound user and assistant lifecycle transitions used by dispatch handling. |
| api/assistant-api/internal/end_of_speech/internal/livekit/livekit_end_of_speech.go | Adds revision-aware transcript reconstruction and coordinated VAD/timer state to prevent stale EOS completion. |
| api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go | Aligns Pipecat EOS behavior with the new transcript, VAD, and stale-timer state machine. |
| api/assistant-api/internal/llm/agentkit/agentkit_stream.go | Maps AgentKit stream outputs into context-aware response, control, interruption, error, and observability packets. |
| api/assistant-api/internal/options/audio.go | Updates the microphone barge-in option contract without the required same-package regression-test update. |
| ui/src/app/components/providers/microphone/barge-in-trigger-control.tsx | Adds a shared advanced control for selecting VAD- or word-triggered barge-in behavior. |
| ui/src/app/components/carbon/record-status-indicator/index.tsx | Adds a shared status-to-shape mapping used across assistant, endpoint, deployment, and configuration tables. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Dispatch
    participant Lifecycle
    participant EOS
    participant AgentKit
    participant TTS
    User->>Dispatch: audio/text packet
    Dispatch->>Lifecycle: validate or rotate context
    Dispatch->>EOS: VAD/STT packet
    EOS-->>Dispatch: EndOfSpeechPacket
    Dispatch->>AgentKit: user input
    AgentKit-->>Dispatch: response delta/done/control
    Dispatch->>TTS: assistant text
    TTS-->>Dispatch: audio/end
    Dispatch->>Lifecycle: assistant finished and idle
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/assistant-api/internal/options/audio.go`, line 10 ([link](https://github.com/rapidaai/voice-ai/blob/eaa42d27a8fb9aae85925d7204688da0bab030c2/api/assistant-api/internal/options/audio.go#L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing backend regression tests**

   The microphone option contract and related backend behavior changed without the required same-package `*_test.go` updates. Add package-level coverage for option compatibility and the associated audio defaults so regressions are detected before release; the same pattern also affects the changed message service and VAD packages.

   **Context Used:** AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: api/assistant-api/internal/options/audio.go
   Line: 10
   
   Comment:
   **Missing backend regression tests**
   
   The microphone option contract and related backend behavior changed without the required same-package `*_test.go` updates. Add package-level coverage for option compatibility and the associated audio defaults so regressions are detected before release; the same pattern also affects the changed message service and VAD packages.
   
   **Context Used:** AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/internal/options/audio.go:10
**Missing backend regression tests**

The microphone option contract and related backend behavior changed without the required same-package `*_test.go` updates. Add package-level coverage for option compatibility and the associated audio defaults so regressions are detected before release; the same pattern also affects the changed message service and VAD packages.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: added change in ui to show record ..."](https://github.com/rapidaai/voice-ai/commit/eaa42d27a8fb9aae85925d7204688da0bab030c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51593287)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->