### PR TITLE
feat: removed prefix to dot prefix

### DIFF
--- a/api/assistant-api/internal/observability/metric.go
+++ b/api/assistant-api/internal/observability/metric.go
@@ -52,7 +52,7 @@ const (
 	MetricTTSInitLatencyMs = "tts_init_ms"
 	MetricTTSLatencyMs     = "tts_latency_ms"
 
-	MetricVADInitLatencyMs = "vad_init_ms"
+	MetricVADInitLatencyMs = "vad.init_ms"
 
 	MetricEOSInitLatencyMs            = "eos.init_ms"
 	MetricEOSLatencyMs                = "eos_latency_ms"
@@ -127,16 +127,6 @@ func NewMetricTTSLatencyMs(duration time.Duration, attr Attributes) RecordMetric
 		Name:        MetricTTSLatencyMs,
 		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
 		Description: "TTS latency from text input to first audio in milliseconds",
-	}})
-	record.Attributes = attr
-	return record
-}
-
-func NewMetricVADInitLatencyMs(duration time.Duration, attr Attributes) RecordMetric {
-	record := NewConversationMetricRecord([]*protos.Metric{{
-		Name:        MetricVADInitLatencyMs,
-		Value:       strconv.FormatInt(duration.Milliseconds(), 10),
-		Description: "VAD initialization latency in milliseconds",
 	}})
 	record.Attributes = attr
 	return record

--- a/api/assistant-api/internal/observability/metric_test.go
+++ b/api/assistant-api/internal/observability/metric_test.go
@@ -40,7 +40,7 @@ func TestMetricNames_MirrorCurrentImplementation(t *testing.T) {
 		{MetricSTTLatencyMs, "stt_latency_ms"},
 		{MetricTTSInitLatencyMs, "tts_init_ms"},
 		{MetricTTSLatencyMs, "tts_latency_ms"},
-		{MetricVADInitLatencyMs, "vad_init_ms"},
+		{MetricVADInitLatencyMs, "vad.init_ms"},
 		{MetricEOSInitLatencyMs, "eos.init_ms"},
 		{MetricEOSLatencyMs, "eos_latency_ms"},
 		{MetricEOSTextToTriggerMs, "eos_text_to_trigger_ms"},
@@ -148,22 +148,6 @@ func TestNewMetricTTSLatencyMs(t *testing.T) {
 		t.Fatalf("expected metric description %q, got %q", "TTS latency from text input to first audio in milliseconds", metric.Description)
 	}
 	assertRecordAttribute(t, record, "provider", "deepgram")
-}
-
-func TestNewMetricVADInitLatencyMs(t *testing.T) {
-	record := NewMetricVADInitLatencyMs(123*time.Millisecond, Attributes{"provider": "silero_vad"})
-	metric := singleMetric(t, record)
-
-	if metric.Name != MetricVADInitLatencyMs {
-		t.Fatalf("expected metric name %q, got %q", MetricVADInitLatencyMs, metric.Name)
-	}
-	if metric.Value != "123" {
-		t.Fatalf("expected metric value %q, got %q", "123", metric.Value)
-	}
-	if metric.Description != "VAD initialization latency in milliseconds" {
-		t.Fatalf("expected metric description %q, got %q", "VAD initialization latency in milliseconds", metric.Description)
-	}
-	assertRecordAttribute(t, record, "provider", "silero_vad")
 }
 
 func TestNewMetricLLMInitLatencyMs(t *testing.T) {

--- a/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
+++ b/api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go
@@ -21,6 +21,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 // -----------------------------------------------------------------------------
@@ -176,8 +177,15 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	if options.onPacket != nil {
 		_ = options.onPacket(options.ctx,
 			internal_type.ObservabilityMetricRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewMetricVADInitLatencyMs(time.Since(start), observability.Attributes{"provider": vad.Name()}),
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{"provider": vad.Name()},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricVADInitLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+						Description: "VAD initialization latency in milliseconds",
+					}},
+				},
 			},
 			internal_type.ObservabilityLogRecordPacket{
 				Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
+++ b/api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go
@@ -21,6 +21,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 // -----------------------------------------------------------------------------
@@ -186,8 +187,15 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	if options.onPacket != nil {
 		_ = options.onPacket(options.ctx,
 			internal_type.ObservabilityMetricRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewMetricVADInitLatencyMs(time.Since(start), observability.Attributes{"provider": svad.Name()}),
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{"provider": svad.Name()},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricVADInitLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+						Description: "VAD initialization latency in milliseconds",
+					}},
+				},
 			},
 			internal_type.ObservabilityLogRecordPacket{
 				Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
+++ b/api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go
@@ -18,6 +18,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
+	"github.com/rapidaai/protos"
 )
 
 // -----------------------------------------------------------------------------
@@ -188,8 +189,15 @@ func New(opts ...Option) (internal_type.VoiceActivityDetectorExecutor, error) {
 	if options.onPacket != nil {
 		_ = options.onPacket(options.ctx,
 			internal_type.ObservabilityMetricRecordPacket{
-				Scope:  internal_type.ObservabilityRecordScopeConversation,
-				Record: observability.NewMetricVADInitLatencyMs(time.Since(start), observability.Attributes{"provider": tv.Name()}),
+				Scope: internal_type.ObservabilityRecordScopeConversation,
+				Record: observability.RecordMetric{
+					Attributes: observability.Attributes{"provider": tv.Name()},
+					Metrics: []*protos.Metric{{
+						Name:        observability.MetricVADInitLatencyMs,
+						Value:       fmt.Sprintf("%d", time.Since(start).Milliseconds()),
+						Description: "VAD initialization latency in milliseconds",
+					}},
+				},
 			},
 			internal_type.ObservabilityLogRecordPacket{
 				Scope: internal_type.ObservabilityRecordScopeConversation,

--- a/api/assistant-api/migrations/000043_normalize_vad_init_metric_name.down.sql
+++ b/api/assistant-api/migrations/000043_normalize_vad_init_metric_name.down.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'vad_init_ms'
+WHERE name = 'vad.init_ms';

--- a/api/assistant-api/migrations/000043_normalize_vad_init_metric_name.up.sql
+++ b/api/assistant-api/migrations/000043_normalize_vad_init_metric_name.up.sql
@@ -1,0 +1,3 @@
+UPDATE public.assistant_conversation_metrics
+SET name = 'vad.init_ms'
+WHERE name = 'vad_init_ms';

--- a/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/constants.ts
@@ -57,7 +57,7 @@ export const METRIC_NAME_OPTIONS: FilterOption[] = [
   { id: 'stt_latency_ms', text: 'stt_latency_ms' },
   { id: 'tts_init_ms', text: 'tts_init_ms' },
   { id: 'tts_latency_ms', text: 'tts_latency_ms' },
-  { id: 'vad_init_ms', text: 'vad_init_ms' },
+  { id: 'vad.init_ms', text: 'vad.init_ms' },
   { id: 'eos.init_ms', text: 'eos.init_ms' },
   { id: 'eos_latency_ms', text: 'eos_latency_ms' },
   { id: 'eos_text_to_trigger_ms', text: 'eos_text_to_trigger_ms' },

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts
@@ -97,6 +97,13 @@ describe('session query search criteria', () => {
         v: '30',
       },
     ]);
+    expect(getSessionSearchCriteria('vad.init_ms~>=:35')).toEqual([
+      {
+        k: 'vad.init_ms',
+        logic: '>=',
+        v: '35',
+      },
+    ]);
   });
 
   it('maps date-only timestamp is to the local day range', () => {

--- a/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
+++ b/ui/src/app/pages/assistant/view/conversations/session-query-search.tsx
@@ -394,8 +394,8 @@ const SESSION_SEARCH_FIELDS: QuerySearchField[] = [
       { label: 'is greater than or equal to', logic: '>=' },
       { label: 'is less than or equal to', logic: '<=' },
     ],
-    queryKey: 'vad_init_ms',
-    text: 'vad_init_ms',
+    queryKey: 'vad.init_ms',
+    text: 'vad.init_ms',
     type: 'number',
   },
   {
@@ -486,7 +486,7 @@ const SESSION_SEARCH_CRITERIA: Record<string, string> = {
   timestamp: 'created_date',
   'tts.duration_ms': 'tts.duration_ms',
   tts_init_ms: 'tts_init_ms',
-  vad_init_ms: 'vad_init_ms',
+  'vad.init_ms': 'vad.init_ms',
 };
 
 const SESSION_SEARCH_TABS = [


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Test update
- [ ] Security fix

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Closes #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an 'x' -->

### General

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes on multiple platforms (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the API documentation (if applicable)

### Security

- [ ] My changes do not introduce any security vulnerabilities
- [ ] I have not committed any sensitive data (API keys, passwords, etc.)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR normalizes the VAD initialization metric name from `vad_init_ms` to `vad.init_ms` across metric emission, stored data, and UI filters.
- Replaces the shared VAD metric constructor with equivalent provider-local records.
- Adds forward and rollback migrations for historical metric names.
- Updates activity and session-search filters, including dotted-key parser coverage.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The migration collision must be fixed before merging because valid existing metric data can prevent deployment from completing.

A conversation may contain rows under both the old and new metric names, and the unconditional rename then conflicts with the table's unique conversation-and-name constraint; the provider changes also omit required local test updates.

**Files Needing Attention:** api/assistant-api/migrations/000043_normalize_vad_init_metric_name.up.sql, api/assistant-api/migrations/000043_normalize_vad_init_metric_name.down.sql, and the three modified VAD provider files
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/assistant-api/migrations/000043_normalize_vad_init_metric_name.up.sql | Renames historical metrics but can violate the conversation-and-name uniqueness constraint when both names coexist. |
| api/assistant-api/migrations/000043_normalize_vad_init_metric_name.down.sql | Reverses the rename but has the same collision failure in the opposite direction. |
| api/assistant-api/internal/observability/metric.go | Normalizes the metric constant and removes the now-inlined VAD-specific constructor. |
| api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go | Inlines an equivalent VAD initialization metric record but lacks the required same-package test update. |
| api/assistant-api/internal/vad/internal/silero_vad/silero_vad.go | Inlines an equivalent VAD initialization metric record but lacks the required same-package test update. |
| api/assistant-api/internal/vad/internal/ten_vad/ten_vad.go | Inlines an equivalent VAD initialization metric record but lacks the required same-package test update. |
| ui/src/app/pages/assistant/view/conversations/session-query-search.tsx | Coordinates the session filter key with the normalized metric name. |
| ui/src/app/pages/assistant/view/conversations/session-query-search.test.ts | Confirms dotted metric names are parsed into the expected search criterion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  VAD[VAD providers] -->|emit vad.init_ms| Recorder[Observability recorder]
  Recorder --> DB[(assistant_conversation_metrics)]
  Migration[Migration 000043] -->|rename vad_init_ms| DB
  UI[Activity and session filters] -->|query vad.init_ms| DB
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/migrations/000043_normalize_vad_init_metric_name.up.sql:2-3
**Metric rename collides with existing rows**

If a conversation already has both `vad_init_ms` and `vad.init_ms` rows, this update renames the legacy row to an existing unique `(assistant_conversation_id, name)` value, causing the migration to fail with a unique-constraint violation. The down migration has the same collision in reverse, so both directions should resolve destination rows before renaming.

### Issue 2
api/assistant-api/internal/vad/internal/firered_vad/firered_vad.go:177-188
**Provider metric tests remain unchanged**

This provider and the Silero and TEN providers now independently construct the VAD initialization metric payload, but none of their same-package tests is updated. Add local coverage for the changed payload construction in each affected package, as required for backend changes, so provider-specific regressions are caught.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: removed prefix to dot prefix"](https://github.com/rapidaai/voice-ai/commit/51f2515678909b4db40a67ee6a4cdf08bdfa29ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53584560)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->