### PR TITLE
fix: correct assistant Postman authentication headers

### DIFF
--- a/openapi/postman/README.md
+++ b/openapi/postman/README.md
@@ -34,8 +34,12 @@ npx --yes newman run openapi/postman/assistant-api/assistant-api.smoke.postman_c
   --folder "Smoke Flow" \
   --bail \
   --env-var baseUrl=http://localhost:9007 \
-  --env-var authToken="$AUTH_TOKEN"
+  --env-var authToken="$AUTH_TOKEN" \
+  --env-var authId="$AUTH_ID" \
+  --env-var projectId="$PROJECT_ID"
 ```
+
+`authToken` must be the raw Rapida auth token without a `Bearer ` prefix. The assistant API also requires the authenticated user ID in `x-auth-id` and the selected project ID in `x-project-id`.
 
 The assistant-api smoke flow runs:
 

--- a/openapi/postman/assistant-api/assistant-api.postman_collection.json
+++ b/openapi/postman/assistant-api/assistant-api.postman_collection.json
@@ -6,11 +6,21 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
-    "type": "bearer",
-    "bearer": [
+    "type": "apikey",
+    "apikey": [
       {
-        "key": "token",
+        "key": "key",
+        "value": "authorization",
+        "type": "string"
+      },
+      {
+        "key": "value",
         "value": "{{authToken}}",
+        "type": "string"
+      },
+      {
+        "key": "in",
+        "value": "header",
         "type": "string"
       }
     ]
@@ -39,6 +49,16 @@
     },
     {
       "key": "authToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "authId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "projectId",
       "value": "",
       "type": "string"
     },
@@ -122,6 +142,14 @@
                 "value": "application/json"
               },
               {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
+              },
+              {
                 "key": "Content-Type",
                 "value": "application/json"
               }
@@ -181,6 +209,14 @@
                 "value": "application/json"
               },
               {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
+              },
+              {
                 "key": "Content-Type",
                 "value": "application/json"
               }
@@ -233,6 +269,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -283,6 +327,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -310,6 +362,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               },
               {
                 "key": "Content-Type",
@@ -350,6 +410,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -385,6 +453,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   },
                   {
                     "key": "Content-Type",
@@ -423,6 +499,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -449,6 +533,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -500,6 +592,14 @@
                     "value": "application/json"
                   },
                   {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
+                  },
+                  {
                     "key": "Content-Type",
                     "value": "application/json"
                   }
@@ -536,6 +636,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -562,6 +670,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -613,6 +729,14 @@
                     "value": "application/json"
                   },
                   {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
+                  },
+                  {
                     "key": "Content-Type",
                     "value": "application/json"
                   }
@@ -649,6 +773,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -675,6 +807,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -726,6 +866,14 @@
                     "value": "application/json"
                   },
                   {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
+                  },
+                  {
                     "key": "Content-Type",
                     "value": "application/json"
                   }
@@ -762,6 +910,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -788,6 +944,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -839,6 +1003,14 @@
                     "value": "application/json"
                   },
                   {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
+                  },
+                  {
                     "key": "Content-Type",
                     "value": "application/json"
                   }
@@ -875,6 +1047,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {
@@ -901,6 +1081,14 @@
                   {
                     "key": "Accept",
                     "value": "application/json"
+                  },
+                  {
+                    "key": "x-auth-id",
+                    "value": "{{authId}}"
+                  },
+                  {
+                    "key": "x-project-id",
+                    "value": "{{projectId}}"
                   }
                 ],
                 "url": {

--- a/openapi/postman/assistant-api/assistant-api.smoke.postman_collection.json
+++ b/openapi/postman/assistant-api/assistant-api.smoke.postman_collection.json
@@ -6,11 +6,21 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
-    "type": "bearer",
-    "bearer": [
+    "type": "apikey",
+    "apikey": [
       {
-        "key": "token",
+        "key": "key",
+        "value": "authorization",
+        "type": "string"
+      },
+      {
+        "key": "value",
         "value": "{{authToken}}",
+        "type": "string"
+      },
+      {
+        "key": "in",
+        "value": "header",
         "type": "string"
       }
     ]
@@ -23,6 +33,16 @@
     },
     {
       "key": "authToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "authId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "projectId",
       "value": "",
       "type": "string"
     },
@@ -106,6 +126,14 @@
                 "value": "application/json"
               },
               {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
+              },
+              {
                 "key": "Content-Type",
                 "value": "application/json"
               }
@@ -170,6 +198,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               },
               {
                 "key": "Content-Type",
@@ -237,6 +273,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -290,6 +334,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -366,6 +418,14 @@
                 "value": "application/json"
               },
               {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
+              },
+              {
                 "key": "Content-Type",
                 "value": "application/json"
               }
@@ -430,6 +490,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -483,6 +551,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               },
               {
                 "key": "Content-Type",
@@ -549,6 +625,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -600,6 +684,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {
@@ -668,6 +760,14 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "x-auth-id",
+                "value": "{{authId}}"
+              },
+              {
+                "key": "x-project-id",
+                "value": "{{projectId}}"
               }
             ],
             "url": {

--- a/openapi/scripts/generate_assistant_postman_collection.py
+++ b/openapi/scripts/generate_assistant_postman_collection.py
@@ -191,6 +191,8 @@ REQUEST_EXAMPLES: dict[str, dict[str, Any]] = {
 COLLECTION_VARIABLES: list[dict[str, str]] = [
     {"key": "baseUrl", "value": "http://localhost:9007", "type": "string"},
     {"key": "authToken", "value": "", "type": "string"},
+    {"key": "authId", "value": "", "type": "string"},
+    {"key": "projectId", "value": "", "type": "string"},
     {"key": "assistantId", "value": "1", "type": "string"},
     {"key": "configurationId", "value": "1", "type": "string"},
     {"key": "apiDeploymentId", "value": "1", "type": "string"},
@@ -512,8 +514,12 @@ def build_collection(ctx: OpenApiContext) -> dict[str, Any]:
             "schema": POSTMAN_SCHEMA,
         },
         "auth": {
-            "type": "bearer",
-            "bearer": [{"key": "token", "value": "{{authToken}}", "type": "string"}],
+            "type": "apikey",
+            "apikey": [
+                {"key": "key", "value": "authorization", "type": "string"},
+                {"key": "value", "value": "{{authToken}}", "type": "string"},
+                {"key": "in", "value": "header", "type": "string"},
+            ],
         },
         "event": [
             {
@@ -555,8 +561,12 @@ def build_smoke_collection(ctx: OpenApiContext) -> dict[str, Any]:
             "schema": POSTMAN_SCHEMA,
         },
         "auth": {
-            "type": "bearer",
-            "bearer": [{"key": "token", "value": "{{authToken}}", "type": "string"}],
+            "type": "apikey",
+            "apikey": [
+                {"key": "key", "value": "authorization", "type": "string"},
+                {"key": "value", "value": "{{authToken}}", "type": "string"},
+                {"key": "in", "value": "header", "type": "string"},
+            ],
         },
         "variable": COLLECTION_VARIABLES,
         "item": [
@@ -652,7 +662,11 @@ def build_item(
 
 
 def build_headers(operation: dict[str, Any]) -> list[dict[str, str]]:
-    headers = [{"key": "Accept", "value": "application/json"}]
+    headers = [
+        {"key": "Accept", "value": "application/json"},
+        {"key": "x-auth-id", "value": "{{authId}}"},
+        {"key": "x-project-id", "value": "{{projectId}}"},
+    ]
     if operation.get("requestBody"):
         headers.append({"key": "Content-Type", "value": "application/json"})
     return headers


### PR DESCRIPTION
## Summary
- send the raw Rapida auth token through the `authorization` header instead of using Postman Bearer authentication
- add `authId` and `projectId` collection variables
- include `x-auth-id` and `x-project-id` on generated assistant API requests
- update the Newman smoke-test documentation and regenerate both collections

## Problem
The generated create-assistant request returned `401 unauthenticated request` because Postman prefixed the token with `Bearer`. Using only a project API key returned `403 missing authentication scope` because the handler requires user, organization, and selected-project scope.

## Validation
- `python3 openapi/scripts/generate_assistant_postman_collection.py --check`
- `go test ./api/assistant-api/api/assistant -run 'TestCreateAssistantRest' -count=1`
- generated collection authentication/header assertions
- end-to-end `POST /v1/assistant/create-assistant` returned HTTP 200 with raw `authorization`, `x-auth-id`, and `x-project-id` headers
