### PR TITLE
feat: removed prefix to dot prefix

### DIFF
--- a/api/assistant-api/internal/analysis/endpoint/executor.go
+++ b/api/assistant-api/internal/analysis/endpoint/executor.go
@@ -92,11 +92,18 @@ func New(opts ...Option) (internal_type.AnalysisExecutor, error) {
 		_ = executor.onPacket(executor.ctx,
 			internal_type.ObservabilityMetricRecordPacket{
 				Scope: internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewMetricAnalysisInitLatencyMs(time.Since(start), observability.Attributes{
-					"provider":         executor.analysis.Provider,
-					"configuration_id": fmt.Sprintf("%d", executor.analysis.Id),
-					"executor":         executor.Name(),
-				}),
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{
+						"provider":         executor.analysis.Provider,
+						"configuration_id": fmt.Sprintf("%d", executor.analysis.Id),
+						"executor":         executor.Name(),
+					},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricAnalysisInitLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+						Description: "Analysis initialization latency in milliseconds",
+					}},
+				},
 			},
 			internal_type.ObservabilityLogRecordPacket{
 				Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/internal/analysis/executor.go
+++ b/api/assistant-api/internal/analysis/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rapidaai/api/assistant-api/internal/observability"
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/protos"
 )
 
 type options struct {
@@ -90,11 +91,18 @@ func New(opts ...Option) (internal_type.AnalysisExecutor, error) {
 			_ = options.onPacket(options.ctx,
 				internal_type.ObservabilityMetricRecordPacket{
 					Scope: internal_type.ObservabilityRecordScopeConversation,
-					Record: observability.NewMetricAnalysisInitLatencyMs(time.Since(start), observability.Attributes{
-						"provider":         options.analysis.Provider,
-						"configuration_id": fmt.Sprintf("%d", options.analysis.Id),
-						"status":           "failed",
-					}),
+					Record: observability.RecordMetric{
+						Attributes: observability.Attributes{
+							"provider":         options.analysis.Provider,
+							"configuration_id": fmt.Sprintf("%d", options.analysis.Id),
+							"status":           "failed",
+						},
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricAnalysisInitLatencyMs,
+							Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+							Description: "Analysis initialization latency in milliseconds",
+						}},
+					},
 				},
 				internal_type.ObservabilityLogRecordPacket{
 					Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/internal/observability/metric.go
+++ b/api/assistant-api/internal/observability/metric.go
@@ -66,7 +66,7 @@ const (
 	MetricAgentTTFTMs                 = "agent.ttft_ms"
 	MetricAgentTRTMs                  = "agent.trt_ms"
 	MetricStorageInitLatencyMs        = "storage_init_ms"
-	MetricAnalysisInitLatencyMs       = "analysis_init_ms"
+	MetricAnalysisInitLatencyMs       = "analysis.init_ms"
 	MetricAuthenticationInitLatencyMs = "authentication.init_ms"
 	MetricAuthenticationLatencyMs     = "authentication.latency_ms"
 	MetricRecordingInitLatencyMs      = "recording.init_ms"
@@ -177,16 +177,6 @@ func NewMetricStorageInitLatencyMs(duration time.Duration, attr Attributes) Reco
 		Name:        MetricStorageInitLatencyMs,
 		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
 		Description: "Storage initialization latency in milliseconds",
-	}})
-	record.Attributes = attr
-	return record
-}
-
-func NewMetricAnalysisInitLatencyMs(duration time.Duration, attr Attributes) RecordMetric {
-	record := NewConversationMetricRecord([]*protos.Metric{{
-		Name:        MetricAnalysisInitLatencyMs,
-		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
-		Description: "Analysis initialization latency in milliseconds",
 	}})
 	record.Attributes = attr
 	return record

--- a/api/assistant-api/internal/observability/metric_test.go
+++ b/api/assistant-api/internal/observability/metric_test.go
@@ -52,6 +52,7 @@ func TestMetricNames_MirrorCurrentImplementation(t *testing.T) {
 		{MetricLLMLatencyMs, "llm_latency_ms"},
 		{MetricAgentTTFTMs, "agent.ttft_ms"},
 		{MetricAgentTRTMs, "agent.trt_ms"},
+		{MetricAnalysisInitLatencyMs, "analysis.init_ms"},
 		{MetricAuthenticationInitLatencyMs, "authentication.init_ms"},
 		{MetricAuthenticationLatencyMs, "authentication.latency_ms"},
 		{MetricRecordingInitLatencyMs, "recording.init_ms"},

--- a/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
+++ b/api/assistant-api/internal/services/assistant/conversaction.impl.service.go
@@ -191,6 +191,7 @@ func (conversationService *assistantConversationService) GetAll(ctx context.Cont
 				qry = qry.Where("EXISTS (SELECT 1 FROM assistant_conversation_metadata WHERE assistant_conversation_metadata.assistant_conversation_id = assistant_conversations.id AND assistant_conversation_metadata.key = ? AND assistant_conversation_metadata.value = ?)", "disconnect_reason", ct.GetValue())
 			}
 		case observability.MetricRecordingInitLatencyMs,
+			observability.MetricAnalysisInitLatencyMs,
 			observability.MetricAuthenticationInitLatencyMs,
 			observability.MetricAuthenticationLatencyMs,
 			observability.MetricSTTInitLatencyMs,

--- a/api/assistant-api/migrations/000039_normalize_analysis_init_metric_name.down.sql
+++ b/api/assistant-api/migrations/000039_normalize_analysis_init_metric_name.down.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'analysis_init_ms'
+WHERE name = 'analysis.init_ms';

--- a/api/assistant-api/migrations/000039_normalize_analysis_init_metric_name.up.sql
+++ b/api/assistant-api/migrations/000039_normalize_analysis_init_metric_name.up.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'analysis.init_ms'
+WHERE name = 'analysis_init_ms';

--- a/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
@@ -67,7 +67,7 @@ export const METRIC_NAME_OPTIONS: FilterOption[] = [
   { id: 'denoise_init_ms', text: 'denoise_init_ms' },
   { id: 'llm_init_ms', text: 'llm_init_ms' },
   { id: 'storage_init_ms', text: 'storage_init_ms' },
-  { id: 'analysis_init_ms', text: 'analysis_init_ms' },
+  { id: 'analysis.init_ms', text: 'analysis.init_ms' },
   { id: 'authentication.init_ms', text: 'authentication.init_ms' },
   { id: 'authentication.latency_ms', text: 'authentication.latency_ms' },
   { id: 'recording.init_ms', text: 'recording.init_ms' },

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
@@ -69,6 +69,13 @@ describe('session query search criteria', () => {
         v: '120',
       },
     ]);
+    expect(getSessionSearchCriteria('analysis.init_ms~<=:40')).toEqual([
+      {
+        k: 'analysis.init_ms',
+        logic: '<=',
+        v: '40',
+      },
+    ]);
   });
 
   it('maps date-only timestamp is to the local day range', () => {

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
@@ -310,6 +310,18 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
       { label: 'is greater than or equal to', logic: '>=' },
       { label: 'is less than or equal to', logic: '<=' },
     ],
+    queryKey: 'analysis.init_ms',
+    text: 'analysis.init_ms',
+    type: 'number',
+  },
+  {
+    category: 'metrics',
+    logicLabel: 'is',
+    logicOptions: [
+      { label: 'is', logic: '=' },
+      { label: 'is greater than or equal to', logic: '>=' },
+      { label: 'is less than or equal to', logic: '<=' },
+    ],
     queryKey: 'stt_init_ms',
     text: 'stt_init_ms',
     type: 'number',
@@ -431,6 +443,7 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
 ];
 
 const SESSION_SEARCH_CRITERIA: Record<string, string> = {
+  'analysis.init_ms': 'analysis.init_ms',
   assistant_provider_model_id: 'assistant_provider_model_id',
   'authentication.init_ms': 'authentication.init_ms',
   'authentication.latency_ms': 'authentication.latency_ms',


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR normalizes the analysis initialization metric from `analysis_init_ms` to `analysis.init_ms` across recording, persisted data, backend filtering, and UI search.

- Replaces the analysis metric helper with direct metric-record construction in both executor paths.
- Adds reversible SQL migrations for existing metric names.
- Exposes the normalized metric in activity filters and conversation search.
- Updates metric-name and search-parser tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking requirement to add package-level regression tests for the changed backend behavior.

The normalized metric is propagated consistently through recording, migration, filtering, and UI search, but several backend packages changed behavior without their required corresponding tests.

**Files Needing Attention:** api/assistant-api/internal/analysis/endpoint/executor.go, api/assistant-api/internal/analysis/executor.go, api/assistant-api/internal/services/assistant/conversaction.impl.service.go
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/analysis/endpoint/executor.go | Inlines normalized analysis metric emission correctly, but the affected package lacks the repository-required corresponding test update. |
| api/assistant-api/internal/analysis/executor.go | Inlines failure-path metric emission with the normalized name, without a corresponding package test update. |
| api/assistant-api/internal/services/assistant/conversaction.impl.service.go | Adds the normalized analysis metric to numeric filtering, but does not update tests in the affected service package. |
| api/assistant-api/migrations/000039_normalize_analysis_init_metric_name.up.sql | Renames persisted legacy metric names; a collision requires an externally determined mixed-writer deployment state not established by repository evidence. |
| ui/src/app/pages/assistant/view/conversations/session-query-search.tsx | Adds the normalized metric as a numeric search field and criterion, with parser coverage in the accompanying test. |
| api/assistant-api/internal/observability/metric.go | Normalizes the metric constant and removes a helper whose callers are replaced by equivalent record literals. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/internal/analysis/endpoint/executor.go:92-109
**Backend changes lack package tests**

The PR changes metric construction in both analysis executor packages and numeric-filter behavior in the assistant service without corresponding `*_test.go` updates in those packages. This violates the repository's backend testing requirement and leaves the changed emission attributes, metric value, and filtering behavior without package-level regression coverage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: removed prefix to dot prefix"](https://github.com/rapidaai/voice-ai/commit/f5cb15984acb5424106c99e86ae019693ddde00e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53581756)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->