### PR TITLE
fix exotel multipart callback parsing

### DIFF
--- a/api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go
+++ b/api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go
@@ -44,23 +44,28 @@ func NewExotelTelephony(config *config.AssistantConfig, logger commons.Logger) (
 func (exo *exotelTelephony) CatchAllStatusCallback(ctx *gin.Context) (*internal_type.StatusInfo, error) {
 	eventDetails := utils.Option{}
 	rawCallbackPayload := ctx.Request.URL.RawQuery
-	if len(ctx.Request.URL.Query()) > 0 {
-		for key, values := range ctx.Request.URL.Query() {
-			if len(values) > 0 {
-				eventDetails[key] = values[0]
-			} else {
-				eventDetails[key] = nil
-			}
+
+	for key, values := range ctx.Request.URL.Query() {
+		if len(values) > 0 {
+			eventDetails[key] = values[0]
+		} else {
+			eventDetails[key] = nil
 		}
-	} else {
-		body, err := io.ReadAll(ctx.Request.Body)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
-		}
+	}
+
+	body, err := io.ReadAll(ctx.Request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
+	}
+	if len(body) > 0 {
 		rawCallbackPayload = string(body)
 		ctx.Request.Body = io.NopCloser(bytes.NewReader(body))
-		if err := ctx.Request.ParseForm(); err == nil && len(ctx.Request.PostForm) > 0 {
-			for key, values := range ctx.Request.PostForm {
+		if strings.HasPrefix(strings.ToLower(ctx.Request.Header.Get("Content-Type")), "multipart/form-data") {
+			form, err := ctx.MultipartForm()
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
+			}
+			for key, values := range form.Value {
 				if len(values) > 0 {
 					eventDetails[key] = values[0]
 				} else {
@@ -68,11 +73,10 @@ func (exo *exotelTelephony) CatchAllStatusCallback(ctx *gin.Context) (*internal_
 				}
 			}
 		} else {
-			form, err := ctx.MultipartForm()
-			if err != nil {
+			if err := ctx.Request.ParseForm(); err != nil {
 				return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
 			}
-			for key, values := range form.Value {
+			for key, values := range ctx.Request.PostForm {
 				if len(values) > 0 {
 					eventDetails[key] = values[0]
 				} else {
@@ -95,23 +99,29 @@ func (exo *exotelTelephony) CatchAllStatusCallback(ctx *gin.Context) (*internal_
 func (exo *exotelTelephony) StatusCallback(c *gin.Context, auth types.SimplePrinciple, assistantId uint64, assistantConversationId uint64) (*internal_type.StatusInfo, error) {
 	eventDetails := utils.Option{}
 	rawCallbackPayload := c.Request.URL.RawQuery
-	if len(c.Request.URL.Query()) > 0 {
-		for key, values := range c.Request.URL.Query() {
-			if len(values) > 0 {
-				eventDetails[key] = values[0]
-			} else {
-				eventDetails[key] = nil
-			}
+
+	for key, values := range c.Request.URL.Query() {
+		if len(values) > 0 {
+			eventDetails[key] = values[0]
+		} else {
+			eventDetails[key] = nil
 		}
-	} else {
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
-		}
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
+	}
+	if len(body) > 0 {
 		rawCallbackPayload = string(body)
 		c.Request.Body = io.NopCloser(bytes.NewReader(body))
-		if err := c.Request.ParseForm(); err == nil && len(c.Request.PostForm) > 0 {
-			for key, values := range c.Request.PostForm {
+
+		if strings.HasPrefix(strings.ToLower(c.Request.Header.Get("Content-Type")), "multipart/form-data") {
+			form, err := c.MultipartForm()
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
+			}
+			for key, values := range form.Value {
 				if len(values) > 0 {
 					eventDetails[key] = values[0]
 				} else {
@@ -119,11 +129,10 @@ func (exo *exotelTelephony) StatusCallback(c *gin.Context, auth types.SimplePrin
 				}
 			}
 		} else {
-			form, err := c.MultipartForm()
-			if err != nil {
+			if err := c.Request.ParseForm(); err != nil {
 				return nil, fmt.Errorf("%w: %w", internal_exotel.ErrCallbackFormParseFailed, err)
 			}
-			for key, values := range form.Value {
+			for key, values := range c.Request.PostForm {
 				if len(values) > 0 {
 					eventDetails[key] = values[0]
 				} else {

--- a/api/assistant-api/internal/channel/telephony/internal/exotel/telephony_test.go
+++ b/api/assistant-api/internal/channel/telephony/internal/exotel/telephony_test.go
@@ -6,7 +6,9 @@
 package internal_exotel_telephony
 
 import (
+	"bytes"
 	"errors"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -332,6 +334,67 @@ func TestStatusCallback(t *testing.T) {
 	}
 }
 
+func TestStatusCallback_MultipartForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger()
+	require.NoError(t, err)
+	telephony, err := NewExotelTelephony(&config.AssistantConfig{}, logger)
+	require.NoError(t, err)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("CallSid", "exotel-call-sid-12345"))
+	require.NoError(t, writer.WriteField("Status", "no-answer"))
+	require.NoError(t, writer.Close())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c.Request = req
+
+	statusInfo, err := telephony.StatusCallback(c, nil, 1, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, statusInfo)
+	assert.Equal(t, internal_type.TelephonyEventCompleted, statusInfo.Event)
+	assert.Equal(t, "exotel-call-sid-12345", statusInfo.ChannelUUID)
+	require.NotNil(t, statusInfo.Error)
+	assert.Equal(t, "no-answer", statusInfo.Error.Reason)
+}
+
+func TestStatusCallback_QueryAndMultipartForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger()
+	require.NoError(t, err)
+	telephony, err := NewExotelTelephony(&config.AssistantConfig{}, logger)
+	require.NoError(t, err)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("CallSid", "exotel-call-sid-12345"))
+	require.NoError(t, writer.WriteField("Status", "no-answer"))
+	require.NoError(t, writer.Close())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/?CustomField=context-answer-path", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c.Request = req
+
+	statusInfo, err := telephony.StatusCallback(c, nil, 1, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, statusInfo)
+	assert.Equal(t, internal_type.TelephonyEventCompleted, statusInfo.Event)
+	assert.Equal(t, "exotel-call-sid-12345", statusInfo.ChannelUUID)
+	require.NotNil(t, statusInfo.Error)
+	assert.Equal(t, "no-answer", statusInfo.Error.Reason)
+	payload, ok := statusInfo.Payload.(utils.Option)
+	require.True(t, ok)
+	assert.Equal(t, "context-answer-path", payload["CustomField"])
+}
+
 func TestCatchAllStatusCallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logger, err := commons.NewApplicationLogger()
@@ -368,6 +431,35 @@ func TestCatchAllStatusCallback(t *testing.T) {
 		assert.Nil(t, statusInfo)
 		assert.True(t, errors.Is(err, internal_exotel.ErrCatchAllCallSIDMissing))
 	})
+}
+
+func TestCatchAllStatusCallback_MultipartForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger()
+	require.NoError(t, err)
+	telephony, err := NewExotelTelephony(&config.AssistantConfig{}, logger)
+	require.NoError(t, err)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("CallSid", "exotel-call-sid-12345"))
+	require.NoError(t, writer.WriteField("Status", "no-answer"))
+	require.NoError(t, writer.Close())
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c.Request = req
+
+	statusInfo, err := telephony.CatchAllStatusCallback(c)
+
+	require.NoError(t, err)
+	require.NotNil(t, statusInfo)
+	assert.Equal(t, internal_type.TelephonyEventCompleted, statusInfo.Event)
+	assert.Equal(t, "exotel-call-sid-12345", statusInfo.ChannelUUID)
+	require.NotNil(t, statusInfo.Error)
+	assert.Equal(t, "no-answer", statusInfo.Error.Reason)
 }
 
 // TestReceiveCall_QueryParameterExtraction tests that all query parameters are captured in CallInfo payload


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telephony status callback processing when data is provided through both URL parameters and request forms.
  * Added support for multipart form submissions, including call status, call ID, error reason, and custom fields.
  * Improved error reporting when callback form data cannot be parsed.
* **Tests**
  * Added coverage for multipart callbacks and combined query/form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes Exotel status callback parsing by parsing query parameters alongside request bodies and selecting multipart or standard form parsing based on Content-Type.

- Adds multipart parsing to both catch-all and context-specific callback handlers.
- Preserves request bodies for subsequent parsing and records body payloads when present.
- Adds tests for multipart callbacks and callbacks combining query parameters with multipart fields.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The updated handlers consistently parse query parameters and nonempty multipart or URL-encoded bodies, and the added tests cover the callback formats targeted by the fix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go | Corrects multipart/form parsing and allows query and body fields to be processed together without an established actionable regression. |
| api/assistant-api/internal/channel/telephony/internal/exotel/telephony_test.go | Adds focused success-path coverage for multipart callbacks and combined query-plus-multipart input. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix exotel multipart callback parsing"](https://github.com/rapidaai/voice-ai/commit/6a7932806a97c76cf0b1cfaabcd5ca389c286ed9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52868340)</sub>

<!-- /greptile_comment -->