### PR TITLE
Feat/conversation authentication init metrics

### DIFF
--- a/api/assistant-api/internal/authentication/executor.go
+++ b/api/assistant-api/internal/authentication/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rapidaai/api/assistant-api/internal/observability"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/protos"
 )
 
 type options struct {
@@ -99,11 +100,18 @@ func New(opts ...Option) (internal_type.AuthenticationExecutor, error) {
 			_ = options.onPacket(options.ctx,
 				internal_type.ObservabilityMetricRecordPacket{
 					Scope: internal_type.ObservabilityRecordScopeConversation,
-					Record: observability.NewMetricAuthenticationInitLatencyMs(time.Since(start), observability.Attributes{
-						"provider":         options.authenticator.Provider,
-						"configuration_id": fmt.Sprintf("%d", options.authenticator.Id),
-						"status":           "failed",
-					}),
+					Record: observability.RecordMetric{
+						Attributes: observability.Attributes{
+							"provider":         options.authenticator.Provider,
+							"configuration_id": fmt.Sprintf("%d", options.authenticator.Id),
+							"status":           "failed",
+						},
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricAuthenticationInitLatencyMs,
+							Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+							Description: "Authentication initialization latency in milliseconds",
+						}},
+					},
 				},
 				internal_type.ObservabilityLogRecordPacket{
 					Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/internal/authentication/http/executor.go
+++ b/api/assistant-api/internal/authentication/http/executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rapidaai/pkg/commons"
 	type_enums "github.com/rapidaai/pkg/types/enums"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 const (
@@ -108,11 +109,18 @@ func New(opts ...Option) (internal_type.AuthenticationExecutor, error) {
 			internal_type.ObservabilityMetricRecordPacket{
 				ContextID: executor.contextID,
 				Scope:     internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewMetricAuthenticationInitLatencyMs(time.Since(start), observability.Attributes{
-					"provider":         executor.authenticator.Provider,
-					"configuration_id": fmt.Sprintf("%d", executor.authenticator.Id),
-					"executor":         executor.Name(),
-				}),
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{
+						"provider":         executor.authenticator.Provider,
+						"configuration_id": fmt.Sprintf("%d", executor.authenticator.Id),
+						"executor":         executor.Name(),
+					},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricAuthenticationInitLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+						Description: "Authentication initialization latency in milliseconds",
+					}},
+				},
 			},
 			internal_type.ObservabilityLogRecordPacket{
 				ContextID: executor.contextID,

--- a/api/assistant-api/internal/authentication/http/executor.go
+++ b/api/assistant-api/internal/authentication/http/executor.go
@@ -187,12 +187,57 @@ func (e *runtimeExecutor) Execute(ctx context.Context, input internal_type.Authe
 	response, err := e.send(callCtx, client, method, input.Arguments, headers)
 	if err != nil {
 		errMsg := err.Error()
+		if e.onPacket != nil {
+			_ = e.onPacket(ctx, internal_type.ObservabilityMetricRecordPacket{
+				ContextID: input.ContextID,
+				Scope:     internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{
+						"provider":         e.authenticator.Provider,
+						"configuration_id": fmt.Sprintf("%d", e.authenticator.Id),
+						"executor":         e.Name(),
+						"method":           method,
+						"status":           type_enums.RECORD_FAILED.String(),
+					},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricAuthenticationLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(startTime).Milliseconds()),
+						Description: "Authentication request latency in milliseconds",
+					}},
+				},
+			})
+		}
 		e.onCreateLog(ctx, input.ContextID, url, method, e.authenticator.Id, startTime, type_enums.RECORD_FAILED, 0, &errMsg, requestPayload, nil)
 		return nil, fmt.Errorf("authentication: request failed: %w", err)
 	}
 
 	result := &internal_type.AuthenticationOutput{
 		Authenticated: response.StatusCode >= 200 && response.StatusCode < 300,
+	}
+	metricStatus := type_enums.RECORD_COMPLETE
+	if !result.Authenticated {
+		metricStatus = type_enums.RECORD_FAILED
+	}
+	if e.onPacket != nil {
+		_ = e.onPacket(ctx, internal_type.ObservabilityMetricRecordPacket{
+			ContextID: input.ContextID,
+			Scope:     internal_type.ObservabilityRecordScopeConversation,
+			Record: observability.RecordMetric{
+				Attributes: observability.Attributes{
+					"provider":         e.authenticator.Provider,
+					"configuration_id": fmt.Sprintf("%d", e.authenticator.Id),
+					"executor":         e.Name(),
+					"method":           method,
+					"response_status":  fmt.Sprintf("%d", response.StatusCode),
+					"status":           metricStatus.String(),
+				},
+				Metrics: []*protos.Metric{{
+					Name:        observability.MetricAuthenticationLatencyMs,
+					Value:       fmt.Sprintf("%d", time.Since(startTime).Milliseconds()),
+					Description: "Authentication request latency in milliseconds",
+				}},
+			},
+		})
 	}
 	if parsed, err := response.ToMap(); err == nil {
 		if args, ok := parsed[ResponseArgumentsKeyV1].(map[string]interface{}); ok {

--- a/api/assistant-api/internal/authentication/http/executor_test.go
+++ b/api/assistant-api/internal/authentication/http/executor_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	"github.com/rapidaai/api/assistant-api/internal/observability"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	gorm_model "github.com/rapidaai/pkg/models/gorm"
 	"github.com/stretchr/testify/require"
@@ -15,6 +17,15 @@ import (
 type testCallback struct{}
 
 func (testCallback) OnPacket(context.Context, ...internal_type.Packet) error {
+	return nil
+}
+
+type captureCallback struct {
+	packets []internal_type.Packet
+}
+
+func (c *captureCallback) OnPacket(_ context.Context, packets ...internal_type.Packet) error {
+	c.packets = append(c.packets, packets...)
 	return nil
 }
 
@@ -90,4 +101,48 @@ func TestExecute_TransportErrorReturnsNilOutput(t *testing.T) {
 
 	require.Nil(t, output)
 	require.Error(t, err)
+}
+
+func TestExecute_RecordsAuthenticationLatencyMetric(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"arguments":{"token":"updated"}}`))
+	}))
+	defer server.Close()
+
+	callback := &captureCallback{}
+	executor, err := New(
+		WithConfiguration(testConfiguration(server.URL, "")),
+		WithCallback(callback),
+	)
+	require.NoError(t, err)
+
+	output, err := executor.Execute(context.Background(), internal_type.AuthenticationInput{
+		ContextID: "ctx-auth-success",
+	})
+
+	require.NoError(t, err)
+	require.True(t, output.Authenticated)
+
+	var latencyMetric *internal_type.ObservabilityMetricRecordPacket
+	for i := range callback.packets {
+		packet, ok := callback.packets[i].(internal_type.ObservabilityMetricRecordPacket)
+		if !ok || len(packet.Record.Metrics) == 0 {
+			continue
+		}
+		if packet.Record.Metrics[0].Name == observability.MetricAuthenticationLatencyMs {
+			latencyMetric = &packet
+			break
+		}
+	}
+	require.NotNil(t, latencyMetric)
+	require.Equal(t, "ctx-auth-success", latencyMetric.ContextID)
+	require.Equal(t, internal_type.ObservabilityRecordScopeConversation, latencyMetric.Scope)
+	require.Equal(t, "http", latencyMetric.Record.Attributes["provider"])
+	require.Equal(t, "POST", latencyMetric.Record.Attributes["method"])
+	require.Equal(t, "200", latencyMetric.Record.Attributes["response_status"])
+	require.Equal(t, "COMPLETE", latencyMetric.Record.Attributes["status"])
+	latencyMs, err := strconv.ParseInt(latencyMetric.Record.Metrics[0].Value, 10, 64)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, latencyMs, int64(0))
 }

--- a/api/assistant-api/internal/observability/metric.go
+++ b/api/assistant-api/internal/observability/metric.go
@@ -67,7 +67,7 @@ const (
 	MetricAgentTRTMs                  = "agent.trt_ms"
 	MetricStorageInitLatencyMs        = "storage_init_ms"
 	MetricAnalysisInitLatencyMs       = "analysis_init_ms"
-	MetricAuthenticationInitLatencyMs = "authentication_init_ms"
+	MetricAuthenticationInitLatencyMs = "authentication.init_ms"
 	MetricRecordingInitLatencyMs      = "recording.init_ms"
 	MetricKnowledgeLatencyMs          = "knowledge_latency_ms"
 	MetricLLMError                    = "llm_error"
@@ -186,16 +186,6 @@ func NewMetricAnalysisInitLatencyMs(duration time.Duration, attr Attributes) Rec
 		Name:        MetricAnalysisInitLatencyMs,
 		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
 		Description: "Analysis initialization latency in milliseconds",
-	}})
-	record.Attributes = attr
-	return record
-}
-
-func NewMetricAuthenticationInitLatencyMs(duration time.Duration, attr Attributes) RecordMetric {
-	record := NewConversationMetricRecord([]*protos.Metric{{
-		Name:        MetricAuthenticationInitLatencyMs,
-		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
-		Description: "Authentication initialization latency in milliseconds",
 	}})
 	record.Attributes = attr
 	return record

--- a/api/assistant-api/internal/observability/metric.go
+++ b/api/assistant-api/internal/observability/metric.go
@@ -68,6 +68,7 @@ const (
 	MetricStorageInitLatencyMs        = "storage_init_ms"
 	MetricAnalysisInitLatencyMs       = "analysis_init_ms"
 	MetricAuthenticationInitLatencyMs = "authentication.init_ms"
+	MetricAuthenticationLatencyMs     = "authentication.latency_ms"
 	MetricRecordingInitLatencyMs      = "recording.init_ms"
 	MetricKnowledgeLatencyMs          = "knowledge_latency_ms"
 	MetricLLMError                    = "llm_error"

--- a/api/assistant-api/internal/observability/metric_test.go
+++ b/api/assistant-api/internal/observability/metric_test.go
@@ -53,6 +53,7 @@ func TestMetricNames_MirrorCurrentImplementation(t *testing.T) {
 		{MetricAgentTTFTMs, "agent.ttft_ms"},
 		{MetricAgentTRTMs, "agent.trt_ms"},
 		{MetricAuthenticationInitLatencyMs, "authentication.init_ms"},
+		{MetricAuthenticationLatencyMs, "authentication.latency_ms"},
 		{MetricRecordingInitLatencyMs, "recording.init_ms"},
 		{MetricKnowledgeLatencyMs, "knowledge_latency_ms"},
 		{MetricLLMError, "llm_error"},

--- a/api/assistant-api/internal/observability/metric_test.go
+++ b/api/assistant-api/internal/observability/metric_test.go
@@ -52,6 +52,7 @@ func TestMetricNames_MirrorCurrentImplementation(t *testing.T) {
 		{MetricLLMLatencyMs, "llm_latency_ms"},
 		{MetricAgentTTFTMs, "agent.ttft_ms"},
 		{MetricAgentTRTMs, "agent.trt_ms"},
+		{MetricAuthenticationInitLatencyMs, "authentication.init_ms"},
 		{MetricRecordingInitLatencyMs, "recording.init_ms"},
 		{MetricKnowledgeLatencyMs, "knowledge_latency_ms"},
 		{MetricLLMError, "llm_error"},

--- a/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
@@ -191,6 +191,7 @@ func (conversationService *assistantConversationService) GetAll(ctx context.Cont
 				qry = qry.Where("EXISTS (SELECT 1 FROM assistant_conversation_metadata WHERE assistant_conversation_metadata.assistant_conversation_id = assistant_conversations.id AND assistant_conversation_metadata.key = ? AND assistant_conversation_metadata.value = ?)", "disconnect_reason", ct.GetValue())
 			}
 		case observability.MetricRecordingInitLatencyMs,
+			observability.MetricAuthenticationInitLatencyMs,
 			observability.MetricSTTInitLatencyMs,
 			observability.MetricTTSInitLatencyMs,
 			observability.MetricLLMInitLatencyMs,

--- a/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
@@ -192,6 +192,7 @@ func (conversationService *assistantConversationService) GetAll(ctx context.Cont
 			}
 		case observability.MetricRecordingInitLatencyMs,
 			observability.MetricAuthenticationInitLatencyMs,
+			observability.MetricAuthenticationLatencyMs,
 			observability.MetricSTTInitLatencyMs,
 			observability.MetricTTSInitLatencyMs,
 			observability.MetricLLMInitLatencyMs,

--- a/api/assistant-api/migrations/000038_normalize_authentication_init_metric_name.down.sql
+++ b/api/assistant-api/migrations/000038_normalize_authentication_init_metric_name.down.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'authentication_init_ms'
+WHERE name = 'authentication.init_ms';

--- a/api/assistant-api/migrations/000038_normalize_authentication_init_metric_name.up.sql
+++ b/api/assistant-api/migrations/000038_normalize_authentication_init_metric_name.up.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'authentication.init_ms'
+WHERE name = 'authentication_init_ms';

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -8,6 +8,7 @@
 package validator
 
 import (
+	"math"
 	"net/mail"
 	"reflect"
 	"strconv"
@@ -54,6 +55,12 @@ func NonNil(value interface{}) bool {
 // NotBlank returns true when value has non-whitespace content.
 func NotBlank(value string) bool {
 	return strings.TrimSpace(value) != ""
+}
+
+// Numeric returns true when value can be parsed as a finite number.
+func Numeric(value string) bool {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	return err == nil && !math.IsNaN(parsed) && !math.IsInf(parsed, 0)
 }
 
 // Between returns true when value is within the inclusive min/max range.

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -56,6 +56,31 @@ func TestNotBlank(t *testing.T) {
 	}
 }
 
+func TestNumeric(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "integer", value: "123", want: true},
+		{name: "decimal", value: "123.45", want: true},
+		{name: "trimmed decimal", value: " 123.45 ", want: true},
+		{name: "negative", value: "-123.45", want: true},
+		{name: "blank", value: " ", want: false},
+		{name: "text", value: "abc", want: false},
+		{name: "nan", value: "NaN", want: false},
+		{name: "infinity", value: "+Inf", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Numeric(tt.value); got != tt.want {
+				t.Fatalf("Numeric(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBetween(t *testing.T) {
 	intTests := []struct {
 		name  string

--- a/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
@@ -69,6 +69,7 @@ export const METRIC_NAME_OPTIONS: FilterOption[] = [
   { id: 'storage_init_ms', text: 'storage_init_ms' },
   { id: 'analysis_init_ms', text: 'analysis_init_ms' },
   { id: 'authentication.init_ms', text: 'authentication.init_ms' },
+  { id: 'authentication.latency_ms', text: 'authentication.latency_ms' },
   { id: 'recording.init_ms', text: 'recording.init_ms' },
   { id: 'knowledge_latency_ms', text: 'knowledge_latency_ms' },
   { id: 'llm_latency_ms', text: 'llm_latency_ms' },

--- a/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
@@ -68,7 +68,7 @@ export const METRIC_NAME_OPTIONS: FilterOption[] = [
   { id: 'llm_init_ms', text: 'llm_init_ms' },
   { id: 'storage_init_ms', text: 'storage_init_ms' },
   { id: 'analysis_init_ms', text: 'analysis_init_ms' },
-  { id: 'authentication_init_ms', text: 'authentication_init_ms' },
+  { id: 'authentication.init_ms', text: 'authentication.init_ms' },
   { id: 'recording.init_ms', text: 'recording.init_ms' },
   { id: 'knowledge_latency_ms', text: 'knowledge_latency_ms' },
   { id: 'llm_latency_ms', text: 'llm_latency_ms' },

--- a/ui/src/app/pages/activities/conversation-activity-v2/utils.test.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/utils.test.ts
@@ -131,6 +131,7 @@ describe('conversation activity v2 telemetry utilities', () => {
         'llm_history_count',
         'llm_response_char_count',
         'agent_time_taken',
+        'authentication.init_ms',
         'recording.init_ms',
         'agent_status',
         'agent_llm_request_id',

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
@@ -60,6 +60,15 @@ describe('session query search criteria', () => {
         v: '80',
       },
     ]);
+    expect(
+      getSessionSearchCriteria('authentication.latency_ms~>=:120'),
+    ).toEqual([
+      {
+        k: 'authentication.latency_ms',
+        logic: '>=',
+        v: '120',
+      },
+    ]);
   });
 
   it('maps date-only timestamp is to the local day range', () => {

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
@@ -52,6 +52,14 @@ describe('session query search criteria', () => {
         v: '120',
       },
     ]);
+
+    expect(getSessionSearchCriteria('authentication.init_ms~<=:80')).toEqual([
+      {
+        k: 'authentication.init_ms',
+        logic: '<=',
+        v: '80',
+      },
+    ]);
   });
 
   it('maps date-only timestamp is to the local day range', () => {

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
@@ -298,6 +298,18 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
       { label: 'is greater than or equal to', logic: '>=' },
       { label: 'is less than or equal to', logic: '<=' },
     ],
+    queryKey: 'authentication.latency_ms',
+    text: 'authentication.latency_ms',
+    type: 'number',
+  },
+  {
+    category: 'metrics',
+    logicLabel: 'is',
+    logicOptions: [
+      { label: 'is', logic: '=' },
+      { label: 'is greater than or equal to', logic: '>=' },
+      { label: 'is less than or equal to', logic: '<=' },
+    ],
     queryKey: 'stt_init_ms',
     text: 'stt_init_ms',
     type: 'number',
@@ -421,6 +433,7 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
 const SESSION_SEARCH_CRITERIA: Record<string, string> = {
   assistant_provider_model_id: 'assistant_provider_model_id',
   'authentication.init_ms': 'authentication.init_ms',
+  'authentication.latency_ms': 'authentication.latency_ms',
   'call.status': 'call.status',
   'call.duration_ms': 'call.duration_ms',
   'conversation.duration_ms': 'conversation.duration_ms',

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
@@ -286,6 +286,18 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
       { label: 'is greater than or equal to', logic: '>=' },
       { label: 'is less than or equal to', logic: '<=' },
     ],
+    queryKey: 'authentication.init_ms',
+    text: 'authentication.init_ms',
+    type: 'number',
+  },
+  {
+    category: 'metrics',
+    logicLabel: 'is',
+    logicOptions: [
+      { label: 'is', logic: '=' },
+      { label: 'is greater than or equal to', logic: '>=' },
+      { label: 'is less than or equal to', logic: '<=' },
+    ],
     queryKey: 'stt_init_ms',
     text: 'stt_init_ms',
     type: 'number',
@@ -408,6 +420,7 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
 
 const SESSION_SEARCH_CRITERIA: Record<string, string> = {
   assistant_provider_model_id: 'assistant_provider_model_id',
+  'authentication.init_ms': 'authentication.init_ms',
   'call.status': 'call.status',
   'call.duration_ms': 'call.duration_ms',
   'conversation.duration_ms': 'conversation.duration_ms',


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR normalizes authentication initialization telemetry, records authentication request latency, and exposes both metrics through conversation filtering.
- Renames the persisted authentication initialization metric and adds a migration for existing data.
- Emits authentication request latency metrics for successful, rejected, and transport-error HTTP requests.
- Adds backend and UI support for filtering conversations by the authentication metrics.
- Adds finite numeric-string validation and focused validator, executor, and UI parser tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking omission of required same-package regression tests for the new backend metric filters.

The telemetry emission, persistence rename, and UI query wiring have no established blocking defect, but the assistant service’s new filtering branches lack the repository-required package-level test update.

**Files Needing Attention:** api/assistant-api/internal/services/assistant/conversaction.impl.service.go
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/authentication/http/executor.go | Adds latency metric emission across HTTP authentication success, rejection, and transport-error paths. |
| api/assistant-api/internal/services/assistant/conversaction.impl.service.go | Adds authentication metrics to numeric conversation filtering, but the affected service package receives no corresponding regression tests. |
| api/assistant-api/migrations/000038_normalize_authentication_init_metric_name.up.sql | Renames persisted legacy authentication initialization metric rows to the normalized dotted name. |
| pkg/validator/validator.go | Adds finite-number string validation using ParseFloat while rejecting NaN and infinities. |
| ui/src/app/pages/assistant/view/conversations/session-query-search.tsx | Exposes both authentication metrics as numeric conversation-search fields. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Authentication initialization or HTTP request] --> B[Emit authentication metric packet]
  B --> C[Persist conversation metric]
  C --> D[Conversation search criteria]
  D --> E[Validate numeric value]
  E --> F[Filter conversations by metric name and value]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/internal/services/assistant/conversaction.impl.service.go:191-194
**Authentication filters lack service tests**

The new `authentication.init_ms` and `authentication.latency_ms` filtering branches have no corresponding test update in the service package, leaving their numeric validation, comparison operators, and persisted-name matching without the backend regression coverage required for changes under `api/**`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: added conversation authentication ..."](https://github.com/rapidaai/voice-ai/commit/4149b56004f57e7f3734c20c30e31510d706a7c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53578659)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->