### PR TITLE
feat: aligned all the vad parameters with standard understanding

### DIFF
--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go
@@ -7,6 +7,7 @@ import (
 
 	adapter_channel "github.com/rapidaai/api/assistant-api/internal/adapters/channel"
 	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	internal_vad "github.com/rapidaai/api/assistant-api/internal/vad"
 	"github.com/rapidaai/pkg/commons"
@@ -100,8 +101,8 @@ func TestHandleModeSwitchInitializeVoiceActivityDetection_VADError_EmitsModeSwit
 		},
 	}
 	r.options = map[string]interface{}{
-		internal_vad.OptionsKeyVadProvider: internal_vad.SILERO_VAD,
-		"microphone.vad.threshold":         1.5, // invalid: detector requires (0,1)
+		internal_vad.OptionsKeyVadProvider:             internal_vad.SILERO_VAD,
+		internal_options.MicrophoneVADOptionConfidence: 1.5, // invalid: detector requires (0,1)
 	}
 	h := requestorDispatchHandler{r: r}
 

--- a/api/assistant-api/internal/options/audio.go
+++ b/api/assistant-api/internal/options/audio.go
@@ -41,6 +41,10 @@ const (
 const (
 	MicrophoneOptionBargeInTrigger          = "microphone.barge_in_trigger"
 	MicrophoneLegacyVADOptionBargeInTrigger = "microphone.vad.barge_in_trigger"
+	MicrophoneVADOptionConfidence           = "microphone.vad.confidence"
+	MicrophoneVADOptionStartSecs            = "microphone.vad.start_secs"
+	MicrophoneVADOptionStopSecs             = "microphone.vad.stop_secs"
+	MicrophoneVADOptionMinVolume            = "microphone.vad.min_volume"
 )
 
 const (

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
@@ -8,6 +8,7 @@ package internal_firered_vad
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,6 +17,7 @@ import (
 
 	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -29,6 +31,11 @@ const (
 	vadName          = "firered_vad"
 	envModelPathKey  = "FIRERED_VAD_MODEL_PATH"
 	defaultModelFile = "models/fireredvad_stream_vad_with_cache.onnx"
+
+	// Default configuration values aligned with Pipecat-style VAD options.
+	defaultConfidence = 0.7
+	defaultStartSecs  = 0.2
+	defaultStopSecs   = 0.2
 )
 
 // -----------------------------------------------------------------------------
@@ -106,6 +113,28 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	}
 	start := time.Now()
 
+	ppCfg := DefaultPostprocessorConfig()
+	if options.options != nil {
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionConfidence); err == nil {
+			ppCfg.SpeechThreshold = float32(v)
+		}
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionStartSecs); err == nil {
+			if v < 0 {
+				return nil, fmt.Errorf("invalid %s: should be a positive number", internal_options.MicrophoneVADOptionStartSecs)
+			}
+			ppCfg.MinSpeechFrame = vadDurationFrames(v)
+		}
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionStopSecs); err == nil {
+			if v < 0 {
+				return nil, fmt.Errorf("invalid %s: should be a positive number", internal_options.MicrophoneVADOptionStopSecs)
+			}
+			ppCfg.MinSilenceFrame = vadDurationFrames(v)
+		}
+	}
+	if ppCfg.SpeechThreshold < 0 || ppCfg.SpeechThreshold > 1 {
+		return nil, fmt.Errorf("invalid %s: should be in range [0, 1]", internal_options.MicrophoneVADOptionConfidence)
+	}
+
 	modelPath := resolveModelPath()
 	detector, err := NewDetector(modelPath)
 	if err != nil {
@@ -126,8 +155,6 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 		}
 		return nil, fmt.Errorf("firered_vad: failed to create detector: %w", err)
 	}
-
-	ppCfg := resolvePostprocessorConfig(options.options)
 
 	vad := &FireRedVAD{
 		logger:        options.logger,
@@ -294,10 +321,56 @@ func (v *FireRedVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRec
 
 	// Emit explicit interruption lifecycle events from VAD transitions.
 	if hasSpeechStart {
-		v.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventStart, speechStartAt)
+		v.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventStart,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechStarted,
+					Attributes: observability.Attributes{
+						"provider": vadName,
+						"event":    string(internal_type.InterruptionEventStart),
+						"start_at": fmt.Sprintf("%f", speechStartAt),
+						"end_at":   fmt.Sprintf("%f", speechEndAt),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 	if hasSpeechEnd {
-		v.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventEnd, speechEndAt)
+		v.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventEnd,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechEnded,
+					Attributes: observability.Attributes{
+						"provider": vadName,
+						"event":    string(internal_type.InterruptionEventEnd),
+						"start_at": fmt.Sprintf("%f", speechStartAt),
+						"end_at":   fmt.Sprintf("%f", speechEndAt),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 
 	return nil
@@ -358,59 +431,13 @@ func resolveModelPath() string {
 	return filepath.Join(filepath.Dir(currentFile), defaultModelFile)
 }
 
-func resolvePostprocessorConfig(options utils.Option) PostprocessorConfig {
-	cfg := DefaultPostprocessorConfig()
-	if options == nil {
-		return cfg
-	}
-	if v, err := options.GetFloat64("microphone.vad.threshold"); err == nil {
-		cfg.SpeechThreshold = float32(v)
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_silence_frame"); err == nil {
-		cfg.MinSilenceFrame = int(v)
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_speech_frame"); err == nil {
-		cfg.MinSpeechFrame = int(v)
-	}
-	return cfg
+func vadDurationFrames(durationSecs float64) int {
+	frameSecs := float64(frameShiftMs) / 1000
+	return int(math.RoundToEven(durationSecs / frameSecs))
 }
 
 func (v *FireRedVAD) isActive() bool {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	return !v.isTerminated && v.detector != nil
-}
-
-func (v *FireRedVAD) notifyInterruption(ctx context.Context, contextID string, event internal_type.InterruptionEvent, at float64) {
-	if v.onPacket == nil {
-		return
-	}
-	eventName := observability.VADSpeechStarted
-	if event == internal_type.InterruptionEventEnd {
-		eventName = observability.VADSpeechEnded
-	}
-	v.onPacket(ctx,
-		internal_type.InterruptionDetectedPacket{
-			ContextID: contextID,
-			Source:    internal_type.InterruptionSourceVad,
-			Event:     event,
-			StartAt:   at,
-			EndAt:     at,
-		},
-		internal_type.ObservabilityEventRecordPacket{
-			ContextID: contextID,
-			Scope:     internal_type.ObservabilityRecordScopeUserMessage,
-			Record: observability.RecordEvent{
-				Component: observability.ComponentVAD,
-				Event:     eventName,
-				Attributes: observability.Attributes{
-					"provider": vadName,
-					"event":    string(event),
-					"start_at": fmt.Sprintf("%f", at),
-					"end_at":   fmt.Sprintf("%f", at),
-				},
-				OccurredAt: time.Now(),
-			},
-		},
-	)
 }

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_benchmark_test.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_benchmark_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/rapidaai/pkg/commons"
 )
 
-func newBenchmarkFireRedVAD(b *testing.B, threshold float64) *FireRedVAD {
+func newBenchmarkFireRedVAD(b *testing.B, confidence float64) *FireRedVAD {
 	logger, _ := commons.NewApplicationLogger()
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
-	opts := newTestOptions(b, threshold)
+	opts := newTestOptions(b, confidence)
 
 	vad, err := newFireRedVADForTest(b.Context(), logger, callback, opts)
 	if err != nil {

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -23,17 +24,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestOptions(tb testing.TB, threshold float64) utils.Option {
+func newTestOptions(tb testing.TB, confidence float64) utils.Option {
 	opts := map[string]interface{}{}
-	if threshold >= 0 {
-		opts["microphone.vad.threshold"] = threshold
+	if confidence >= 0 {
+		opts[internal_options.MicrophoneVADOptionConfidence] = confidence
 	}
 	return opts
 }
 
-func newFireRedOrSkip(t *testing.T, threshold float64, cb func(ctx context.Context, pkt ...internal_type.Packet) error) *FireRedVAD {
+func newFireRedOrSkip(t *testing.T, confidence float64, cb func(ctx context.Context, pkt ...internal_type.Packet) error) *FireRedVAD {
 	logger, _ := commons.NewApplicationLogger()
-	opts := newTestOptions(t, threshold)
+	opts := newTestOptions(t, confidence)
 	vad, err := newFireRedVADForTest(t.Context(), logger, cb, opts)
 	if err != nil {
 		if os.IsNotExist(err) || strings.Contains(err.Error(), "no such file") {
@@ -70,7 +71,7 @@ func generateNoise(samples int) internal_type.UserAudioReceivedPacket {
 
 // Core functionality tests
 
-func TestNew_DefaultThreshold(t *testing.T) {
+func TestNew_DefaultConfig(t *testing.T) {
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
 
 	vad := newFireRedOrSkip(t, -1, callback)
@@ -78,6 +79,71 @@ func TestNew_DefaultThreshold(t *testing.T) {
 	assert.NotNil(t, vad.detector)
 	assert.NotNil(t, vad.fbank)
 	assert.NotNil(t, vad.postprocessor)
+	assert.Equal(t, float32(defaultConfidence), vad.postprocessor.cfg.SpeechThreshold)
+	assert.Equal(t, vadDurationFrames(defaultStartSecs), vad.postprocessor.cfg.MinSpeechFrame)
+	assert.Equal(t, vadDurationFrames(defaultStopSecs), vad.postprocessor.cfg.MinSilenceFrame)
+}
+
+func TestNew_OverridesConfig(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	logger, _ := commons.NewApplicationLogger()
+	opts := utils.Option{
+		internal_options.MicrophoneVADOptionConfidence: 0.55,
+		internal_options.MicrophoneVADOptionStartSecs:  0.1,
+		internal_options.MicrophoneVADOptionStopSecs:   0.4,
+	}
+
+	vad, err := newFireRedVADForTest(t.Context(), logger, callback, opts)
+	if err != nil {
+		if os.IsNotExist(err) || strings.Contains(err.Error(), "no such file") {
+			t.Skipf("firered model not available: %v", err)
+		}
+		require.NoError(t, err)
+	}
+	fr := vad.(*FireRedVAD)
+	t.Cleanup(func() { _ = fr.Close(context.Background()) })
+
+	assert.Equal(t, float32(0.55), fr.postprocessor.cfg.SpeechThreshold)
+	assert.Equal(t, 10, fr.postprocessor.cfg.MinSpeechFrame)
+	assert.Equal(t, 40, fr.postprocessor.cfg.MinSilenceFrame)
+}
+
+func TestNew_RejectsNegativeDurationBeforeFrameConversion(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+
+	for name, opts := range map[string]utils.Option{
+		"start_secs": {
+			internal_options.MicrophoneVADOptionStartSecs: -0.004,
+		},
+		"stop_secs": {
+			internal_options.MicrophoneVADOptionStopSecs: -0.004,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(WithContext(t.Context()), WithOnPacket(callback), WithOptions(opts))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "should be a positive number")
+		})
+	}
+}
+
+func TestPostprocessor_SpeechStartFrameIsNotBackdated(t *testing.T) {
+	pp := NewPostprocessor(PostprocessorConfig{
+		SmoothWindowSize: 1,
+		SpeechThreshold:  0.5,
+		MinSpeechFrame:   3,
+		MaxSpeechFrame:   2000,
+		MinSilenceFrame:  2,
+	})
+
+	pp.ProcessFrame(0)
+	pp.ProcessFrame(0)
+	pp.ProcessFrame(1)
+	pp.ProcessFrame(1)
+	result := pp.ProcessFrame(1)
+
+	require.True(t, result.IsSpeechStart)
+	assert.Equal(t, 3, result.SpeechStartFrame)
 }
 
 func TestFireRedVAD_Name(t *testing.T) {
@@ -349,25 +415,4 @@ func TestFireRedVAD_Process_PartialFrameCarry_NoDrop(t *testing.T) {
 	require.NoError(t, err)
 	// 428 total samples buffered -> one frame processed, shift by 160 samples -> 268 retained.
 	assert.Equal(t, 268, len(vad.audioBuf))
-}
-
-func TestFireRedVAD_NotifyInterruption_SetsEvent(t *testing.T) {
-	var got internal_type.InterruptionDetectedPacket
-	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
-		for _, p := range pkts {
-			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
-				got = ip
-			}
-		}
-		return nil
-	}
-
-	v := &FireRedVAD{onPacket: callback}
-	v.notifyInterruption(context.Background(), "ctx-test", internal_type.InterruptionEventEnd, 1.75)
-
-	assert.Equal(t, "ctx-test", got.ContextID)
-	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
-	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
-	assert.Equal(t, 1.75, got.StartAt)
-	assert.Equal(t, 1.75, got.EndAt)
 }

--- a/api/assistant-api/internal/vad/internal/firered_vad/postprocessor.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/postprocessor.go
@@ -34,22 +34,20 @@ type StreamVadFrameResult struct {
 type PostprocessorConfig struct {
 	SmoothWindowSize int
 	SpeechThreshold  float32
-	PadStartFrame    int
 	MinSpeechFrame   int
 	MaxSpeechFrame   int
 	MinSilenceFrame  int
 }
 
-// DefaultPostprocessorConfig returns the default configuration matching
-// the FireRedVAD streaming defaults.
+// DefaultPostprocessorConfig returns the default configuration exposed by the
+// provider options.
 func DefaultPostprocessorConfig() PostprocessorConfig {
 	return PostprocessorConfig{
 		SmoothWindowSize: 5,
-		SpeechThreshold:  0.4,
-		PadStartFrame:    5,
-		MinSpeechFrame:   8,
+		SpeechThreshold:  defaultConfidence,
+		MinSpeechFrame:   vadDurationFrames(defaultStartSecs),
 		MaxSpeechFrame:   2000,
-		MinSilenceFrame:  20,
+		MinSilenceFrame:  vadDurationFrames(defaultStopSecs),
 	}
 }
 
@@ -78,9 +76,6 @@ type Postprocessor struct {
 func NewPostprocessor(cfg PostprocessorConfig) *Postprocessor {
 	if cfg.SmoothWindowSize < 1 {
 		cfg.SmoothWindowSize = 1
-	}
-	if cfg.PadStartFrame < cfg.SmoothWindowSize {
-		cfg.PadStartFrame = cfg.SmoothWindowSize
 	}
 	return &Postprocessor{
 		cfg:                  cfg,
@@ -179,7 +174,7 @@ func (p *Postprocessor) stateTransition(isSpeech bool, result *StreamVadFrameRes
 			if p.speechCnt >= p.cfg.MinSpeechFrame {
 				p.state = stateSpeech
 				result.IsSpeechStart = true
-				startFrame := p.frameCnt - p.speechCnt + 1 - p.cfg.PadStartFrame
+				startFrame := p.frameCnt - p.speechCnt + 1
 				if startFrame < 1 {
 					startFrame = 1
 				}

--- a/api/assistant-api/internal/vad/internal/silero_vad/README.md
+++ b/api/assistant-api/internal/vad/internal/silero_vad/README.md
@@ -36,17 +36,19 @@ resampling is a no-op.
    - All graph optimizations enabled
    - If loading fails, return an error and abort initialization.
 
-3. Resolve the speech detection threshold:
+3. Resolve the Pipecat-style VAD parameters:
 
-   - Read `microphone.vad.threshold` from configuration.
-   - If not provided, default to `0.5`.
+   - Read `microphone.vad.confidence` from configuration.
+   - Read `microphone.vad.start_secs` from configuration.
+   - Read `microphone.vad.stop_secs` from configuration.
+   - If not provided, default to confidence `0.7`, start `0.2s`, stop `0.2s`.
 
 4. Initialize the detector with:
 
    - The loaded ONNX session
-   - The resolved detection threshold
-   - Min silence duration: 100 ms
-   - Speech pad: 30 ms
+   - The resolved confidence threshold
+   - Speech-start debounce duration
+   - Speech-stop debounce duration
 
 5. Create an internal audio processing configuration:
 
@@ -76,7 +78,7 @@ resampling is a no-op.
    - Slide a 512-sample window across the buffer (2 windows per 80 ms chunk).
    - For each window, prepend 64 samples of context from the previous window.
    - Run ONNX inference to get speech probability.
-   - Track speech onset/offset using threshold with 0.15 hysteresis.
+   - Track speech onset/offset using confidence plus start/stop debounce windows.
 
 5. If the buffer is smaller than one window (512 samples / 32 ms):
 

--- a/api/assistant-api/internal/vad/internal/silero_vad/detector.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/detector.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"fmt"
+	"math"
 	"unsafe"
 )
 
@@ -27,6 +28,12 @@ const (
 	// contextLen is the number of trailing samples saved from each window
 	// and prepended to the next inference call for temporal continuity.
 	contextLen = 64
+
+	// volumeWindowSecs matches Pipecat's VAD volume rolling window.
+	volumeWindowSecs = 0.4
+
+	// volumeSmoothingFactor matches Pipecat's exponential smoothing factor.
+	volumeSmoothingFactor = 0.2
 )
 
 // -----------------------------------------------------------------------------
@@ -39,14 +46,15 @@ type DetectorConfig struct {
 	ModelPath string
 	// SampleRate of the input audio. Must be 8000 or 16000.
 	SampleRate int
-	// Threshold is the speech probability above which we detect voice.
-	// Valid range: (0, 1). A good default is 0.5.
-	Threshold float32
-	// MinSilenceDurationMs is the minimum silence duration (ms) before
-	// splitting a speech segment.
-	MinSilenceDurationMs int
-	// SpeechPadMs is padding (ms) added around speech segment boundaries.
-	SpeechPadMs int
+	// Confidence is the speech probability above which we detect voice.
+	// Valid range: (0, 1). A good default is 0.7.
+	Confidence float32
+	// StartSecs is the duration of continuous speech before confirming a start.
+	StartSecs float64
+	// StopSecs is the duration of continuous non-speech before confirming an end.
+	StopSecs float64
+	// MinVolume is the minimum detector volume score required to classify speech.
+	MinVolume float64
 }
 
 func (c DetectorConfig) validate() error {
@@ -56,14 +64,17 @@ func (c DetectorConfig) validate() error {
 	if c.SampleRate != 8000 && c.SampleRate != 16000 {
 		return fmt.Errorf("invalid SampleRate: valid values are 8000 and 16000")
 	}
-	if c.Threshold <= 0 || c.Threshold >= 1 {
-		return fmt.Errorf("invalid Threshold: should be in range (0, 1)")
+	if c.Confidence <= 0 || c.Confidence >= 1 {
+		return fmt.Errorf("invalid Confidence: should be in range (0, 1)")
 	}
-	if c.MinSilenceDurationMs < 0 {
-		return fmt.Errorf("invalid MinSilenceDurationMs: should be a positive number")
+	if c.StartSecs < 0 {
+		return fmt.Errorf("invalid StartSecs: should be a positive number")
 	}
-	if c.SpeechPadMs < 0 {
-		return fmt.Errorf("invalid SpeechPadMs: should be a positive number")
+	if c.StopSecs < 0 {
+		return fmt.Errorf("invalid StopSecs: should be a positive number")
+	}
+	if c.MinVolume < 0 || c.MinVolume > 1 {
+		return fmt.Errorf("invalid MinVolume: should be in range [0, 1]")
 	}
 	return nil
 }
@@ -111,9 +122,14 @@ type Detector struct {
 	// Pending samples (< window size) carried across Detect calls
 	pending []float32
 
+	// Rolling volume state used as a second speech gate.
+	volumeWindow []float32
+	prevVolume   float64
+
 	// Speech segmentation state
 	currSample int
 	triggered  bool
+	tempStart  int
 	tempEnd    int
 }
 
@@ -125,8 +141,9 @@ func NewDetector(cfg DetectorConfig) (*Detector, error) {
 	}
 
 	sd := &Detector{
-		cfg:      cfg,
-		cStrings: map[string]*C.char{},
+		cfg:       cfg,
+		cStrings:  map[string]*C.char{},
+		tempStart: -1,
 	}
 
 	// Obtain the global ONNX Runtime API handle
@@ -235,8 +252,8 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 		return nil, nil
 	}
 
-	minSilenceSamples := sd.cfg.MinSilenceDurationMs * sd.cfg.SampleRate / 1000
-	speechPadSamples := sd.cfg.SpeechPadMs * sd.cfg.SampleRate / 1000
+	startSamples := vadDurationSamples(sd.cfg.StartSecs, windowSize, sd.cfg.SampleRate)
+	stopSamples := vadDurationSamples(sd.cfg.StopSecs, windowSize, sd.cfg.SampleRate)
 
 	var segments []Segment
 	fullWindows := len(input) / windowSize
@@ -248,38 +265,49 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 		}
 
 		sd.currSample += windowSize
+		windowStartSample := sd.currSample - windowSize
+		volume := sd.voiceVolumeScore(input[i : i+windowSize])
+		speaking := speechProb >= sd.cfg.Confidence && volume >= sd.cfg.MinVolume
 
 		// Speech resumes during a silence measurement — cancel the silence timer
-		if speechProb >= sd.cfg.Threshold && sd.tempEnd != 0 {
+		if speaking && sd.tempEnd != 0 {
 			sd.tempEnd = 0
 		}
 
 		// Speech onset
-		if speechProb >= sd.cfg.Threshold && !sd.triggered {
-			sd.triggered = true
-			speechStartAt := float64(sd.currSample-windowSize-speechPadSamples) / float64(sd.cfg.SampleRate)
-			if speechStartAt < 0 {
-				speechStartAt = 0
+		if speaking && !sd.triggered {
+			if sd.tempStart < 0 {
+				sd.tempStart = windowStartSample
 			}
+			if sd.currSample-sd.tempStart < startSamples {
+				continue
+			}
+			sd.triggered = true
+			speechStartAt := float64(sd.tempStart) / float64(sd.cfg.SampleRate)
+			sd.tempStart = -1
 			segments = append(segments, Segment{
 				SpeechStartAt: speechStartAt,
 				SpeechEndAt:   -1,
 			})
 		}
+		if !speaking && !sd.triggered {
+			sd.tempStart = -1
+		}
 
-		// Speech offset (with hysteresis)
-		if speechProb < (sd.cfg.Threshold-0.15) && sd.triggered {
+		// Speech offset
+		if !speaking && sd.triggered {
 			if sd.tempEnd == 0 {
-				sd.tempEnd = sd.currSample
+				sd.tempEnd = windowStartSample
 			}
 
 			// Not enough silence yet to split
-			if sd.currSample-sd.tempEnd < minSilenceSamples {
+			if sd.currSample-sd.tempEnd < stopSamples {
 				continue
 			}
 
-			speechEndAt := float64(sd.tempEnd+speechPadSamples) / float64(sd.cfg.SampleRate)
+			speechEndAt := float64(sd.tempEnd) / float64(sd.cfg.SampleRate)
 			sd.tempEnd = 0
+			sd.tempStart = -1
 			sd.triggered = false
 
 			// Speech started in a previous Detect() call — no start event in
@@ -306,6 +334,53 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 	return segments, nil
 }
 
+func vadDurationSamples(durationSecs float64, frameSamples, sampleRate int) int {
+	frameSecs := float64(frameSamples) / float64(sampleRate)
+	return int(math.RoundToEven(durationSecs/frameSecs)) * frameSamples
+}
+
+func (sd *Detector) voiceVolumeScore(pcm []float32) float64 {
+	windowSamples := int(volumeWindowSecs * float64(sd.cfg.SampleRate))
+	sd.volumeWindow = append(sd.volumeWindow, pcm...)
+	if len(sd.volumeWindow) > windowSamples {
+		sd.volumeWindow = sd.volumeWindow[len(sd.volumeWindow)-windowSamples:]
+	}
+	if len(sd.volumeWindow) < windowSamples {
+		return 0
+	}
+
+	score := sd.volumeScore()
+	smoothed := sd.prevVolume + volumeSmoothingFactor*(score-sd.prevVolume)
+	sd.prevVolume = smoothed
+	return smoothed
+}
+
+func (sd *Detector) volumeScore() float64 {
+	var sum float64
+	for _, sample := range sd.volumeWindow {
+		value := float64(sample)
+		sum += value * value
+	}
+	if sum <= 0 {
+		return 0
+	}
+
+	rms := math.Sqrt(sum / float64(len(sd.volumeWindow)))
+	if rms <= 0 {
+		return 0
+	}
+
+	dbfs := 20 * math.Log10(rms)
+	score := (dbfs + 110) / 100
+	if score < 0 {
+		return 0
+	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}
+
 // Reset clears all stateful data: hidden state, context buffer, and
 // speech segmentation counters. Use this to reuse the detector for
 // a new audio stream without re-loading the model.
@@ -315,7 +390,10 @@ func (sd *Detector) Reset() {
 	}
 	sd.currSample = 0
 	sd.triggered = false
+	sd.tempStart = -1
 	sd.tempEnd = 0
+	sd.volumeWindow = sd.volumeWindow[:0]
+	sd.prevVolume = 0
 	for i := range sd.state {
 		sd.state[i] = 0
 	}

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
@@ -17,6 +17,7 @@ import (
 	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
 	internal_audio_resampler "github.com/rapidaai/api/assistant-api/internal/audio/resampler"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -30,11 +31,11 @@ const (
 	// vadName is the identifier for this VAD implementation
 	vadName = "silero_vad"
 
-	// Default configuration values — aligned with FireRedVAD defaults
-	// (20 frames × 10 ms = 200 ms silence, 8 frames × 10 ms = 80 ms pad)
-	defaultThreshold            = 0.5
-	defaultMinSilenceDurationMs = 200
-	defaultSpeechPadMs          = 80
+	// Default configuration values aligned with Pipecat VADParams.
+	defaultConfidence = 0.7
+	defaultStartSecs  = 0.2
+	defaultStopSecs   = 0.2
+	defaultMinVolume  = 0.6
 
 	// Environment variable for model path
 	envModelPathKey = "SILERO_MODEL_PATH"
@@ -332,12 +333,59 @@ func (s *SileroVAD) Execute(ctx context.Context, pkt internal_type.UserAudioRece
 		}
 	}
 
-	// Emit explicit interruption lifecycle events from VAD transitions.
 	if hasSpeechStart {
-		s.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventStart, speechStartAt, len(segments))
+		s.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventStart,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechStarted,
+					Attributes: observability.Attributes{
+						"provider":      vadName,
+						"event":         string(internal_type.InterruptionEventStart),
+						"start_at":      fmt.Sprintf("%f", speechStartAt),
+						"end_at":        fmt.Sprintf("%f", speechEndAt),
+						"segment_count": fmt.Sprintf("%d", len(segments)),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 	if hasSpeechEnd {
-		s.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventEnd, speechEndAt, len(segments))
+		s.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventEnd,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechEnded,
+					Attributes: observability.Attributes{
+						"provider":      vadName,
+						"event":         string(internal_type.InterruptionEventEnd),
+						"start_at":      fmt.Sprintf("%f", speechStartAt),
+						"end_at":        fmt.Sprintf("%f", speechEndAt),
+						"segment_count": fmt.Sprintf("%d", len(segments)),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 
 	return nil
@@ -395,15 +443,31 @@ func (s *SileroVAD) Close(ctx context.Context) error {
 // createDetector initializes the Silero speech detector with configuration.
 func createDetector(options utils.Option) (*Detector, error) {
 	modelPath := resolveModelPath()
-	threshold := resolveThreshold(options)
 
 	config := DetectorConfig{
-		ModelPath:            modelPath,
-		SampleRate:           16000, // Silero requires 16kHz
-		Threshold:            float32(threshold),
-		MinSilenceDurationMs: resolveMinSilenceDurationMs(options),
-		SpeechPadMs:          resolveSpeechPadMs(options),
+		ModelPath:  modelPath,
+		SampleRate: 16000, // Silero requires 16kHz
+		Confidence: defaultConfidence,
+		StartSecs:  defaultStartSecs,
+		StopSecs:   defaultStopSecs,
+		MinVolume:  defaultMinVolume,
 	}
+
+	if options != nil {
+		if confidence, err := options.GetFloat64(internal_options.MicrophoneVADOptionConfidence); err == nil {
+			config.Confidence = float32(confidence)
+		}
+		if startSecs, err := options.GetFloat64(internal_options.MicrophoneVADOptionStartSecs); err == nil {
+			config.StartSecs = startSecs
+		}
+		if stopSecs, err := options.GetFloat64(internal_options.MicrophoneVADOptionStopSecs); err == nil {
+			config.StopSecs = stopSecs
+		}
+		if minVolume, err := options.GetFloat64(internal_options.MicrophoneVADOptionMinVolume); err == nil {
+			config.MinVolume = minVolume
+		}
+	}
+
 	return NewDetector(config)
 }
 
@@ -415,45 +479,6 @@ func resolveModelPath() string {
 
 	_, currentFile, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(currentFile), defaultModelFile)
-}
-
-// resolveThreshold extracts threshold from options or returns default.
-func resolveThreshold(options utils.Option) float64 {
-	if options == nil {
-		return defaultThreshold
-	}
-
-	if threshold, err := options.GetFloat64("microphone.vad.threshold"); err == nil {
-		return threshold
-	}
-
-	return defaultThreshold
-}
-
-// resolveMinSilenceDurationMs extracts min silence duration from options.
-// The option key uses frame count (consistent with FireRedVAD config);
-// each frame is 10 ms, so we multiply by 10 to get milliseconds.
-func resolveMinSilenceDurationMs(options utils.Option) int {
-	if options == nil {
-		return defaultMinSilenceDurationMs
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_silence_frame"); err == nil {
-		return int(v) * 10
-	}
-	return defaultMinSilenceDurationMs
-}
-
-// resolveSpeechPadMs extracts speech pad duration from options.
-// The option key uses frame count (consistent with FireRedVAD config);
-// each frame is 10 ms, so we multiply by 10 to get milliseconds.
-func resolveSpeechPadMs(options utils.Option) int {
-	if options == nil {
-		return defaultSpeechPadMs
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_speech_frame"); err == nil {
-		return int(v) * 10
-	}
-	return defaultSpeechPadMs
 }
 
 // isActive checks if the VAD is still operational.
@@ -486,39 +511,4 @@ func (s *SileroVAD) detectSafely(samples []float32) ([]Segment, bool, error) {
 	}
 
 	return segments, s.detector.triggered, nil
-}
-
-// notifyInterruption emits a VAD interruption lifecycle event packet.
-func (s *SileroVAD) notifyInterruption(ctx context.Context, contextID string, event internal_type.InterruptionEvent, at float64, segmentCount int) {
-	if s.onPacket != nil {
-		eventName := observability.VADSpeechStarted
-		if event == internal_type.InterruptionEventEnd {
-			eventName = observability.VADSpeechEnded
-		}
-		_ = s.onPacket(ctx,
-			internal_type.InterruptionDetectedPacket{
-				ContextID: contextID,
-				Source:    internal_type.InterruptionSourceVad,
-				Event:     event,
-				StartAt:   at,
-				EndAt:     at,
-			},
-			internal_type.ObservabilityEventRecordPacket{
-				ContextID: contextID,
-				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
-				Record: observability.RecordEvent{
-					Component: observability.ComponentVAD,
-					Event:     eventName,
-					Attributes: observability.Attributes{
-						"provider":      vadName,
-						"event":         string(event),
-						"start_at":      fmt.Sprintf("%f", at),
-						"end_at":        fmt.Sprintf("%f", at),
-						"segment_count": fmt.Sprintf("%d", segmentCount),
-					},
-					OccurredAt: time.Now(),
-				},
-			},
-		)
-	}
 }

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -28,7 +29,7 @@ import (
 func newTestOptions(tb testing.TB, threshold float64) utils.Option {
 	opts := map[string]interface{}{}
 	if threshold >= 0 {
-		opts["microphone.vad.threshold"] = threshold
+		opts[internal_options.MicrophoneVADOptionConfidence] = threshold
 	}
 	return opts
 }
@@ -394,25 +395,4 @@ func TestSileroVAD_Process_RemainderCarry(t *testing.T) {
 	err = vad.Execute(context.Background(), generateSilence(448))
 	require.NoError(t, err)
 	assert.Equal(t, 2048, vad.detector.currSample, "64 carry + 448 samples should process one more window")
-}
-
-func TestSileroVAD_NotifyInterruption_SetsEvent(t *testing.T) {
-	var got internal_type.InterruptionDetectedPacket
-	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
-		for _, p := range pkts {
-			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
-				got = ip
-			}
-		}
-		return nil
-	}
-
-	s := &SileroVAD{onPacket: callback}
-	s.notifyInterruption(context.Background(), "ctx-test", internal_type.InterruptionEventEnd, 2.75, 1)
-
-	assert.Equal(t, "ctx-test", got.ContextID)
-	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
-	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
-	assert.Equal(t, 2.75, got.StartAt)
-	assert.Equal(t, 2.75, got.EndAt)
 }

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
@@ -8,11 +8,13 @@ package internal_ten_vad
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
 	internal_audio "github.com/rapidaai/api/assistant-api/internal/audio"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -28,13 +30,10 @@ const (
 	// TEN VAD processes fixed-size frames. hop_size=256 = 16ms at 16kHz.
 	defaultHopSize = 256
 
-	// Default speech detection threshold [0.0, 1.0]
-	defaultThreshold = 0.5
-
-	// Default durations — aligned with FireRedVAD defaults
-	// (20 frames × 10 ms = 200 ms silence, 8 frames × 10 ms = 80 ms pad)
-	defaultMinSilenceDurationMs = 200
-	defaultSpeechPadMs          = 80
+	// Default configuration values aligned with Pipecat-style VAD options.
+	defaultConfidence = 0.7
+	defaultStartSecs  = 0.2
+	defaultStopSecs   = 0.2
 )
 
 // -----------------------------------------------------------------------------
@@ -62,14 +61,15 @@ type TenVAD struct {
 	// Frame-level state for segment tracking
 	currSample int
 	triggered  bool
+	tempStart  int
 	tempEnd    int
 	pending    []int16
 
 	// Configuration
-	hopSize              int
-	threshold            float32
-	minSilenceDurationMs int
-	speechPadMs          int
+	hopSize    int
+	confidence float32
+	startSecs  float64
+	stopSecs   float64
 }
 
 type options struct {
@@ -123,9 +123,29 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	start := time.Now()
 
 	hopSize := defaultHopSize
-	threshold := resolveThreshold(options.options)
+	confidence := defaultConfidence
+	startSecs := defaultStartSecs
+	stopSecs := defaultStopSecs
+	if options.options != nil {
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionConfidence); err == nil {
+			confidence = v
+		}
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionStartSecs); err == nil {
+			startSecs = v
+		}
+		if v, err := options.options.GetFloat64(internal_options.MicrophoneVADOptionStopSecs); err == nil {
+			stopSecs = v
+		}
+	}
 
-	detector, err := NewDetector(hopSize, float32(threshold))
+	if startSecs < 0 {
+		return nil, fmt.Errorf("invalid %s: should be a positive number", internal_options.MicrophoneVADOptionStartSecs)
+	}
+	if stopSecs < 0 {
+		return nil, fmt.Errorf("invalid %s: should be a positive number", internal_options.MicrophoneVADOptionStopSecs)
+	}
+
+	detector, err := NewDetector(hopSize, float32(confidence))
 	if err != nil {
 		if options.onPacket != nil {
 			_ = options.onPacket(options.ctx, internal_type.ObservabilityLogRecordPacket{
@@ -146,16 +166,17 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	}
 
 	tv := &TenVAD{
-		logger:               options.logger,
-		onPacket:             options.onPacket,
-		opts:                 options.options,
-		detector:             detector,
-		hopSize:              hopSize,
-		threshold:            float32(threshold),
-		minSilenceDurationMs: resolveMinSilenceDurationMs(options.options),
-		speechPadMs:          resolveSpeechPadMs(options.options),
-		isTerminated:         false,
-		vadStartedAt:         time.Now(),
+		logger:       options.logger,
+		onPacket:     options.onPacket,
+		opts:         options.options,
+		detector:     detector,
+		hopSize:      hopSize,
+		confidence:   float32(confidence),
+		startSecs:    startSecs,
+		stopSecs:     stopSecs,
+		tempStart:    -1,
+		isTerminated: false,
+		vadStartedAt: time.Now(),
 	}
 
 	// Auto-close on context cancellation
@@ -269,10 +290,58 @@ func (t *TenVAD) Execute(ctx context.Context, pkt internal_type.UserAudioReceive
 
 	// Emit explicit interruption lifecycle events from VAD transitions.
 	if hasSpeechStart {
-		t.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventStart, speechStartAt, len(segments))
+		t.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventStart,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechStarted,
+					Attributes: observability.Attributes{
+						"provider":      vadName,
+						"event":         string(internal_type.InterruptionEventStart),
+						"start_at":      fmt.Sprintf("%f", speechStartAt),
+						"end_at":        fmt.Sprintf("%f", speechEndAt),
+						"segment_count": fmt.Sprintf("%d", len(segments)),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 	if hasSpeechEnd {
-		t.notifyInterruption(ctx, pkt.ContextID, internal_type.InterruptionEventEnd, speechEndAt, len(segments))
+		t.onPacket(ctx,
+			internal_type.InterruptionDetectedPacket{
+				ContextID: pkt.ContextID,
+				Source:    internal_type.InterruptionSourceVad,
+				Event:     internal_type.InterruptionEventEnd,
+				StartAt:   speechStartAt,
+				EndAt:     speechEndAt,
+			},
+			internal_type.ObservabilityEventRecordPacket{
+				ContextID: pkt.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+				Record: observability.RecordEvent{
+					Component: observability.ComponentVAD,
+					Event:     observability.VADSpeechEnded,
+					Attributes: observability.Attributes{
+						"provider":      vadName,
+						"event":         string(internal_type.InterruptionEventEnd),
+						"start_at":      fmt.Sprintf("%f", speechStartAt),
+						"end_at":        fmt.Sprintf("%f", speechEndAt),
+						"segment_count": fmt.Sprintf("%d", len(segments)),
+					},
+					OccurredAt: time.Now(),
+				},
+			},
+		)
 	}
 
 	return nil
@@ -350,8 +419,8 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 	}
 
 	sampleRate := 16000
-	minSilenceSamples := t.minSilenceDurationMs * sampleRate / 1000
-	speechPadSamples := t.speechPadMs * sampleRate / 1000
+	startSamples := vadDurationSamples(t.startSecs, t.hopSize, sampleRate)
+	stopSamples := vadDurationSamples(t.stopSecs, t.hopSize, sampleRate)
 
 	input := samples
 	if len(t.pending) > 0 {
@@ -384,34 +453,44 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 		}
 
 		t.currSample += t.hopSize
+		windowStartSample := t.currSample - t.hopSize
+		speaking := probability >= t.confidence
 
 		// Speech resumes during silence measurement
-		if probability >= t.threshold && t.tempEnd != 0 {
+		if speaking && t.tempEnd != 0 {
 			t.tempEnd = 0
 		}
 
 		// Speech onset
-		if probability >= t.threshold && !t.triggered {
-			t.triggered = true
-			speechStartAt := float64(t.currSample-t.hopSize-speechPadSamples) / float64(sampleRate)
-			if speechStartAt < 0 {
-				speechStartAt = 0
+		if speaking && !t.triggered {
+			if t.tempStart < 0 {
+				t.tempStart = windowStartSample
 			}
+			if t.currSample-t.tempStart < startSamples {
+				continue
+			}
+			t.triggered = true
+			speechStartAt := float64(t.tempStart) / float64(sampleRate)
+			t.tempStart = -1
 			segments = append(segments, segment{startAt: speechStartAt, endAt: -1})
 		}
+		if !speaking && !t.triggered {
+			t.tempStart = -1
+		}
 
-		// Speech offset (with hysteresis)
-		if probability < (t.threshold-0.15) && t.triggered {
+		// Speech offset
+		if !speaking && t.triggered {
 			if t.tempEnd == 0 {
-				t.tempEnd = t.currSample
+				t.tempEnd = windowStartSample
 			}
 
-			if t.currSample-t.tempEnd < minSilenceSamples {
+			if t.currSample-t.tempEnd < stopSamples {
 				continue
 			}
 
-			speechEndAt := float64(t.tempEnd+speechPadSamples) / float64(sampleRate)
+			speechEndAt := float64(t.tempEnd) / float64(sampleRate)
 			t.tempEnd = 0
+			t.tempStart = -1
 			t.triggered = false
 
 			// Speech started in a previous call — onset already reported
@@ -426,72 +505,7 @@ func (t *TenVAD) processFrames(samples []int16) ([]segment, error) {
 	return segments, nil
 }
 
-func (t *TenVAD) notifyInterruption(ctx context.Context, contextID string, event internal_type.InterruptionEvent, at float64, segmentCount int) {
-	if t.onPacket != nil {
-		eventName := observability.VADSpeechStarted
-		if event == internal_type.InterruptionEventEnd {
-			eventName = observability.VADSpeechEnded
-		}
-		_ = t.onPacket(ctx,
-			internal_type.InterruptionDetectedPacket{
-				ContextID: contextID,
-				Source:    internal_type.InterruptionSourceVad,
-				Event:     event,
-				StartAt:   at,
-				EndAt:     at,
-			},
-			internal_type.ObservabilityEventRecordPacket{
-				ContextID: contextID,
-				Scope:     internal_type.ObservabilityRecordScopeUserMessage,
-				Record: observability.RecordEvent{
-					Component: observability.ComponentVAD,
-					Event:     eventName,
-					Attributes: observability.Attributes{
-						"provider":      vadName,
-						"event":         string(event),
-						"start_at":      fmt.Sprintf("%f", at),
-						"end_at":        fmt.Sprintf("%f", at),
-						"segment_count": fmt.Sprintf("%d", segmentCount),
-					},
-					OccurredAt: time.Now(),
-				},
-			},
-		)
-	}
-}
-
-func resolveThreshold(options utils.Option) float64 {
-	if options == nil {
-		return defaultThreshold
-	}
-	if threshold, err := options.GetFloat64("microphone.vad.threshold"); err == nil {
-		return threshold
-	}
-	return defaultThreshold
-}
-
-// resolveMinSilenceDurationMs extracts min silence duration from options.
-// The option key uses frame count (consistent with FireRedVAD config);
-// each frame is 10 ms, so we multiply by 10 to get milliseconds.
-func resolveMinSilenceDurationMs(options utils.Option) int {
-	if options == nil {
-		return defaultMinSilenceDurationMs
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_silence_frame"); err == nil {
-		return int(v) * 10
-	}
-	return defaultMinSilenceDurationMs
-}
-
-// resolveSpeechPadMs extracts speech pad duration from options.
-// The option key uses frame count (consistent with FireRedVAD config);
-// each frame is 10 ms, so we multiply by 10 to get milliseconds.
-func resolveSpeechPadMs(options utils.Option) int {
-	if options == nil {
-		return defaultSpeechPadMs
-	}
-	if v, err := options.GetFloat64("microphone.vad.min_speech_frame"); err == nil {
-		return int(v) * 10
-	}
-	return defaultSpeechPadMs
+func vadDurationSamples(durationSecs float64, frameSamples, sampleRate int) int {
+	frameSecs := float64(frameSamples) / float64(sampleRate)
+	return int(math.RoundToEven(durationSecs/frameSecs)) * frameSamples
 }

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_benchmark_test.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_benchmark_test.go
@@ -18,10 +18,10 @@ import (
 
 // Benchmark helpers
 
-func newBenchmarkTenVAD(b *testing.B, threshold float64) *TenVAD {
+func newBenchmarkTenVAD(b *testing.B, confidence float64) *TenVAD {
 	logger, _ := commons.NewApplicationLogger()
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
-	opts := newTestOptions(b, threshold)
+	opts := newTestOptions(b, confidence)
 
 	vad, err := newTenVADForTest(b.Context(), logger, callback, opts)
 	if err != nil {
@@ -180,9 +180,9 @@ func BenchmarkTenVAD_Process_ChunkSize_2s(b *testing.B) {
 	}
 }
 
-// Different thresholds
+// Different confidence values
 
-func BenchmarkTenVAD_Process_Threshold_0_1(b *testing.B) {
+func BenchmarkTenVAD_Process_Confidence_0_1(b *testing.B) {
 	vad := newBenchmarkTenVAD(b, 0.1)
 	data := generateBenchmarkSineWave(8000, 440, 0.8)
 
@@ -193,7 +193,7 @@ func BenchmarkTenVAD_Process_Threshold_0_1(b *testing.B) {
 	}
 }
 
-func BenchmarkTenVAD_Process_Threshold_0_5(b *testing.B) {
+func BenchmarkTenVAD_Process_Confidence_0_5(b *testing.B) {
 	vad := newBenchmarkTenVAD(b, 0.5)
 	data := generateBenchmarkSineWave(8000, 440, 0.8)
 
@@ -204,7 +204,7 @@ func BenchmarkTenVAD_Process_Threshold_0_5(b *testing.B) {
 	}
 }
 
-func BenchmarkTenVAD_Process_Threshold_0_9(b *testing.B) {
+func BenchmarkTenVAD_Process_Confidence_0_9(b *testing.B) {
 	vad := newBenchmarkTenVAD(b, 0.9)
 	data := generateBenchmarkSineWave(8000, 440, 0.8)
 

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_test.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_options "github.com/rapidaai/api/assistant-api/internal/options"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
@@ -21,17 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestOptions(tb testing.TB, threshold float64) utils.Option {
+func newTestOptions(tb testing.TB, confidence float64) utils.Option {
 	opts := map[string]interface{}{}
-	if threshold >= 0 {
-		opts["microphone.vad.threshold"] = threshold
+	if confidence >= 0 {
+		opts[internal_options.MicrophoneVADOptionConfidence] = confidence
 	}
 	return opts
 }
 
-func newTenVADOrSkip(t *testing.T, threshold float64, cb func(ctx context.Context, pkt ...internal_type.Packet) error) *TenVAD {
+func newTenVADOrSkip(t *testing.T, confidence float64, cb func(ctx context.Context, pkt ...internal_type.Packet) error) *TenVAD {
 	logger, _ := commons.NewApplicationLogger()
-	opts := newTestOptions(t, threshold)
+	opts := newTestOptions(t, confidence)
 	vad, err := newTenVADForTest(t.Context(), logger, cb, opts)
 	if err != nil {
 		t.Skipf("ten_vad library not available: %v", err)
@@ -65,12 +66,36 @@ func generateNoise(samples int) internal_type.UserAudioReceivedPacket {
 
 // Core functionality tests
 
-func TestNew_DefaultThreshold(t *testing.T) {
+func TestNew_DefaultConfig(t *testing.T) {
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }
 
 	vad := newTenVADOrSkip(t, -1, callback)
 
 	assert.NotNil(t, vad.detector)
+	assert.Equal(t, float32(defaultConfidence), vad.confidence)
+	assert.Equal(t, defaultStartSecs, vad.startSecs)
+	assert.Equal(t, defaultStopSecs, vad.stopSecs)
+}
+
+func TestNew_OverridesConfig(t *testing.T) {
+	callback := func(context.Context, ...internal_type.Packet) error { return nil }
+	logger, _ := commons.NewApplicationLogger()
+	opts := utils.Option{
+		internal_options.MicrophoneVADOptionConfidence: 0.55,
+		internal_options.MicrophoneVADOptionStartSecs:  0.1,
+		internal_options.MicrophoneVADOptionStopSecs:   0.4,
+	}
+
+	vad, err := newTenVADForTest(t.Context(), logger, callback, opts)
+	if err != nil {
+		t.Skipf("ten_vad library not available: %v", err)
+	}
+	tv := vad.(*TenVAD)
+	t.Cleanup(func() { _ = tv.Close(context.Background()) })
+
+	assert.Equal(t, float32(0.55), tv.confidence)
+	assert.Equal(t, 0.1, tv.startSecs)
+	assert.Equal(t, 0.4, tv.stopSecs)
 }
 
 func TestTenVAD_Name(t *testing.T) {
@@ -333,25 +358,4 @@ func TestTenVAD_Process_PartialFrameCarry_NoDrop(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 256, vad.currSample)
 	assert.Equal(t, 72, len(vad.pending))
-}
-
-func TestTenVAD_NotifyInterruption_SetsEvent(t *testing.T) {
-	var got internal_type.InterruptionDetectedPacket
-	callback := func(_ context.Context, pkts ...internal_type.Packet) error {
-		for _, p := range pkts {
-			if ip, ok := p.(internal_type.InterruptionDetectedPacket); ok {
-				got = ip
-			}
-		}
-		return nil
-	}
-
-	v := &TenVAD{onPacket: callback}
-	v.notifyInterruption(context.Background(), "ctx-test", internal_type.InterruptionEventEnd, 3.25, 1)
-
-	assert.Equal(t, "ctx-test", got.ContextID)
-	assert.Equal(t, internal_type.InterruptionSourceVad, got.Source)
-	assert.Equal(t, internal_type.InterruptionEventEnd, got.Event)
-	assert.Equal(t, 3.25, got.StartAt)
-	assert.Equal(t, 3.25, got.EndAt)
 }

--- a/ui/src/app/components/providers/__tests__/audio-input-advanced-defaults-parity.test.ts
+++ b/ui/src/app/components/providers/__tests__/audio-input-advanced-defaults-parity.test.ts
@@ -23,19 +23,20 @@ const {
 
 const backendVadDefaults: Record<string, Record<string, string>> = {
   silero_vad: {
-    'microphone.vad.threshold': '0.5',
-    'microphone.vad.min_silence_frame': '20',
-    'microphone.vad.min_speech_frame': '8',
+    'microphone.vad.confidence': '0.7',
+    'microphone.vad.start_secs': '0.2',
+    'microphone.vad.stop_secs': '0.2',
+    'microphone.vad.min_volume': '0.6',
   },
   ten_vad: {
-    'microphone.vad.threshold': '0.5',
-    'microphone.vad.min_silence_frame': '20',
-    'microphone.vad.min_speech_frame': '8',
+    'microphone.vad.confidence': '0.7',
+    'microphone.vad.start_secs': '0.2',
+    'microphone.vad.stop_secs': '0.2',
   },
   firered_vad: {
-    'microphone.vad.threshold': '0.4',
-    'microphone.vad.min_silence_frame': '20',
-    'microphone.vad.min_speech_frame': '8',
+    'microphone.vad.confidence': '0.7',
+    'microphone.vad.start_secs': '0.2',
+    'microphone.vad.stop_secs': '0.2',
   },
 };
 
@@ -157,9 +158,9 @@ describe('Audio input advanced defaults parity', () => {
         createMetadata('rapida.credential_id', 'cred'),
         createMetadata('listen.model', 'nova-3'),
         createMetadata('microphone.vad.provider', 'ten_vad'),
-        createMetadata('microphone.vad.threshold', '0.77'),
-        createMetadata('microphone.vad.min_silence_frame', '15'),
-        createMetadata('microphone.vad.min_speech_frame', '4'),
+        createMetadata('microphone.vad.confidence', '0.77'),
+        createMetadata('microphone.vad.start_secs', '0.04'),
+        createMetadata('microphone.vad.stop_secs', '0.15'),
       ];
 
       const expected = expectedGetDefaultVADConfig(
@@ -194,7 +195,7 @@ describe('Audio input advanced defaults parity', () => {
   it('VAD provider key is always updated to the selected provider', () => {
     const seed = [
       createMetadata('microphone.vad.provider', 'ten_vad'),
-      createMetadata('microphone.vad.threshold', '0.3'),
+      createMetadata('microphone.vad.confidence', '0.3'),
     ];
     const updated = GetDefaultVADConfig('silero_vad', cloneMetadata(seed));
 
@@ -253,7 +254,10 @@ describe('Audio input advanced defaults parity', () => {
     expect(getMetadataValue(defaults, 'microphone.barge_in_trigger')).toBe(
       'vad',
     );
-    expect(getMetadataValue(defaults, 'microphone.vad.threshold')).toBe('0.5');
+    expect(getMetadataValue(defaults, 'microphone.vad.confidence')).toBe('0.7');
+    expect(getMetadataValue(defaults, 'microphone.vad.start_secs')).toBe('0.2');
+    expect(getMetadataValue(defaults, 'microphone.vad.stop_secs')).toBe('0.2');
+    expect(getMetadataValue(defaults, 'microphone.vad.min_volume')).toBe('0.6');
     expect(getMetadataValue(defaults, 'microphone.eos.provider')).toBe(
       'pipecat_smart_turn_eos',
     );
@@ -328,7 +332,7 @@ describe('Audio input advanced defaults parity', () => {
     const seed = [
       createMetadata('listen.model', 'nova-3'),
       createMetadata('microphone.eos.fallback_timeout', '700'),
-      createMetadata('microphone.vad.threshold', '0.6'),
+      createMetadata('microphone.vad.confidence', '0.6'),
       createMetadata('microphone.denoising.provider', 'rn_noise'),
     ];
 

--- a/ui/src/app/components/providers/speech-to-text/provider.tsx
+++ b/ui/src/app/components/providers/speech-to-text/provider.tsx
@@ -166,7 +166,10 @@ export const GetDefaultMicrophoneConfig = (
     'microphone.barge_in_trigger'?: string;
     'microphone.vad.provider'?: string;
     'microphone.vad.barge_in_trigger'?: string;
-    'microphone.vad.threshold'?: string;
+    'microphone.vad.confidence'?: string;
+    'microphone.vad.start_secs'?: string;
+    'microphone.vad.stop_secs'?: string;
+    'microphone.vad.min_volume'?: string;
   },
 ): Metadata[] => {
   const upsertMetadata = (
@@ -207,8 +210,20 @@ export const GetDefaultMicrophoneConfig = (
         'vad',
     },
     {
-      key: 'microphone.vad.threshold',
-      value: defaults?.['microphone.vad.threshold'] ?? '0.5',
+      key: 'microphone.vad.confidence',
+      value: defaults?.['microphone.vad.confidence'] ?? '0.7',
+    },
+    {
+      key: 'microphone.vad.start_secs',
+      value: defaults?.['microphone.vad.start_secs'] ?? '0.2',
+    },
+    {
+      key: 'microphone.vad.stop_secs',
+      value: defaults?.['microphone.vad.stop_secs'] ?? '0.2',
+    },
+    {
+      key: 'microphone.vad.min_volume',
+      value: defaults?.['microphone.vad.min_volume'] ?? '0.6',
     },
   ];
 

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-audio-input.design.test.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-audio-input.design.test.tsx
@@ -114,13 +114,13 @@ describe('ConfigureAudioInputProvider design integration', () => {
       createMetadata('listen.model', 'nova-3'),
       createMetadata('microphone.eos.fallback_timeout', '900'),
       createMetadata('microphone.barge_in_trigger', 'word'),
-      createMetadata('microphone.vad.threshold', '0.7'),
+      createMetadata('microphone.vad.confidence', '0.7'),
       createMetadata('microphone.denoising.provider', 'rn_noise'),
       createMetadata('speaker.model', 'sonic'),
     ];
     const microphoneDefaults = [
       createMetadata('microphone.eos.fallback_timeout', '700'),
-      createMetadata('microphone.vad.threshold', '0.6'),
+      createMetadata('microphone.vad.confidence', '0.6'),
       createMetadata('microphone.denoising.provider', 'rn_noise'),
     ];
     const sttDefaults = [createMetadata('listen.model', 'whisper-large-v3-turbo')];
@@ -144,7 +144,7 @@ describe('ConfigureAudioInputProvider design integration', () => {
       [
         'microphone.eos.fallback_timeout',
         'microphone.barge_in_trigger',
-        'microphone.vad.threshold',
+        'microphone.vad.confidence',
         'microphone.denoising.provider',
       ].sort(),
     );

--- a/ui/src/providers/__tests__/config-defaults.test.ts
+++ b/ui/src/providers/__tests__/config-defaults.test.ts
@@ -148,8 +148,8 @@ const scopedVadConfig: ProviderConfig = {
   vad: {
     parameters: [
       {
-        key: 'microphone.vad.threshold',
-        label: 'VAD Threshold',
+        key: 'microphone.vad.confidence',
+        label: 'VAD Confidence',
         type: 'slider',
         default: '0.6',
       },
@@ -351,8 +351,8 @@ describe('getDefaultsFromConfig', () => {
       createMetadata('rapida.credential_id', 'cred-1'),
       createMetadata('listen.model', 'nova-3'),
       createMetadata('microphone.vad.provider', 'ten_vad'),
-      createMetadata('microphone.vad.threshold', '0.8'),
-      createMetadata('microphone.vad.min_silence_frame', '12'),
+      createMetadata('microphone.vad.confidence', '0.8'),
+      createMetadata('microphone.vad.stop_secs', '0.12'),
     ];
 
     const result = getDefaultsFromConfig(
@@ -368,8 +368,8 @@ describe('getDefaultsFromConfig', () => {
 
     expect(findMeta(result, 'listen.model')?.getValue()).toBe('nova-3');
     expect(findMeta(result, 'rapida.credential_id')?.getValue()).toBe('cred-1');
-    expect(findMeta(result, 'microphone.vad.threshold')?.getValue()).toBe('0.8');
-    expect(findMeta(result, 'microphone.vad.min_silence_frame')).toBeUndefined();
+    expect(findMeta(result, 'microphone.vad.confidence')?.getValue()).toBe('0.8');
+    expect(findMeta(result, 'microphone.vad.stop_secs')).toBeUndefined();
   });
 });
 

--- a/ui/src/providers/__tests__/provider-stt-comparison.test.ts
+++ b/ui/src/providers/__tests__/provider-stt-comparison.test.ts
@@ -6,7 +6,7 @@
  * as the original hand-written constant.ts functions.
  */
 import { Metadata } from '@rapidaai/react';
-import { loadProviderConfig } from '../config-loader';
+import { loadProviderConfig, resolveCategoryParameters } from '../config-loader';
 import { getDefaultsFromConfig, validateFromConfig } from '../config-defaults';
 
 function createMetadata(key: string, value: string): Metadata {
@@ -126,6 +126,24 @@ describe('Deepgram STT — config vs original', () => {
         'listen.keywords',
       ]),
     );
+  });
+
+  it('renders endpointing as a bounded number input', () => {
+    const params = resolveCategoryParameters(
+      'deepgram',
+      'stt',
+      config.stt!,
+      [createMetadata('listen.model', 'nova-3')],
+    );
+    const endpointing = params.find(p => p.key === 'listen.endpointing');
+
+    expect(endpointing).toMatchObject({
+      label: 'Endpointing (ms)',
+      type: 'number',
+      min: 5,
+      max: 500,
+      step: 1,
+    });
   });
 
   it('validates: valid options returns undefined', () => {

--- a/ui/src/providers/deepgram/speech-to-text-models.json
+++ b/ui/src/providers/deepgram/speech-to-text-models.json
@@ -72,11 +72,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -190,11 +190,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -308,11 +308,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -426,11 +426,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -544,11 +544,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -662,11 +662,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -780,11 +780,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -898,11 +898,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1016,11 +1016,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1134,11 +1134,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1252,11 +1252,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1370,11 +1370,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1487,11 +1487,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1604,11 +1604,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {
@@ -1721,11 +1721,11 @@
         {
           "key": "listen.endpointing",
           "label": "Endpointing (ms)",
-          "type": "slider",
+          "type": "number",
           "required": false,
           "default": "5",
           "min": 5,
-          "max": 200,
+          "max": 500,
           "step": 1
         },
         {

--- a/ui/src/providers/firered_vad/vad.json
+++ b/ui/src/providers/firered_vad/vad.json
@@ -1,36 +1,36 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.threshold",
-      "label": "Speech Threshold",
+      "key": "microphone.vad.confidence",
+      "label": "Confidence",
       "type": "slider",
-      "default": "0.4",
+      "default": "0.7",
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "helpText": "Speech probability threshold used by FireRed VAD post-processing. Higher values are less sensitive; lower values detect quieter speech. Backend default is 0.4.",
+      "helpText": "Speech probability required to classify a frame as speech.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_silence_frame",
-      "label": "Min Silence Frames",
+      "key": "microphone.vad.start_secs",
+      "label": "Start Seconds",
       "type": "slider",
-      "default": "20",
-      "min": 1,
-      "max": 50,
-      "step": 1,
-      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous speech required before confirming speech start.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_speech_frame",
-      "label": "Min Speech Frames",
+      "key": "microphone.vad.stop_secs",
+      "label": "Stop Seconds",
       "type": "slider",
-      "default": "8",
-      "min": 1,
-      "max": 20,
-      "step": 1,
-      "helpText": "Number of speech frames FireRed requires before confirming speech start. One frame is 10ms, so the default 8 frames is 80ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous non-speech required before confirming speech end.",
       "helpTextDisplay": "toggletip"
     }
   ]

--- a/ui/src/providers/silero_vad/vad.json
+++ b/ui/src/providers/silero_vad/vad.json
@@ -1,36 +1,47 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.threshold",
-      "label": "Speech Threshold",
+      "key": "microphone.vad.confidence",
+      "label": "Confidence",
       "type": "slider",
-      "default": "0.5",
+      "default": "0.7",
       "min": 0.05,
       "max": 0.95,
       "step": 0.05,
-      "helpText": "Speech probability threshold used by Silero VAD. Higher values are less sensitive; lower values detect quieter speech. Backend valid range is greater than 0 and less than 1.",
+      "helpText": "Speech probability required to classify a frame as speech.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_silence_frame",
-      "label": "Min Silence Frames",
+      "key": "microphone.vad.start_secs",
+      "label": "Start Seconds",
       "type": "slider",
-      "default": "20",
-      "min": 1,
-      "max": 50,
-      "step": 1,
-      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous speech required before confirming speech start.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_speech_frame",
-      "label": "Min Speech Frames",
+      "key": "microphone.vad.stop_secs",
+      "label": "Stop Seconds",
       "type": "slider",
-      "default": "8",
-      "min": 1,
-      "max": 20,
-      "step": 1,
-      "helpText": "Speech padding applied around detected speech boundaries. One frame is 10ms, so the default 8 frames is 80ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous non-speech required before confirming speech end.",
+      "helpTextDisplay": "toggletip"
+    },
+    {
+      "key": "microphone.vad.min_volume",
+      "label": "Min Volume",
+      "type": "slider",
+      "default": "0.6",
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "helpText": "Minimum detector volume score required before speech can be confirmed.",
       "helpTextDisplay": "toggletip"
     }
   ]

--- a/ui/src/providers/ten_vad/vad.json
+++ b/ui/src/providers/ten_vad/vad.json
@@ -1,36 +1,36 @@
 {
   "parameters": [
     {
-      "key": "microphone.vad.threshold",
-      "label": "Speech Threshold",
+      "key": "microphone.vad.confidence",
+      "label": "Confidence",
       "type": "slider",
-      "default": "0.5",
+      "default": "0.7",
       "min": 0,
       "max": 1,
       "step": 0.05,
-      "helpText": "Speech probability threshold used by TEN VAD. Higher values are less sensitive; lower values detect quieter speech. Backend valid range is 0 through 1.",
+      "helpText": "Speech probability required to classify a frame as speech.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_silence_frame",
-      "label": "Min Silence Frames",
+      "key": "microphone.vad.start_secs",
+      "label": "Start Seconds",
       "type": "slider",
-      "default": "20",
-      "min": 1,
-      "max": 50,
-      "step": 1,
-      "helpText": "Number of consecutive silence frames before the backend marks speech ended. One frame is 10ms, so the default 20 frames is 200ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous speech required before confirming speech start.",
       "helpTextDisplay": "toggletip"
     },
     {
-      "key": "microphone.vad.min_speech_frame",
-      "label": "Min Speech Frames",
+      "key": "microphone.vad.stop_secs",
+      "label": "Stop Seconds",
       "type": "slider",
-      "default": "8",
-      "min": 1,
-      "max": 20,
-      "step": 1,
-      "helpText": "Speech padding applied around detected speech boundaries. One frame is 10ms, so the default 8 frames is 80ms.",
+      "default": "0.2",
+      "min": 0,
+      "max": 2,
+      "step": 0.05,
+      "helpText": "Seconds of continuous non-speech required before confirming speech end.",
       "helpTextDisplay": "toggletip"
     }
   ]

--- a/ui/src/styles/generated/tailwindcss.css
+++ b/ui/src/styles/generated/tailwindcss.css
@@ -10549,6 +10549,16 @@
       outline-style: none !important;
     }
   }
+  .\[\&_\.cds--slider\]\:\!max-w-none {
+    & .cds--slider {
+      max-width: none !important;
+    }
+  }
+  .\[\&_\.cds--slider\]\:\!min-w-0 {
+    & .cds--slider {
+      min-width: calc(var(--spacing) * 0) !important;
+    }
+  }
   .\[\&_\.cds--slider__range-label\]\:hidden {
     & .cds--slider  range-label {
       display: none;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR standardizes FireRed, Silero, and TEN VAD configuration around confidence and start/stop durations.
- Adds shared microphone VAD option names and aligned provider defaults.
- Reworks speech transition timing and interruption event payloads across the VAD implementations.
- Updates provider metadata, UI defaults, documentation, and parity tests.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because startup speech remains suppressed in Silero and existing deployments still lose their legacy VAD tuning.

Silero continues to require a nonzero volume score while its rolling window returns zero during startup, and all three provider constructors continue to ignore persisted legacy VAD keys in favor of new defaults.

**Files Needing Attention:** api/assistant-api/internal/vad/internal/silero_vad/detector.go, api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go, api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go, api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/vad/internal/silero_vad/detector.go | Adds duration-based transitions and a rolling volume gate; the previously reported startup speech suppression remains. |
| api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go | Adopts standardized VAD options and emits richer lifecycle packets, but legacy persisted options remain unsupported. |
| api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go | Converts standardized durations to frames and updates event timestamps, while still discarding legacy tuning keys. |
| api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go | Replaces legacy frame settings with confidence and duration-based debounce state, without legacy-option compatibility. |
| ui/src/providers/silero_vad/vad.json | Exposes the standardized Silero confidence, duration, and minimum-volume configuration. |
| ui/src/providers/firered_vad/vad.json | Aligns FireRed provider metadata with the standardized confidence and duration options. |
| ui/src/providers/ten_vad/vad.json | Aligns TEN provider metadata with the standardized confidence and duration options. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Deployment VAD options] --> B{VAD provider}
  B --> C[FireRed]
  B --> D[Silero]
  B --> E[TEN]
  C --> F[Confidence and start/stop debounce]
  D --> G[Confidence, volume gate, and start/stop debounce]
  E --> H[Confidence and start/stop debounce]
  F --> I[Interruption lifecycle packets]
  G --> I
  H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: added number input for deepgram en..."](https://github.com/rapidaai/voice-ai/commit/5936b265299b981ca91b4e1a0d519528de2105b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52189261)</sub>

<!-- /greptile_comment -->