### PR TITLE
chore: add Go-only CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          build-mode: autobuild
+          queries: security-and-quality
+
+      - name: Autobuild Go
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Analyze Go
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:go


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow scoped to Go
- run security-and-quality queries on pushes and pull requests targeting `main` or `develop`
- run a weekly scheduled scan and support manual dispatch
- use CodeQL Action v4 with Go autobuild
- apply minimal permissions, concurrency cancellation, and a 45-minute timeout

## Repository configuration

GitHub default CodeQL setup was disabled so this advanced workflow can upload results. Default setup previously scanned multiple languages and would override the repository workflow.

## Validation

- `actionlint .github/workflows/codeql.yml`
- YAML parsing with Ruby
- pre-commit merge-conflict and secret checks
- `git diff --check`
