### PR TITLE
fix: added default unclear input timeout

### DIFF
--- a/ui/src/app/pages/assistant/actions/create-deployment/api/__tests__/voice-input-intent.test.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/api/__tests__/voice-input-intent.test.tsx
@@ -18,6 +18,8 @@ let mockParams: Record<string, string | undefined> = {
 };
 
 const mockGoToDeploymentAssistant = jest.fn();
+const mockSetUnclearInputTimeout = jest.fn();
+const mockSetUnclearInputMessage = jest.fn();
 
 jest.mock('@rapidaai/react', () => {
   class ConnectionConfig {
@@ -67,14 +69,18 @@ jest.mock('@rapidaai/react', () => {
     setGreeting(_: string) {}
     setGreetinginterruptible(_: boolean) {}
     setMistake(_: string) {}
-    setUnclearinputtimeout(_: number) {}
+    setUnclearinputtimeout(v: number) {
+      mockSetUnclearInputTimeout(v);
+    }
     hasUnclearinputtimeout() {
       return false;
     }
     getUnclearinputtimeout() {
       return 0;
     }
-    setUnclearinputmessage(_: string) {}
+    setUnclearinputmessage(v: string) {
+      mockSetUnclearInputMessage(v);
+    }
     hasUnclearinputmessage() {
       return false;
     }
@@ -200,6 +206,9 @@ jest.mock(
   '@/app/pages/assistant/actions/create-deployment/commons/configure-experience',
   () => ({
     ConfigureExperience: () => <div>experience</div>,
+    DEFAULT_UNCLEAR_INPUT_TIMEOUT: '2',
+    DEFAULT_UNCLEAR_INPUT_MESSAGE:
+      "I didn't catch that. Could you repeat that?",
   }),
 );
 
@@ -328,6 +337,8 @@ describe('API deployment voice input intent actions', () => {
     const req = (CreateAssistantApiDeployment as jest.Mock).mock.calls[0][1];
     const deployment = req.getApi();
     expect(deployment.getInputaudio()).toBeDefined();
+    expect(mockSetUnclearInputTimeout).not.toHaveBeenCalled();
+    expect(mockSetUnclearInputMessage).not.toHaveBeenCalled();
     await act(async () => {});
   });
 

--- a/ui/src/app/pages/assistant/actions/create-deployment/api/edit.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/api/edit.tsx
@@ -1,7 +1,5 @@
 import {
   ConfigureExperience,
-  DEFAULT_UNCLEAR_INPUT_MESSAGE,
-  DEFAULT_UNCLEAR_INPUT_TIMEOUT,
   ExperienceConfig,
 } from '@/app/pages/assistant/actions/create-deployment/commons/configure-experience';
 import { ConfigureAudioOutputProvider } from '@/app/pages/assistant/actions/create-deployment/commons/configure-audio-output';
@@ -78,8 +76,8 @@ const EditAssistantApiDeployment: FC<{ assistantId: string }> = ({
     greeting: undefined,
     greetingInterruptible: true,
     messageOnError: undefined,
-    unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-    unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+    unclearInputTimeout: undefined,
+    unclearInputMessage: undefined,
     idealTimeout: '30',
     idealMessage: 'Are you there?',
     maxCallDuration: '300',
@@ -139,10 +137,10 @@ const EditAssistantApiDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/api/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/api/index.tsx
@@ -155,10 +155,10 @@ const ConfigureAssistantApiDeployment: FC<{ assistantId: string }> = ({
             messageOnError: deployment?.getMistake(),
             unclearInputTimeout: deployment?.hasUnclearinputtimeout?.()
               ? deployment.getUnclearinputtimeout().toString()
-              : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+              : undefined,
             unclearInputMessage: deployment?.hasUnclearinputmessage?.()
               ? deployment.getUnclearinputmessage()
-              : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+              : undefined,
             idealTimeout: deployment?.getIdealtimeout(),
             idealMessage: deployment?.getIdealtimeoutmessage(),
             maxCallDuration: deployment?.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/debugger/edit.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/debugger/edit.tsx
@@ -1,7 +1,5 @@
 import {
   ConfigureExperience,
-  DEFAULT_UNCLEAR_INPUT_MESSAGE,
-  DEFAULT_UNCLEAR_INPUT_TIMEOUT,
   ExperienceConfig,
 } from '@/app/pages/assistant/actions/create-deployment/commons/configure-experience';
 import { ConfigureAudioOutputProvider } from '@/app/pages/assistant/actions/create-deployment/commons/configure-audio-output';
@@ -95,8 +93,8 @@ const EditAssistantDebuggerDeployment: FC<{ assistantId: string }> = ({
     greeting: undefined,
     greetingInterruptible: true,
     messageOnError: undefined,
-    unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-    unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+    unclearInputTimeout: undefined,
+    unclearInputMessage: undefined,
     idealTimeout: '30',
     idealMessage: 'Are you there?',
     maxCallDuration: '300',
@@ -157,10 +155,10 @@ const EditAssistantDebuggerDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/debugger/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/debugger/index.tsx
@@ -104,8 +104,8 @@ const ConfigureAssistantDebuggerDeployment: FC<{ assistantId: string }> = ({
       greeting: undefined,
       greetingInterruptible: true,
       messageOnError: undefined,
-      unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-      unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+      unclearInputTimeout: undefined,
+      unclearInputMessage: undefined,
       idealTimeout: '30',
       idealMessage: 'Are you there?',
       maxCallDuration: '300',
@@ -191,10 +191,10 @@ const ConfigureAssistantDebuggerDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/hooks/use-deployment-section-edit.ts
+++ b/ui/src/app/pages/assistant/actions/create-deployment/hooks/use-deployment-section-edit.ts
@@ -24,8 +24,6 @@ import { useCurrentCredential } from '@/hooks/use-credential';
 import { useAllProviderCredentials } from '@/hooks/use-model';
 import { useRapidaStore } from '@/hooks';
 import {
-  DEFAULT_UNCLEAR_INPUT_MESSAGE,
-  DEFAULT_UNCLEAR_INPUT_TIMEOUT,
   ExperienceConfig,
 } from '@/app/pages/assistant/actions/create-deployment/commons/configure-experience';
 import {
@@ -65,8 +63,8 @@ const DEFAULT_EXPERIENCE: ExperienceConfig = {
   greeting: undefined,
   greetingInterruptible: true,
   messageOnError: undefined,
-  unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-  unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+  unclearInputTimeout: undefined,
+  unclearInputMessage: undefined,
   idealTimeout: '30',
   idealMessage: 'Are you there?',
   maxCallDuration: '300',
@@ -185,10 +183,10 @@ export function useDeploymentSectionEdit(
             messageOnError: deployment.getMistake(),
             unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
               ? deployment.getUnclearinputtimeout().toString()
-              : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+              : undefined,
             unclearInputMessage: deployment.hasUnclearinputmessage?.()
               ? deployment.getUnclearinputmessage()
-              : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+              : undefined,
             idealTimeout: deployment.getIdealtimeout(),
             idealMessage: deployment.getIdealtimeoutmessage(),
             maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/phone/edit.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/phone/edit.tsx
@@ -1,7 +1,5 @@
 import {
   ConfigureExperience,
-  DEFAULT_UNCLEAR_INPUT_MESSAGE,
-  DEFAULT_UNCLEAR_INPUT_TIMEOUT,
   ExperienceConfig,
 } from '@/app/pages/assistant/actions/create-deployment/commons/configure-experience';
 import { ConfigureAudioInputProvider } from '@/app/pages/assistant/actions/create-deployment/commons/configure-audio-input';
@@ -99,8 +97,8 @@ const EditAssistantCallDeployment: FC<{ assistantId: string }> = ({
     greeting: undefined,
     greetingInterruptible: true,
     messageOnError: undefined,
-    unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-    unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+    unclearInputTimeout: undefined,
+    unclearInputMessage: undefined,
     idealTimeout: '30',
     idealMessage: 'Are you there?',
     maxCallDuration: '300',
@@ -168,10 +166,10 @@ const EditAssistantCallDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/phone/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/phone/index.tsx
@@ -172,10 +172,10 @@ const ConfigureAssistantCallDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/edit.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/edit.tsx
@@ -4,10 +4,6 @@ import {
   ConfigureExperience,
   WebWidgetExperienceConfig,
 } from '@/app/pages/assistant/actions/create-deployment/web-plugin/configure-experience';
-import {
-  DEFAULT_UNCLEAR_INPUT_MESSAGE,
-  DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-} from '@/app/pages/assistant/actions/create-deployment/commons/configure-experience';
 import { useRapidaStore } from '@/hooks';
 import { useAllProviderCredentials } from '@/hooks/use-model';
 import { useCurrentCredential } from '@/hooks/use-credential';
@@ -81,8 +77,8 @@ const EditAssistantWebDeployment: FC<{ assistantId: string }> = ({
       greeting: undefined,
       greetingInterruptible: true,
       messageOnError: undefined,
-      unclearInputTimeout: DEFAULT_UNCLEAR_INPUT_TIMEOUT,
-      unclearInputMessage: DEFAULT_UNCLEAR_INPUT_MESSAGE,
+      unclearInputTimeout: undefined,
+      unclearInputMessage: undefined,
       idealTimeout: '30',
       idealMessage: 'Are you there?',
       maxCallDuration: '300',
@@ -144,10 +140,10 @@ const EditAssistantWebDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/web-plugin/index.tsx
@@ -166,10 +166,10 @@ const ConfigureAssistantWebDeployment: FC<{ assistantId: string }> = ({
           messageOnError: deployment.getMistake(),
           unclearInputTimeout: deployment.hasUnclearinputtimeout?.()
             ? deployment.getUnclearinputtimeout().toString()
-            : DEFAULT_UNCLEAR_INPUT_TIMEOUT,
+            : undefined,
           unclearInputMessage: deployment.hasUnclearinputmessage?.()
             ? deployment.getUnclearinputmessage()
-            : DEFAULT_UNCLEAR_INPUT_MESSAGE,
+            : undefined,
           idealTimeout: deployment.getIdealtimeout(),
           idealMessage: deployment.getIdealtimeoutmessage(),
           maxCallDuration: deployment.getMaxsessionduration(),

--- a/ui/src/styles/generated/tailwindcss.css
+++ b/ui/src/styles/generated/tailwindcss.css
@@ -72,6 +72,7 @@
     --color-teal-900: oklch(38.6% 0.063 188.416);
     --color-cyan-100: oklch(95.6% 0.045 203.388);
     --color-cyan-400: oklch(78.9% 0.154 211.53);
+    --color-cyan-500: oklch(71.5% 0.143 215.221);
     --color-cyan-600: oklch(60.9% 0.126 221.723);
     --color-cyan-800: oklch(45% 0.085 224.283);
     --color-cyan-900: oklch(39.8% 0.07 227.392);
@@ -98,10 +99,12 @@
     --color-indigo-700: oklch(45.7% 0.24 277.023);
     --color-indigo-800: oklch(39.8% 0.195 277.366);
     --color-indigo-900: oklch(35.9% 0.144 278.697);
+    --color-violet-50: oklch(96.9% 0.016 293.756);
     --color-violet-100: oklch(94.3% 0.029 294.588);
     --color-violet-400: oklch(70.2% 0.183 293.541);
     --color-violet-500: oklch(60.6% 0.25 292.717);
     --color-violet-600: oklch(54.1% 0.281 293.009);
+    --color-violet-700: oklch(49.1% 0.27 292.581);
     --color-violet-800: oklch(43.2% 0.232 292.759);
     --color-violet-900: oklch(38% 0.189 293.745);
     --color-violet-950: oklch(28.3% 0.141 291.089);
@@ -413,6 +416,9 @@
   }
   .inset-0 {
     inset: calc(var(--spacing) * 0);
+  }
+  .inset-auto {
+    inset: auto;
   }
   .inset-auto\! {
     inset: auto !important;
@@ -2128,6 +2134,205 @@
       margin-bottom: 0;
     }
   }
+  .prose-sm {
+    font-size: 0.875rem;
+    line-height: 1.7142857;
+    :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+      margin-bottom: 1.1428571em;
+    }
+    :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 1.2857143em;
+      line-height: 1.5555556;
+      margin-top: 0.8888889em;
+      margin-bottom: 0.8888889em;
+    }
+    :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.3333333em;
+      margin-bottom: 1.3333333em;
+      padding-left: 1.1111111em;
+    }
+    :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 2.1428571em;
+      margin-top: 0;
+      margin-bottom: 0.8em;
+      line-height: 1.2;
+    }
+    :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 1.4285714em;
+      margin-top: 1.6em;
+      margin-bottom: 0.8em;
+      line-height: 1.4;
+    }
+    :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 1.2857143em;
+      margin-top: 1.5555556em;
+      margin-bottom: 0.4444444em;
+      line-height: 1.5555556;
+    }
+    :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.4285714em;
+      margin-bottom: 0.5714286em;
+      line-height: 1.4285714;
+    }
+    :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.7142857em;
+      margin-bottom: 1.7142857em;
+    }
+    :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.7142857em;
+      margin-bottom: 1.7142857em;
+    }
+    :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.7142857em;
+      margin-bottom: 1.7142857em;
+    }
+    :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8571429em;
+      border-radius: 0.3125rem;
+      padding-top: 0.1428571em;
+      padding-right: 0.3571429em;
+      padding-bottom: 0.1428571em;
+      padding-left: 0.3571429em;
+    }
+    :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8571429em;
+    }
+    :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.9em;
+    }
+    :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8888889em;
+    }
+    :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8571429em;
+      line-height: 1.6666667;
+      margin-top: 1.6666667em;
+      margin-bottom: 1.6666667em;
+      border-radius: 0.25rem;
+      padding-top: 0.6666667em;
+      padding-right: 1em;
+      padding-bottom: 0.6666667em;
+      padding-left: 1em;
+    }
+    :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+      margin-bottom: 1.1428571em;
+      padding-left: 1.5714286em;
+    }
+    :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+      margin-bottom: 1.1428571em;
+      padding-left: 1.5714286em;
+    }
+    :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0.2857143em;
+      margin-bottom: 0.2857143em;
+    }
+    :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-left: 0.4285714em;
+    }
+    :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-left: 0.4285714em;
+    }
+    :where(.prose-sm > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0.5714286em;
+      margin-bottom: 0.5714286em;
+    }
+    :where(.prose-sm > ul > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+    }
+    :where(.prose-sm > ul > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-bottom: 1.1428571em;
+    }
+    :where(.prose-sm > ol > li > *:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+    }
+    :where(.prose-sm > ol > li > *:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-bottom: 1.1428571em;
+    }
+    :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0.5714286em;
+      margin-bottom: 0.5714286em;
+    }
+    :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+      margin-bottom: 1.1428571em;
+    }
+    :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.1428571em;
+    }
+    :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0.2857143em;
+      padding-left: 1.5714286em;
+    }
+    :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 2.8571429em;
+      margin-bottom: 2.8571429em;
+    }
+    :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+    }
+    :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+    }
+    :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+    }
+    :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+    }
+    :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8571429em;
+      line-height: 1.5;
+    }
+    :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-right: 1em;
+      padding-bottom: 0.6666667em;
+      padding-left: 1em;
+    }
+    :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-left: 0;
+    }
+    :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-right: 0;
+    }
+    :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-top: 0.6666667em;
+      padding-right: 1em;
+      padding-bottom: 0.6666667em;
+      padding-left: 1em;
+    }
+    :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-left: 0;
+    }
+    :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      padding-right: 0;
+    }
+    :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 1.7142857em;
+      margin-bottom: 1.7142857em;
+    }
+    :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      font-size: 0.8571429em;
+      line-height: 1.3333333;
+      margin-top: 0.6666667em;
+    }
+    :where(.prose-sm > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-top: 0;
+    }
+    :where(.prose-sm > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+      margin-bottom: 0;
+    }
+  }
   .prose-sm\! {
     font-size: 0.875rem !important;
     line-height: 1.7142857 !important;
@@ -2375,6 +2580,9 @@
   .mt-auto {
     margin-top: auto;
   }
+  .mr-1 {
+    margin-right: calc(var(--spacing) * 1);
+  }
   .mr-1\.5 {
     margin-right: calc(var(--spacing) * 1.5);
   }
@@ -2404,6 +2612,9 @@
   }
   .\!mb-6 {
     margin-bottom: calc(var(--spacing) * 6) !important;
+  }
+  .mb-0 {
+    margin-bottom: calc(var(--spacing) * 0);
   }
   .mb-0\! {
     margin-bottom: calc(var(--spacing) * 0) !important;
@@ -2729,6 +2940,9 @@
   }
   .h-\[calc\(100vh-48px\)\] {
     height: calc(100vh - 48px);
+  }
+  .h-auto {
+    height: auto;
   }
   .h-auto\! {
     height: auto !important;
@@ -3384,6 +3598,9 @@
   .flex-none {
     flex: none;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .flex-shrink-0 {
     flex-shrink: 0;
   }
@@ -3392,6 +3609,9 @@
   }
   .shrink-0 {
     flex-shrink: 0;
+  }
+  .flex-grow {
+    flex-grow: 1;
   }
   .grow {
     flex-grow: 1;
@@ -3407,6 +3627,10 @@
   }
   .translate-x-full {
     --tw-translate-x: 100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-1 {
+    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -3703,6 +3927,13 @@
   .gap-16 {
     gap: calc(var(--spacing) * 16);
   }
+  .space-y-0 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
   .space-y-0\.5 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -3807,6 +4038,9 @@
   }
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
+  }
+  .gap-y-2 {
+    row-gap: calc(var(--spacing) * 2);
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
@@ -4168,6 +4402,9 @@
   .border-gray-500 {
     border-color: var(--color-gray-500);
   }
+  .border-green-600 {
+    border-color: var(--color-green-600);
+  }
   .border-green-600\/30 {
     border-color: color-mix(in srgb, oklch(62.7% 0.194 149.214) 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4176,6 +4413,9 @@
   }
   .border-primary {
     border-color: var(--color-primary);
+  }
+  .border-red-200 {
+    border-color: var(--color-red-200);
   }
   .border-red-600 {
     border-color: var(--color-red-600);
@@ -4195,11 +4435,17 @@
   .border-transparent\! {
     border-color: transparent !important;
   }
+  .border-white {
+    border-color: var(--color-white);
+  }
   .border-white\/80 {
     border-color: color-mix(in srgb, #fff 80%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--color-white) 80%, transparent);
     }
+  }
+  .border-yellow-600 {
+    border-color: var(--color-yellow-600);
   }
   .border-yellow-600\/20 {
     border-color: color-mix(in srgb, oklch(68.1% 0.162 75.834) 20%, transparent);
@@ -4279,11 +4525,17 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
+  .bg-blue-200 {
+    background-color: var(--color-blue-200);
+  }
   .bg-blue-200\/30 {
     background-color: color-mix(in srgb, oklch(88.2% 0.059 254.128) 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-blue-200) 30%, transparent);
     }
+  }
+  .bg-blue-300 {
+    background-color: var(--color-blue-300);
   }
   .bg-blue-300\/10 {
     background-color: color-mix(in srgb, oklch(80.9% 0.105 251.813) 10%, transparent);
@@ -4363,6 +4615,9 @@
   .bg-gray-500 {
     background-color: var(--color-gray-500);
   }
+  .bg-gray-800 {
+    background-color: var(--color-gray-800);
+  }
   .bg-gray-800\/10 {
     background-color: color-mix(in srgb, #333333 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4378,11 +4633,17 @@
   .bg-green-100 {
     background-color: var(--color-green-100);
   }
+  .bg-green-400 {
+    background-color: var(--color-green-400);
+  }
   .bg-green-400\/20 {
     background-color: color-mix(in srgb, oklch(79.2% 0.209 151.711) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-green-400) 20%, transparent);
     }
+  }
+  .bg-green-600 {
+    background-color: var(--color-green-600);
   }
   .bg-green-600\/10 {
     background-color: color-mix(in srgb, oklch(62.7% 0.194 149.214) 10%, transparent);
@@ -4404,6 +4665,9 @@
   }
   .bg-lime-800 {
     background-color: var(--color-lime-800);
+  }
+  .bg-neutral-950 {
+    background-color: var(--color-neutral-950);
   }
   .bg-neutral-950\/70 {
     background-color: color-mix(in srgb, oklch(14.5% 0 0) 70%, transparent);
@@ -4453,6 +4717,9 @@
   .bg-red-100 {
     background-color: var(--color-red-100);
   }
+  .bg-red-400 {
+    background-color: var(--color-red-400);
+  }
   .bg-red-400\/50 {
     background-color: color-mix(in srgb, oklch(70.4% 0.191 22.216) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4477,6 +4744,9 @@
   .bg-red-800 {
     background-color: var(--color-red-800);
   }
+  .bg-rose-400 {
+    background-color: var(--color-rose-400);
+  }
   .bg-rose-400\/20 {
     background-color: color-mix(in srgb, oklch(71.2% 0.194 13.428) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -4492,11 +4762,17 @@
   .bg-slate-300 {
     background-color: var(--color-slate-300);
   }
+  .bg-slate-900 {
+    background-color: var(--color-slate-900);
+  }
   .bg-slate-900\/20 {
     background-color: color-mix(in srgb, #1a1a1a 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-slate-900) 20%, transparent);
     }
+  }
+  .bg-stone-400 {
+    background-color: var(--color-stone-400);
   }
   .bg-stone-400\/10 {
     background-color: color-mix(in srgb, oklch(70.9% 0.01 56.259) 10%, transparent);
@@ -4537,11 +4813,17 @@
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
+  .bg-yellow-400 {
+    background-color: var(--color-yellow-400);
+  }
   .bg-yellow-400\/20 {
     background-color: color-mix(in srgb, oklch(85.2% 0.199 91.936) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-yellow-400) 20%, transparent);
     }
+  }
+  .bg-yellow-600 {
+    background-color: var(--color-yellow-600);
   }
   .bg-yellow-600\/5 {
     background-color: color-mix(in srgb, oklch(68.1% 0.162 75.834) 5%, transparent);
@@ -4599,6 +4881,10 @@
   }
   .to-pink-500 {
     --tw-gradient-to: var(--color-pink-500);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-violet-500 {
+    --tw-gradient-to: var(--color-violet-500);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-violet-500\/5 {
@@ -4682,6 +4968,9 @@
   }
   .p-8\! {
     padding: calc(var(--spacing) * 8) !important;
+  }
+  .p-10 {
+    padding: calc(var(--spacing) * 10);
   }
   .p-10\! {
     padding: calc(var(--spacing) * 10) !important;
@@ -4809,6 +5098,9 @@
   .pe-4 {
     padding-inline-end: calc(var(--spacing) * 4);
   }
+  .pt-0 {
+    padding-top: calc(var(--spacing) * 0);
+  }
   .pt-0\.5 {
     padding-top: calc(var(--spacing) * 0.5);
   }
@@ -4919,6 +5211,9 @@
   }
   .pl-8 {
     padding-left: calc(var(--spacing) * 8);
+  }
+  .pl-9 {
+    padding-left: calc(var(--spacing) * 9);
   }
   .pl-9\! {
     padding-left: calc(var(--spacing) * 9) !important;
@@ -5203,6 +5498,9 @@
   .text-pretty {
     text-wrap: pretty;
   }
+  .text-wrap {
+    text-wrap: wrap;
+  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -5367,6 +5665,9 @@
   }
   .text-lime-600 {
     color: var(--color-lime-600);
+  }
+  .text-neutral-700 {
+    color: var(--color-neutral-700);
   }
   .text-neutral-700\! {
     color: var(--color-neutral-700) !important;
@@ -5596,6 +5897,9 @@
   .ring-blue-200 {
     --tw-ring-color: var(--color-blue-200);
   }
+  .ring-emerald-200 {
+    --tw-ring-color: var(--color-emerald-200);
+  }
   .ring-emerald-200\/10 {
     --tw-ring-color: color-mix(in srgb, oklch(90.5% 0.093 164.15) 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -5604,6 +5908,9 @@
   }
   .ring-gray-200 {
     --tw-ring-color: var(--color-gray-200);
+  }
+  .ring-gray-700 {
+    --tw-ring-color: var(--color-gray-700);
   }
   .ring-gray-700\/20 {
     --tw-ring-color: color-mix(in srgb, #4d4d4d 20%, transparent);
@@ -5619,6 +5926,9 @@
   }
   .ring-orange-200 {
     --tw-ring-color: var(--color-orange-200);
+  }
+  .ring-primary {
+    --tw-ring-color: var(--color-primary);
   }
   .ring-primary\/10 {
     --tw-ring-color: color-mix(in srgb, #0353e9 10%, transparent);
@@ -5638,11 +5948,17 @@
   .ring-red-200 {
     --tw-ring-color: var(--color-red-200);
   }
+  .ring-red-500 {
+    --tw-ring-color: var(--color-red-500);
+  }
   .ring-red-500\/20 {
     --tw-ring-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       --tw-ring-color: color-mix(in oklab, var(--color-red-500) 20%, transparent);
     }
+  }
+  .ring-stone-500 {
+    --tw-ring-color: var(--color-stone-500);
   }
   .ring-stone-500\/30 {
     --tw-ring-color: color-mix(in srgb, oklch(55.3% 0.013 58.071) 30%, transparent);
@@ -5717,6 +6033,10 @@
   }
   .backdrop-blur-xs {
     --tw-backdrop-blur: blur(var(--blur-xs));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment configurations now preserve unset unclear-input timeout and message settings instead of automatically applying fallback values.
  * This behavior is consistent across assistant, debugger, phone, and web plugin deployments when creating or loading configurations.
  * Voice-input deployments no longer receive unintended unclear-input settings while voice input remains enabled.
* **Tests**
  * Added coverage to verify unclear-input settings remain unchanged for voice-input deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes missing unclear-input timeout and message values from explicit UI defaults to undefined across API, phone, debugger, web-plugin, and section-edit deployment flows.
- Updates deployment initialization and response-loading behavior for unclear-input settings.
- Adds a test asserting that absent settings are not serialized.
- Regenerates the checked-in Tailwind CSS artifact with additional utilities.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until missing unclear-input settings are serialized or defaulted consistently with the values displayed in the deployment form.

Missing fields now become undefined, the save paths omit their setters, and the backend has no fallback, leaving the runtime unclear-input watchdog disabled despite the UI showing a two-second timeout.

**Files Needing Attention:** ui/src/app/pages/assistant/actions/create-deployment/api/edit.tsx and the equivalent debugger, phone, web-plugin, and section-edit deployment flows
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/app/pages/assistant/actions/create-deployment/api/edit.tsx | Loads absent unclear-input fields as undefined, causing displayed defaults to be omitted when the deployment is saved. |
| ui/src/app/pages/assistant/actions/create-deployment/hooks/use-deployment-section-edit.ts | Propagates undefined unclear-input settings through section saves and conditionally omits their protobuf setters. |
| ui/src/app/pages/assistant/actions/create-deployment/api/__tests__/voice-input-intent.test.tsx | Updates mocks and explicitly asserts that absent unclear-input defaults are not serialized, preserving the faulty behavior. |
| ui/src/styles/generated/tailwindcss.css | Adds generated utility classes without modifying or removing existing selectors; no concrete regression was established. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Deployment response omits unclear-input fields] --> B[UI state stores undefined]
    B --> C[Form displays fallback timeout and message]
    B --> D[Save skips protobuf setters]
    D --> E[Backend stores nil]
    E --> F[Runtime does not start unclear-input watchdog]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ui/src/app/pages/assistant/actions/create-deployment/api/edit.tsx:137-143
**Displayed defaults are not persisted**

When a deployment omits the unclear-input fields, this callback stores `undefined` while the form displays a two-second timeout and default message. Saving then skips both protobuf setters, causing the backend to retain nil values and the runtime to leave the unclear-input watchdog disabled.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: added default unclear input timeout"](https://github.com/rapidaai/voice-ai/commit/9a683229b2837edba5edfd176cb2910b78809fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51599069)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->