### PR TITLE
fix: render interpolated composite prompt arguments as json

### DIFF
--- a/pkg/parsers/pongo2.template.parser.go
+++ b/pkg/parsers/pongo2.template.parser.go
@@ -6,6 +6,8 @@
 package parsers
 
 import (
+	"bytes"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -39,12 +41,104 @@ func (stp *pongo2StringTemplateParser) Parse(template string, argument map[strin
 		stp.logger.Errorf("error while parsing the template with pongo2: %v", err)
 		return template
 	}
-	formattedTemplate, err := tpl.Execute(pongo2.Context(CanonicalizePromptArguments(utils.NormalizeInterface(argument))))
+	context := CanonicalizePromptArguments(utils.NormalizeInterface(argument))
+	context = EncodeInterpolatedComposites(template, context)
+	formattedTemplate, err := tpl.Execute(pongo2.Context(context))
 	if err != nil {
 		stp.logger.Errorf("error while executing the template with pongo2: %v", err)
 		return template
 	}
 	return formattedTemplate
+}
+
+// EncodeInterpolatedComposites JSON-encodes composite values that the template
+// interpolates directly, for example "{{ messages }}" over a slice of turns.
+// pongo2 has no string form for a composite value and falls back to Go's debug
+// formatting, so such a placeholder renders as "<[]interface {} Value>" and the
+// data never reaches the prompt.
+//
+// Encoding is deliberately narrow, because composites are otherwise load-bearing:
+//
+//   - Templates containing tags are left untouched. "{% for m in messages %}"
+//     iterates the composite itself and needs the original value.
+//   - Only keys used as a standalone "{{ key }}" are encoded. Attribute access
+//     such as "{{ message.language }}" still resolves against the live map.
+func EncodeInterpolatedComposites(template string, in map[string]interface{}) map[string]interface{} {
+	if len(in) == 0 || strings.Contains(template, "{%") {
+		return in
+	}
+
+	keys := bareInterpolationKeys(template)
+	if len(keys) == 0 {
+		return in
+	}
+
+	out := make(map[string]interface{}, len(in))
+	for key, value := range in {
+		out[key] = value
+
+		if _, interpolated := keys[key]; !interpolated {
+			continue
+		}
+
+		switch value.(type) {
+		case []interface{}, map[string]interface{}:
+			encoded, err := encodeCompositeValue(value)
+			if err != nil {
+				continue
+			}
+			// Marked safe so pongo2 autoescaping does not turn the quotes of
+			// the encoded payload into HTML entities.
+			out[key] = pongo2.AsSafeValue(encoded)
+		}
+	}
+
+	return out
+}
+
+// encodeCompositeValue renders value as JSON without escaping "<", ">" and "&".
+// The output is destined for a model prompt rather than a browser, and escaping
+// those characters only makes a transcript harder for the model to read.
+func encodeCompositeValue(value interface{}) (string, error) {
+	var buffer bytes.Buffer
+
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", err
+	}
+
+	// Encode always terminates the payload with a newline.
+	return strings.TrimRight(buffer.String(), "\n"), nil
+}
+
+// bareInterpolationKeys collects identifiers used as a standalone "{{ key }}".
+// Expressions carrying attribute access, filters or calls are skipped, since
+// those resolve against the value's structure rather than its string form.
+func bareInterpolationKeys(template string) map[string]struct{} {
+	keys := make(map[string]struct{})
+
+	for rest := template; ; {
+		open := strings.Index(rest, "{{")
+		if open < 0 {
+			break
+		}
+		rest = rest[open+2:]
+
+		end := strings.Index(rest, "}}")
+		if end < 0 {
+			break
+		}
+
+		expression := strings.TrimSpace(rest[:end])
+		rest = rest[end+2:]
+
+		if expression != "" && !strings.ContainsAny(expression, ".|()[] ") {
+			keys[expression] = struct{}{}
+		}
+	}
+
+	return keys
 }
 
 // canonicalizePromptArguments expands dotted top-level keys (for example

--- a/pkg/parsers/pongo2_template_parser_test.go
+++ b/pkg/parsers/pongo2_template_parser_test.go
@@ -196,3 +196,63 @@ Take care of yourself, and remember that recognizing your worth is the first ste
 		})
 	}
 }
+
+func TestPongo2StringTemplateParser_Parse_CompositeInterpolation(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	parser := NewPongo2StringTemplateParser(logger)
+
+	transcript := `[{"role":"user","content":"i want to book a cab"},` +
+		`{"role":"assistant","content":"sure, where to?"}]`
+
+	tests := []struct {
+		name     string
+		template string
+		argument map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "interpolated slice renders as json rather than a go value",
+			template: "Analyse this conversation: {{ messages }}",
+			argument: map[string]interface{}{"messages": transcript},
+			expected: `Analyse this conversation: [{"content":"i want to book a cab","role":"user"},` +
+				`{"content":"sure, where to?","role":"assistant"}]`,
+		},
+		{
+			name:     "interpolated map renders as json",
+			template: "{{ metadata }}",
+			argument: map[string]interface{}{"metadata": `{"channel":"phone"}`},
+			expected: `{"channel":"phone"}`,
+		},
+		{
+			name:     "encoded json is not html escaped",
+			template: "{{ metadata }}",
+			argument: map[string]interface{}{"metadata": `{"note":"a & b"}`},
+			expected: `{"note":"a & b"}`,
+		},
+		{
+			name:     "tag templates keep iterating the composite",
+			template: "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}",
+			argument: map[string]interface{}{"messages": transcript},
+			expected: "user: i want to book a cab\nassistant: sure, where to?\n",
+		},
+		{
+			name:     "attribute access still resolves against the live map",
+			template: "lang={{ message.language }}",
+			argument: map[string]interface{}{"message": `{"language":"en"}`},
+			expected: "lang=en",
+		},
+		{
+			name:     "scalars are unaffected",
+			template: "Hello, {{ name }}!",
+			argument: map[string]interface{}{"name": "World"},
+			expected: "Hello, World!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parser.Parse(tt.template, tt.argument)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/parsers/pongo2_template_parser_test.go
+++ b/pkg/parsers/pongo2_template_parser_test.go
@@ -256,3 +256,20 @@ func TestPongo2StringTemplateParser_Parse_CompositeInterpolation(t *testing.T) {
 		})
 	}
 }
+
+func TestPongo2StringTemplateParser_Parse_Fallbacks(t *testing.T) {
+	logger, _ := commons.NewApplicationLogger()
+	parser := NewPongo2StringTemplateParser(logger)
+
+	t.Run("malformed template is returned unchanged", func(t *testing.T) {
+		template := "{% for m in messages %}{{ m.role }}"
+		result := parser.Parse(template, map[string]interface{}{"messages": `[{"role":"user"}]`})
+		assert.Equal(t, template, result)
+	})
+
+	t.Run("composite that cannot be encoded keeps its original value", func(t *testing.T) {
+		unencodable := map[string]interface{}{"callback": func() {}}
+		result := parser.Parse("{{ data }}", map[string]interface{}{"data": unencodable})
+		assert.NotContains(t, result, "callback")
+	})
+}


### PR DESCRIPTION
## Description

Analysis prompts that interpolate the transcript directly (`{{ messages }}`) were sending the model the literal string `<[]interface {} Value>` instead of the conversation. The model received no transcript, did not error, and returned confident, well-formed, entirely fabricated JSON. Silent failure that looks like success.

`utils.NormalizeInterface` parses JSON string arguments into Go composites, and pongo2 has no string form for a composite, so it falls back to Go's debug formatting. Normalization is what breaks the value it exists to normalize.

This encodes composites as JSON before rendering, but narrowly, because composites are still load-bearing elsewhere:

- Templates containing `{% %}` are left completely untouched — they iterate the composite themselves and need the original value.
- Only keys used as a standalone `{{ key }}` are encoded, so `{{ message.language }}` still resolves against the live map (covered by the existing `TestPongo2StringTemplateParser_Parse_DottedKeys`).
- The encoded payload is marked safe, otherwise autoescaping renders the JSON quotes as `&quot;`.
- Encoding uses `SetEscapeHTML(false)`, since the output is a model prompt rather than HTML and `&` only makes a transcript harder to read.

A blanket "encode every composite" change breaks both the dotted-key and the tag path, so the narrowing is the substance of the fix rather than an optimisation.

### Alternative considered

A `{{ messages|json }}` filter plus a warning log on bare composite interpolation. Non-breaking, but it requires every existing template to be edited, so it does not fix current deployments on its own. Happy to switch to that shape, or to add the warning log on top of this, if you prefer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

Fixes #207

Very likely also the root cause of #127, which was closed without a diagnosis.

## Checklist

### General

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [x] My changes do not introduce any security vulnerabilities
- [x] I have not committed any sensitive data (API keys, passwords, etc.)

## Additional Notes

Before:

```
Analyse this conversation: <[]interface {} Value>
```

After:

```
Analyse this conversation: [{"content":"i want to book a cab","role":"user"},{"content":"sure, where to?","role":"assistant"}]
```

`TestPongo2StringTemplateParser_Parse_CompositeInterpolation` adds six cases covering the interpolated slice, the interpolated map, the absence of HTML escaping, the tag path still iterating, attribute access still resolving, and scalars being unaffected. `go test ./pkg/parsers/...`, `go vet` and `gofmt` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Composite values in standalone template interpolations are now rendered as readable JSON.
  * JSON output preserves characters such as quotes and angle brackets without unwanted HTML escaping.
  * Nested attributes and scalar interpolation behavior remain unchanged.
  * Composite values used in template tags continue to support iteration and other existing operations.
  * Values that cannot be converted to JSON continue to use the existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR JSON-encodes directly interpolated composite prompt arguments while preserving live composites for tag iteration and attribute access.
- Detects standalone interpolation keys before template execution.
- Emits composite JSON without HTML escaping.
- Adds successful-rendering and parser-fallback tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/parsers/pongo2.template.parser.go | Adds narrowly scoped JSON serialization for directly interpolated composite prompt arguments. |
| pkg/parsers/pongo2_template_parser_test.go | Adds coverage for composite rendering, tag and attribute behavior, scalar interpolation, and parser fallback scenarios. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover parser fallback paths for ma..."](https://github.com/rapidaai/voice-ai/commit/b562af61520580f0221b914ea7e50514971d1734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53350398)</sub>

<!-- /greptile_comment -->