### PR TITLE
fix(ui): point Smallest AI provider logo at bundled asset in production config

### DIFF
--- a/ui/src/providers/provider.production.json
+++ b/ui/src/providers/provider.production.json
@@ -670,7 +670,7 @@
         "code": "smallest",
         "name": "Smallest AI",
         "description": "Smallest AI builds ultra-low-latency, cost-efficient speech models — Lightning text-to-speech and Pulse speech-to-text — purpose-built for real-time voice agents.",
-        "image": "https://cdn-01.rapida.ai/providers/smallest-ai.png",
+        "image": "/images/providers/smallest-ai.png",
         "featureList": [
             "stt",
             "tts",


### PR DESCRIPTION
## Problem
The Smallest AI provider card logo doesn't render in the connectors/providers section on production builds.

## Root cause
`provider.production.json` still references `https://cdn-01.rapida.ai/providers/smallest-ai.png`, which 404s — the asset was never uploaded to the CDN (confirmed: other providers' CDN assets, e.g. `11labs.png`, return 200; `smallest-ai.png` returns 404).

`provider.development.json` was already fixed in #185 (10821b4f) to use the locally bundled `ui/public/images/providers/smallest-ai.png` instead, but the production config was left pointing at the CDN.

## Fix
Mirror the dev fix in `provider.production.json`, pointing it at the same locally bundled asset (`/images/providers/smallest-ai.png`) so the logo renders without depending on a CDN upload.

## Verification
- Confirmed the CDN URL 404s and the local asset exists at `ui/public/images/providers/smallest-ai.png`.
- Rebuilt the `ui` Docker image locally and verified the provider config picks up the bundled asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Smallest AI provider image to use the correct local asset, improving image loading and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the broken Smallest AI CDN logo URL in production configuration with the bundled same-origin asset path.
- Aligns the production image path with the development provider configuration.
- Removes reliance on the unavailable CDN asset.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/providers/provider.production.json | Updates the Smallest AI production logo URL to reference the bundled provider image. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): point smallest ai provider logo..."](https://github.com/rapidaai/voice-ai/commit/0fb038d592c2f03af5e4e2e822f622b3ddf6b40c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54239903)</sub>

<!-- /greptile_comment -->