### PR TITLE
feat: require RFC confirmation before implementation

### DIFF
--- a/.claude/agents/plan-challenger.md
+++ b/.claude/agents/plan-challenger.md
@@ -4,10 +4,11 @@ description: Independently challenge a task plan for simplicity, correctness, ow
 tools: Read,Glob,Grep,LS,Bash
 ---
 
-You review a proposed task plan before implementation. You do not edit production or test files.
+You review the proposed task plan and the exact drafted RFC before implementation. You do not edit repository files.
 
 Review requirements:
 - Verify the problem and acceptance criteria are testable.
+- Verify the RFC path and SHA-256 identify the exact bytes reviewed and that the RFC matches the plan.
 - Identify a smaller or simpler valid solution.
 - Challenge speculative abstractions, configuration, and unrelated cleanup.
 - Check file ownership is explicit, complete, and non-overlapping.
@@ -20,4 +21,9 @@ Decision:
 - `revise`: the plan needs specific corrections before implementation.
 - `block`: the task is unsafe, unclear, or lacks required evidence.
 
-You may not approve a plan you authored. Record reasons and required revisions explicitly.
+For `approve`, emit a JSON receipt containing `run_id`, `task_id`, `decision`,
+`rfc_file`, `rfc_sha256`, `reviewed_at`, and `reviewer`. The digest must be computed
+from the exact accepted RFC bytes reviewed. `revise` and `block` must not emit an
+approval receipt.
+
+You may not approve a plan or RFC you authored. Record reasons and required revisions explicitly. Any RFC byte change invalidates the decision and requires another challenge.

--- a/.claude/agents/rfc-author.md
+++ b/.claude/agents/rfc-author.md
@@ -1,0 +1,20 @@
+---
+name: rfc-author
+description: Convert a completed task plan into the coordinator-reserved RFC before implementation.
+tools: Read,Glob,Grep,LS,Edit,Write,Bash
+---
+
+You own only the coordinator-reserved RFC path supplied in the task. You do not edit production code, tests, the RFC index, or any other repository file.
+
+Required output:
+- An RFC that faithfully represents the completed task plan and is iterated until challenge findings are resolved.
+- Explicit contracts, compatibility constraints, alternatives, risks, migration, rollout, observability, verification, and rollback.
+- Open decisions that still require confirmation.
+- The exact RFC path created or updated.
+
+Rules:
+- Refuse an absolute path, a path outside `rfcs/`, or a path that already existed before reservation.
+- Do not broaden the approved scope or invent decisions not supported by the plan.
+- Before final challenge approval, set the sole metadata status line to `- Status: Accepted`; the later exact-digest gate confirms those unchanged bytes.
+- Use repository evidence and cite paths where useful.
+- Stop if the reserved path collides or any other file would need modification.

--- a/.claude/agents/task-planner.md
+++ b/.claude/agents/task-planner.md
@@ -4,7 +4,7 @@ description: Investigate a change and produce a principle-driven task contract b
 tools: Read,Glob,Grep,LS,Bash
 ---
 
-You own investigation and planning. You do not edit production or test files.
+You own investigation and planning. You do not edit repository files.
 
 Required output:
 - Verified problem statement and relevant existing behavior.
@@ -15,10 +15,12 @@ Required output:
 - Required test categories and exact verification commands.
 - Security, observability, rollout, migration, and rollback considerations.
 - Assumptions and open questions requiring a decision.
+- RFC applicability, reserved RFC path, and the inputs the RFC author must preserve.
 
 Rules:
 - Prefer evidence from repository code, tests, and history over assumptions.
 - Apply KISS and YAGNI before proposing new abstractions.
 - Do not approve your own plan.
 - Mark the decision as `pending` until an independent challenge is resolved.
+- Hand the completed plan to the RFC author before challenge; implementation cannot start from the plan alone.
 - Use `.claude/orchestrator/templates/task-plan.md` as the output structure.

--- a/.claude/orchestrator/README.md
+++ b/.claude/orchestrator/README.md
@@ -59,8 +59,15 @@ Templates:
 Create the corresponding Orca Run, task DAG, approval gate, and planner worker with:
 
 ```bash
-make orca-development-run OBJECTIVE="describe the desired outcome" AGENT=claude
+make orca-development-run OBJECTIVE="describe the desired outcome" \
+  RFC="rfcs/NNNN-short-name.md" AGENT=claude
 ```
+
+This creates only the planner, RFC-author, and challenger tasks and starts the planner.
+After the exact challenged RFC bytes contain `- Status: Accepted`, use
+`make orca-confirm-rfc-create` to create a dedicated confirmation task and exact-digest gate. Use
+`make orca-confirm-rfc-collect` to verify the resolved gate and write its receipt before
+creating or starting implementation tasks.
 
 ## Notes
 

--- a/.claude/orchestrator/templates/task-plan.md
+++ b/.claude/orchestrator/templates/task-plan.md
@@ -13,6 +13,13 @@
 - Acceptance criteria:
 - Non-goals:
 
+## RFC
+
+- Reserved path:
+- RFC author:
+- Exact reviewed SHA-256:
+- Confirmation gate / receipt:
+
 ## Scope and Ownership
 
 | Path or module | Owner | Responsibility |

--- a/.codex/agents/plan-challenger.md
+++ b/.codex/agents/plan-challenger.md
@@ -4,10 +4,11 @@ description: Independently challenge a task plan for simplicity, correctness, ow
 tools: Read,Glob,Grep,LS,Bash
 ---
 
-You review a proposed task plan before implementation. You do not edit production or test files.
+You review the proposed task plan and the exact drafted RFC before implementation. You do not edit repository files.
 
 Review requirements:
 - Verify the problem and acceptance criteria are testable.
+- Verify the RFC path and SHA-256 identify the exact bytes reviewed and that the RFC matches the plan.
 - Identify a smaller or simpler valid solution.
 - Challenge speculative abstractions, configuration, and unrelated cleanup.
 - Check file ownership is explicit, complete, and non-overlapping.
@@ -20,4 +21,9 @@ Decision:
 - `revise`: the plan needs specific corrections before implementation.
 - `block`: the task is unsafe, unclear, or lacks required evidence.
 
-You may not approve a plan you authored. Record reasons and required revisions explicitly.
+For `approve`, emit a JSON receipt containing `run_id`, `task_id`, `decision`,
+`rfc_file`, `rfc_sha256`, `reviewed_at`, and `reviewer`. The digest must be computed
+from the exact accepted RFC bytes reviewed. `revise` and `block` must not emit an
+approval receipt.
+
+You may not approve a plan or RFC you authored. Record reasons and required revisions explicitly. Any RFC byte change invalidates the decision and requires another challenge.

--- a/.codex/agents/rfc-author.md
+++ b/.codex/agents/rfc-author.md
@@ -1,0 +1,20 @@
+---
+name: rfc-author
+description: Convert a completed task plan into the coordinator-reserved RFC before implementation.
+tools: Read,Glob,Grep,LS,Edit,Write,Bash
+---
+
+You own only the coordinator-reserved RFC path supplied in the task. You do not edit production code, tests, the RFC index, or any other repository file.
+
+Required output:
+- An RFC that faithfully represents the completed task plan and is iterated until challenge findings are resolved.
+- Explicit contracts, compatibility constraints, alternatives, risks, migration, rollout, observability, verification, and rollback.
+- Open decisions that still require confirmation.
+- The exact RFC path created or updated.
+
+Rules:
+- Refuse an absolute path, a path outside `rfcs/`, or a path that already existed before reservation.
+- Do not broaden the approved scope or invent decisions not supported by the plan.
+- Before final challenge approval, set the sole metadata status line to `- Status: Accepted`; the later exact-digest gate confirms those unchanged bytes.
+- Use repository evidence and cite paths where useful.
+- Stop if the reserved path collides or any other file would need modification.

--- a/.codex/agents/task-planner.md
+++ b/.codex/agents/task-planner.md
@@ -4,7 +4,7 @@ description: Investigate a change and produce a principle-driven task contract b
 tools: Read,Glob,Grep,LS,Bash
 ---
 
-You own investigation and planning. You do not edit production or test files.
+You own investigation and planning. You do not edit repository files.
 
 Required output:
 - Verified problem statement and relevant existing behavior.
@@ -15,10 +15,12 @@ Required output:
 - Required test categories and exact verification commands.
 - Security, observability, rollout, migration, and rollback considerations.
 - Assumptions and open questions requiring a decision.
+- RFC applicability, reserved RFC path, and the inputs the RFC author must preserve.
 
 Rules:
 - Prefer evidence from repository code, tests, and history over assumptions.
 - Apply KISS and YAGNI before proposing new abstractions.
 - Do not approve your own plan.
 - Mark the decision as `pending` until an independent challenge is resolved.
+- Hand the completed plan to the RFC author before challenge; implementation cannot start from the plan alone.
 - Use `.codex/orchestrator/templates/task-plan.md` as the output structure.

--- a/.codex/orchestrator/README.md
+++ b/.codex/orchestrator/README.md
@@ -59,8 +59,15 @@ Templates:
 Create the corresponding Orca Run, task DAG, approval gate, and planner worker with:
 
 ```bash
-make orca-development-run OBJECTIVE="describe the desired outcome" AGENT=codex
+make orca-development-run OBJECTIVE="describe the desired outcome" \
+  RFC="rfcs/NNNN-short-name.md" AGENT=codex
 ```
+
+This creates only the planner, RFC-author, and challenger tasks and starts the planner.
+After the exact challenged RFC bytes contain `- Status: Accepted`, use
+`make orca-confirm-rfc-create` to create a dedicated confirmation task and exact-digest gate. Use
+`make orca-confirm-rfc-collect` to verify the resolved gate and write its receipt before
+creating or starting implementation tasks.
 
 ## Notes
 

--- a/.codex/orchestrator/templates/task-plan.md
+++ b/.codex/orchestrator/templates/task-plan.md
@@ -13,6 +13,13 @@
 - Acceptance criteria:
 - Non-goals:
 
+## RFC
+
+- Reserved path:
+- RFC author:
+- Exact reviewed SHA-256:
+- Confirmation gate / receipt:
+
 ## Scope and Ownership
 
 | Path or module | Owner | Responsibility |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,12 @@
 - Ownership:
 - Rollback or disablement:
 
+## RFC Confirmation
+
+- Accepted RFC:
+- Confirmed SHA-256:
+- Orca confirmation gate / receipt:
+
 ## Principles
 
 <!-- Explain relevant tradeoffs. Use N/A only when genuinely inapplicable. -->
@@ -41,7 +47,8 @@
 
 ## Checklist
 
-- [ ] The plan was challenged and explicitly approved before implementation.
+- [ ] The exact plan and RFC were challenged before implementation.
+- [ ] The accepted RFC digest was explicitly confirmed before implementation started.
 - [ ] I kept the change focused.
 - [ ] I updated tests or docs where needed.
 - [ ] Required validation commands passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,12 @@ Every non-trivial change follows this sequence:
 - Define acceptance criteria, allowed paths, out-of-scope paths, file ownership, required tests, required commands, risks, and rollback strategy.
 - Record how the plan applies KISS, YAGNI, single ownership, explicit contracts, fail-safe behavior, observability, and least privilege.
 
-3. Discuss:
-- A plan challenger who is not the planner must test assumptions, identify a simpler option, and surface compatibility or operational risks.
-- Implementation must not start until open questions are resolved and the plan decision is explicitly `approved`.
+3. RFC and discuss:
+- Reserve an unused `rfcs/NNNN-short-name.md` path before drafting.
+- An RFC author converts the plan into an RFC without implementing the change and resolves challenge revisions.
+- A plan challenger who is neither planner nor RFC author must challenge the exact plan and RFC bytes, identify a simpler option, and surface compatibility or operational risks.
+- The challenger approves only final bytes whose sole metadata status line is `- Status: Accepted`; the coordinator then creates an exact-digest confirmation gate without changing the RFC.
+- Implementation must not start until the gate is explicitly `approved`; any RFC byte change invalidates confirmation.
 
 4. Implement:
 - Use execution-focused worker(s) with disjoint ownership by file or module.
@@ -38,6 +41,7 @@ Every non-trivial change follows this sequence:
 7. Ship:
 - Ship only after implementation, verification, and independent code review gates pass.
 - Preserve the approved plan, verification commands, review report, and unresolved follow-ups in the PR.
+- Preserve the accepted RFC path, confirmed digest, and confirmation receipt in the PR.
 
 See `DEVELOPMENT_PROCESS.md` for role responsibilities and the Orca workflow.
 

--- a/DEVELOPMENT_PROCESS.md
+++ b/DEVELOPMENT_PROCESS.md
@@ -6,7 +6,7 @@ This repository uses a principle-driven, multi-agent lifecycle designed for Orca
 
 The required sequence is:
 
-`understand -> plan -> discuss -> approve -> implement -> verify -> review -> ship`
+`understand -> plan -> draft RFC -> challenge -> confirm -> implement -> verify -> review -> ship`
 
 No agent may collapse planning, implementation, verification, and final code review into one self-approved action for a non-trivial change.
 
@@ -64,6 +64,15 @@ Before implementation, the approved plan must contain:
 - Required test categories and exact verification commands.
 - Rollback, disablement, or migration strategy.
 - Plan challenge outcome and explicit approval.
+- Reserved RFC path and the exact accepted RFC SHA-256.
+- RFC confirmation gate receipt with Run, Task, Gate, question, resolution, and timestamps.
+
+The RFC author drafts only the coordinator-reserved path. The challenger reviews the
+exact plan and RFC bytes. After all findings are resolved, the final challenged bytes
+must already contain the sole metadata line `- Status: Accepted`. The coordinator then
+creates a gate whose question includes the RFC path and SHA-256 without editing the RFC.
+Implementation may start only after that gate resolves to `approved`. Any
+subsequent RFC byte change requires a new challenge and confirmation.
 
 The approved plan is stored as a separate JSON artifact. Its SHA-256 and a coordinator-generated HMAC are recorded in the cumulative lifecycle envelope, and every gate verifies that the envelope plan still matches that artifact. The HMAC signs `<run_id>:<plan_sha256>` using `DEVELOPMENT_GATE_KEY`. That key belongs only to the coordinator or CI gate runner and must not be exposed to implementation or review workers.
 
@@ -83,9 +92,28 @@ Start a governed Run from an Orca-managed terminal:
 
 ```bash
 make orca-development-run OBJECTIVE="describe the desired outcome" AGENT=codex
+  RFC="rfcs/NNNN-short-name.md"
 ```
 
-The command creates the Orca Run, dependent planning, challenge, implementation, verification, and code-review tasks, an approval gate blocking implementation, and a supervised planner worker. Orca must be running with orchestration enabled.
+The command creates the Orca Run and dependent planning, RFC-authoring, and challenge
+tasks, then starts only the planner. It intentionally does not create or start an
+implementation task.
+
+After challenge approval, the coordinator creates the exact-digest gate on a dedicated
+confirmation task. No implementation task is created yet:
+
+```bash
+make orca-confirm-rfc-create RUN_ID="<run>" CHALLENGE_TASK_ID="<challenge-task>" \
+  CHALLENGE_RECEIPT="<approved-challenge.json>" RFC="rfcs/NNNN-short-name.md"
+```
+
+After the gate resolves, collect the authoritative receipt before starting a worker:
+
+```bash
+make orca-confirm-rfc-collect RUN_ID="<run>" TASK_ID="<confirmation-task>" \
+  CHALLENGE_TASK_ID="<challenge-task>" CHALLENGE_RECEIPT="<approved-challenge.json>" \
+  GATE_ID="<gate>" RFC="rfcs/NNNN-short-name.md" RECEIPT="<receipt.json>"
+```
 
 Generate the development panel from a lifecycle envelope:
 
@@ -102,15 +130,16 @@ make orca-panel-open PANEL_INPUT="path/to/lifecycle-input.json"
 The panel displays stage readiness, principle decisions, ownership, exact verification commands, review findings, final-gate issues, and Orca Run/Task/Dispatch provenance. With `DEVELOPMENT_GATE_KEY` available to the coordinator, it also executes the final gate and shows trusted ship readiness.
 
 1. Create one Orca Run for the objective.
-2. Create investigation and planning tasks before implementation tasks.
-3. Dispatch the planner and plan challenger independently.
-4. Resolve discussion through messages and an explicit decision gate.
-5. Create implementation tasks with disjoint file ownership.
-6. Dispatch verification after implementation settles.
-7. Dispatch the code reviewer only after verification passes.
-8. Route review findings to the original implementation owner.
-9. Re-run affected verification after fixes.
-10. Ship only after the final review decision is `approved`.
+2. Reserve the RFC number and create planning, RFC-authoring, and challenge tasks.
+3. Dispatch planner, RFC author, and challenger in dependency order.
+4. Resolve challenge findings before marking the RFC `Accepted`.
+5. Create an exact-digest confirmation gate on a dedicated confirmation task.
+6. Collect the approved receipt and preserve the accepted RFC baseline.
+7. Start implementation tasks with disjoint file ownership.
+8. Dispatch verification after implementation settles.
+9. Dispatch the code reviewer only after verification passes.
+10. Route findings to the original implementation owner and re-verify fixes.
+11. Ship only after the final review decision is `approved`.
 
 The final review envelope must include the Orca Run, review Task, and review Dispatch identifiers. Reviewer identity comes from the execution metadata, while implementation ownership comes from the coordinator-attested approved-plan artifact.
 
@@ -128,6 +157,7 @@ Use Orca worktree comments to record decisions and keep each implementation task
 A completed change retains:
 
 - Approved plan and challenge decision.
+- Accepted RFC and exact-digest confirmation receipt.
 - Implementation summary and changed-file list.
 - Verification commands with results.
 - Independent code-review report.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
         push-rapida-golang-bookworm push-rapida-golang-alpine push-rapida-alpine \
         push-rapida-debian-slim push-rapida-node-alpine push-rapida-python \
         test-tts-integration test-stt-integration test-transformer-integration \
-        validate-development-process validate-agent-tooling validate-development-toolkit sign-approved-plan orca-development-run orca-panel orca-panel-open doctor
+        validate-development-process validate-agent-tooling validate-development-toolkit sign-approved-plan orca-development-run orca-confirm-rfc-create orca-confirm-rfc-collect orca-panel orca-panel-open doctor
 
 COMPOSE           := DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml
 COMPOSE_KNOWLEDGE := DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml -f docker-compose.knowledge.yml
@@ -792,8 +792,16 @@ sign-approved-plan:
 	@bash bin/sign-approved-plan "$(RUN_ID)" "$(PLAN)"
 
 orca-development-run:
-	@test -n "$(OBJECTIVE)" || (echo "Usage: make orca-development-run OBJECTIVE='task objective' [AGENT=codex]" && exit 2)
-	@bash bin/orca-development-run "$(OBJECTIVE)" "$(or $(AGENT),codex)"
+	@test -n "$(OBJECTIVE)" -a -n "$(RFC)" || (echo "Usage: make orca-development-run OBJECTIVE='task objective' RFC='rfcs/NNNN-name.md' [AGENT=codex]" && exit 2)
+	@bash bin/orca-development-run "$(OBJECTIVE)" "$(or $(AGENT),codex)" "$(RFC)"
+
+orca-confirm-rfc-create:
+	@test -n "$(RUN_ID)" -a -n "$(CHALLENGE_TASK_ID)" -a -n "$(CHALLENGE_RECEIPT)" -a -n "$(RFC)" || (echo "Usage: make orca-confirm-rfc-create RUN_ID=... CHALLENGE_TASK_ID=... CHALLENGE_RECEIPT=... RFC=rfcs/NNNN-name.md" && exit 2)
+	@python3 bin/orca-confirm-rfc create --run "$(RUN_ID)" --challenge-task "$(CHALLENGE_TASK_ID)" --challenge-receipt "$(CHALLENGE_RECEIPT)" --rfc "$(RFC)"
+
+orca-confirm-rfc-collect:
+	@test -n "$(RUN_ID)" -a -n "$(TASK_ID)" -a -n "$(CHALLENGE_TASK_ID)" -a -n "$(CHALLENGE_RECEIPT)" -a -n "$(GATE_ID)" -a -n "$(RFC)" || (echo "Usage: make orca-confirm-rfc-collect RUN_ID=... TASK_ID=... CHALLENGE_TASK_ID=... CHALLENGE_RECEIPT=... GATE_ID=... RFC=rfcs/NNNN-name.md [RECEIPT=...]" && exit 2)
+	@python3 bin/orca-confirm-rfc collect --run "$(RUN_ID)" --task "$(TASK_ID)" --challenge-task "$(CHALLENGE_TASK_ID)" --challenge-receipt "$(CHALLENGE_RECEIPT)" --gate "$(GATE_ID)" --rfc "$(RFC)" $(if $(RECEIPT),--output "$(RECEIPT)",)
 
 orca-panel:
 	@python3 bin/orca-development-panel --input "$(or $(PANEL_INPUT),.codex/orchestrator/examples/lifecycle-input.json)" --output "$(or $(PANEL_OUTPUT),.cache/orca-development-panel.html)"

--- a/bin/README.md
+++ b/bin/README.md
@@ -3,6 +3,12 @@
 Scripts to perform various build, install, analysis, etc operations.
 These scripts keep the root level Makefile small and simple.
 
+Development governance helpers:
+
+- `orca-development-run` reserves an RFC path and creates the planning/RFC/challenge DAG.
+- `orca-confirm-rfc` creates or collects the exact-digest RFC confirmation gate.
+- `sign-approved-plan` attests an approved plan for lifecycle hooks.
+
 - artifacts-generate.sh Generating artifacts from protos and OpenAPI specs
 - git-commit-hook-setup.sh Setup pre-commit, commit-msg, and pre-push hooks.
 - check-go-version-consistency Verifies Go, CI, and Docker base-image versions remain aligned.

--- a/bin/orca-confirm-rfc
+++ b/bin/orca-confirm-rfc
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+RFC_PATTERN = re.compile(r"^rfcs/[0-9]{4}-[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?\.md$")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def orca_command() -> list[str]:
+    configured = os.environ.get("ORCA_CLI_COMMAND", "").strip()
+    if configured:
+        return shlex.split(configured)
+    if os.environ.get("ORCA_DEV_REPO_ROOT"):
+        return ["orca-dev"]
+    if sys.platform.startswith("linux"):
+        return ["orca-ide"]
+    return ["orca"]
+
+
+def run_orca(*arguments: str) -> dict:
+    completed = subprocess.run(
+        [*orca_command(), *arguments, "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        fail(completed.stderr.strip() or completed.stdout.strip() or "Orca command failed")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        fail(f"Orca returned invalid JSON: {exc}")
+
+
+def find_identifier(payload: object, names: tuple[str, ...], nested: str) -> str:
+    if isinstance(payload, dict):
+        for name in names:
+            value = payload.get(name)
+            if isinstance(value, str) and value:
+                return value
+        value = payload.get(nested)
+        if isinstance(value, dict):
+            identifier = value.get("id")
+            if isinstance(identifier, str) and identifier:
+                return identifier
+        for value in payload.values():
+            identifier = find_identifier(value, names, nested)
+            if identifier:
+                return identifier
+    if isinstance(payload, list):
+        for value in payload:
+            identifier = find_identifier(value, names, nested)
+            if identifier:
+                return identifier
+    return ""
+
+
+def load_rfc(repo_root: Path, relative_path: str) -> tuple[Path, bytes, str]:
+    if not RFC_PATTERN.fullmatch(relative_path) or Path(relative_path).is_absolute():
+        fail("RFC must be a relative path matching rfcs/NNNN-short-name.md")
+    root = repo_root.resolve()
+    rfc_directory = root / "rfcs"
+    if rfc_directory.is_symlink() or not rfc_directory.is_dir():
+        fail("Repository rfcs path must be a real directory, not a symlink")
+    rfc_root = rfc_directory.resolve()
+    candidate = root / relative_path
+    if candidate.is_symlink() or not candidate.is_file():
+        fail("RFC must be an existing regular file, not a symlink")
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(rfc_root)
+    except ValueError:
+        fail("RFC path escapes the repository rfcs directory")
+    raw = resolved.read_bytes()
+    text = raw.decode("utf-8")
+    header = text.split("\n## ", 1)[0]
+    status_lines = [line for line in header.splitlines() if line.startswith("- Status:")]
+    if status_lines != ["- Status: Accepted"]:
+        fail("RFC must contain exactly one '- Status: Accepted' before the first section")
+    return resolved, raw, hashlib.sha256(raw).hexdigest()
+
+
+def confirmation_question(rfc_path: str, digest: str, challenge_task: str, challenge_receipt_sha256: str) -> str:
+    return (
+        f"Approve implementation of RFC {rfc_path} with SHA-256 {digest} after approved "
+        f"challenge task {challenge_task} with receipt SHA-256 {challenge_receipt_sha256}?"
+    )
+
+
+def load_challenge_receipt(path: str, run_id: str, challenge_task: str, rfc_file: str, digest: str) -> tuple[dict, str]:
+    receipt_path = Path(path)
+    if receipt_path.is_symlink() or not receipt_path.is_file():
+        fail("Challenge receipt must be an existing regular JSON file")
+    raw = receipt_path.read_bytes()
+    try:
+        receipt = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"Challenge receipt is invalid: {exc}")
+    expected = {
+        "run_id": run_id,
+        "task_id": challenge_task,
+        "decision": "approved",
+        "rfc_file": rfc_file,
+        "rfc_sha256": digest,
+    }
+    for key, value in expected.items():
+        if receipt.get(key) != value:
+            fail(f"Challenge receipt {key} does not match the confirmed RFC")
+    parse_timestamp(receipt.get("reviewed_at"), "reviewed_at")
+    reviewer = receipt.get("reviewer")
+    if not isinstance(reviewer, str) or not reviewer.strip():
+        fail("Challenge receipt reviewer is required")
+    return receipt, hashlib.sha256(raw).hexdigest()
+
+
+def iter_gates(payload: object):
+    if isinstance(payload, dict):
+        if isinstance(payload.get("gate_id") or payload.get("gateId") or payload.get("id"), str) and (
+            "question" in payload or "resolution" in payload or "status" in payload
+        ):
+            yield payload
+        for value in payload.values():
+            yield from iter_gates(value)
+    elif isinstance(payload, list):
+        for value in payload:
+            yield from iter_gates(value)
+
+
+def parse_timestamp(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"Gate is missing {field}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        fail(f"Gate has malformed {field}")
+    if "T" not in value or parsed.tzinfo is None:
+        fail(f"Gate {field} must be an RFC3339 timestamp with timezone")
+    return value
+
+
+def create(args: argparse.Namespace) -> None:
+    _, _, digest = load_rfc(Path(args.repo_root), args.rfc)
+    _, challenge_receipt_sha256 = load_challenge_receipt(
+        args.challenge_receipt, args.run, args.challenge_task, args.rfc, digest
+    )
+    question = confirmation_question(args.rfc, digest, args.challenge_task, challenge_receipt_sha256)
+    task_payload = run_orca(
+        "orchestration",
+        "task-create",
+        "--run",
+        args.run,
+        "--task-title",
+        "Confirm exact RFC",
+        "--spec",
+        f"Record confirmation for {args.rfc} at SHA-256 {digest}. This task does not authorize or perform implementation.",
+        "--deps",
+        json.dumps([args.challenge_task]),
+    )
+    task_id = find_identifier(task_payload, ("taskId", "task_id"), "task")
+    if not task_id:
+        fail("Unable to find confirmation task id in Orca response")
+    gate_payload = run_orca(
+        "orchestration",
+        "gate-create",
+        "--task",
+        task_id,
+        "--question",
+        question,
+        "--options",
+        json.dumps(["approved", "rejected"]),
+    )
+    gate_id = find_identifier(gate_payload, ("gateId", "gate_id"), "gate")
+    if not gate_id:
+        fail("Unable to find gate id in Orca response")
+    print(
+        json.dumps(
+            {
+                "run_id": args.run,
+                "challenge_task_id": args.challenge_task,
+                "challenge_receipt_sha256": challenge_receipt_sha256,
+                "confirmation_task_id": task_id,
+                "gate_id": gate_id,
+                "rfc_file": args.rfc,
+                "rfc_sha256": digest,
+                "question": question,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    git_path = subprocess.run(
+        ["git", "-C", args.repo_root, "rev-parse", "--git-common-dir"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if git_path.returncode == 0:
+        reservation_root = Path(git_path.stdout.strip())
+        if not reservation_root.is_absolute():
+            reservation_root = Path(args.repo_root) / reservation_root
+        reservation = reservation_root / "orca-rfc-reservations" / f"{Path(args.rfc).name}.lock"
+        try:
+            reservation.rmdir()
+        except OSError:
+            pass
+
+
+def collect(args: argparse.Namespace) -> None:
+    _, _, digest = load_rfc(Path(args.repo_root), args.rfc)
+    challenge_receipt, challenge_receipt_sha256 = load_challenge_receipt(
+        args.challenge_receipt, args.run, args.challenge_task, args.rfc, digest
+    )
+    expected_question = confirmation_question(
+        args.rfc, digest, args.challenge_task, challenge_receipt_sha256
+    )
+    payload = run_orca("orchestration", "gate-list", "--run", args.run, "--task", args.task)
+    matching = []
+    for gate in iter_gates(payload):
+        identifier = gate.get("gate_id") or gate.get("gateId") or gate.get("id")
+        if identifier == args.gate:
+            matching.append(gate)
+    if len(matching) != 1:
+        fail("Expected exactly one authoritative matching gate")
+    gate = matching[0]
+    gate_task = gate.get("task_id") or gate.get("taskId")
+    if gate_task != args.task:
+        fail("Gate task does not match the requested confirmation task")
+    gate_run = gate.get("run_id") or gate.get("runId")
+    if gate_run != args.run:
+        fail("Gate run does not match the requested Run")
+    if gate.get("question") != expected_question:
+        fail("Gate question does not match the current RFC path and digest")
+    resolution = str(gate.get("resolution") or "").lower()
+    status = str(gate.get("status") or "").lower()
+    if resolution != "approved" or status != "resolved":
+        fail("RFC confirmation gate is not approved")
+    created_at = parse_timestamp(gate.get("created_at") or gate.get("createdAt"), "created_at")
+    resolved_at = parse_timestamp(gate.get("resolved_at") or gate.get("resolvedAt"), "resolved_at")
+    receipt = {
+        "run_id": args.run,
+        "task_id": args.task,
+        "challenge_task_id": args.challenge_task,
+        "challenge_reviewer": challenge_receipt["reviewer"],
+        "challenge_reviewed_at": challenge_receipt["reviewed_at"],
+        "challenge_receipt_sha256": challenge_receipt_sha256,
+        "gate_id": args.gate,
+        "question": expected_question,
+        "resolution": "approved",
+        "created_at": created_at,
+        "resolved_at": resolved_at,
+        "confirmed_sha256": digest,
+        "rfc_file": args.rfc,
+    }
+    rendered = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Create or collect an exact-digest RFC confirmation gate")
+    result.add_argument("--repo-root", default=".")
+    subparsers = result.add_subparsers(dest="command", required=True)
+    create_parser = subparsers.add_parser("create")
+    create_parser.add_argument("--run", required=True)
+    create_parser.add_argument("--challenge-task", required=True)
+    create_parser.add_argument("--challenge-receipt", required=True)
+    create_parser.add_argument("--rfc", required=True)
+    create_parser.set_defaults(handler=create)
+    collect_parser = subparsers.add_parser("collect")
+    collect_parser.add_argument("--run", required=True)
+    collect_parser.add_argument("--task", required=True)
+    collect_parser.add_argument("--challenge-task", required=True)
+    collect_parser.add_argument("--challenge-receipt", required=True)
+    collect_parser.add_argument("--gate", required=True)
+    collect_parser.add_argument("--rfc", required=True)
+    collect_parser.add_argument("--output")
+    collect_parser.set_defaults(handler=collect)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    args.handler(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/orca-development-run
+++ b/bin/orca-development-run
@@ -2,12 +2,44 @@
 set -euo pipefail
 
 objective="${1:-}"
-planner_agent="${2:-codex}"
+planner_agent="${2:-}"
+rfc_path="${3:-}"
 
-if [[ -z "$objective" ]]; then
-  echo "Usage: $0 <objective> [planner-agent]" >&2
+if [[ -z "$objective" || -z "$planner_agent" || -z "$rfc_path" ]]; then
+  echo "Usage: $0 <objective> <planner-agent> <reserved-rfc-path>" >&2
   exit 2
 fi
+
+if [[ "$rfc_path" == /* || ! "$rfc_path" =~ ^rfcs/[0-9]{4}-[a-z0-9]+([a-z0-9-]*[a-z0-9])?\.md$ ]]; then
+  echo "RFC path must be a relative unused path matching rfcs/NNNN-short-name.md." >&2
+  exit 2
+fi
+
+if [[ -e "$rfc_path" || -L "$rfc_path" ]]; then
+  echo "Reserved RFC path already exists: $rfc_path" >&2
+  exit 2
+fi
+
+git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+reservation_root="${git_common_dir:+$git_common_dir/orca-rfc-reservations}"
+if [[ -z "$reservation_root" ]]; then
+  echo "RFC reservation requires a Git worktree." >&2
+  exit 1
+fi
+mkdir -p "$reservation_root"
+reservation_name="${rfc_path#rfcs/}"
+reservation_lock="$reservation_root/$reservation_name.lock"
+if ! mkdir "$reservation_lock" 2>/dev/null; then
+  echo "RFC path is already reserved by another Run: $rfc_path" >&2
+  exit 2
+fi
+reservation_active=1
+cleanup_reservation() {
+  if [[ "$reservation_active" == 1 ]]; then
+    rmdir "$reservation_lock" 2>/dev/null || true
+  fi
+}
+trap cleanup_reservation EXIT
 
 if [[ -n "${ORCA_CLI_COMMAND:-}" ]]; then
   read -r -a orca_cmd <<<"$ORCA_CLI_COMMAND"
@@ -102,33 +134,17 @@ create_task() {
 
 planner_task="$(create_task \
   "Understand and plan" \
-  "Investigate: $objective. Use the task-planner role and task-plan template. Do not edit code. Produce verified context, acceptance criteria, non-goals, explicit path ownership, principle decisions, risks, exact verification commands, and open questions.")"
+  "Investigate: $objective. Use the task-planner role and task-plan template. Do not edit repository files. Produce verified context, acceptance criteria, non-goals, explicit path ownership, principle decisions, risks, exact verification commands, and open questions. Hand the completed plan to the RFC author; do not approve it.")"
 
-challenger_task="$(create_task \
-  "Challenge plan" \
-  "Independently challenge the completed plan for $objective. Use the plan-challenger role. Find a simpler solution, ownership conflicts, missing contracts, unsafe failure paths, weak tests, and rollout risks. Return approve, revise, or block with evidence." \
+rfc_task="$(create_task \
+  "Draft reserved RFC" \
+  "Draft and revise the RFC for: $objective. Use the rfc-author role. The only path you may create or edit is $rfc_path, which the coordinator reserved for this run. Translate the completed plan into exact RFC bytes with contracts, alternatives, migration, testing, observability, rollback, and open decisions. Before final challenge approval, set the sole metadata status line to '- Status: Accepted'. Do not edit the RFC index." \
   "[\"$planner_task\"]")"
 
-implementation_task="$(create_task \
-  "Implement approved plan" \
-  "Implement only the coordinator-approved plan for $objective. Respect its allowed paths and disjoint ownership. Add behavior-focused tests and return the implementation evidence envelope. Do not request or use DEVELOPMENT_GATE_KEY; the coordinator runs lifecycle gates." \
-  "[\"$challenger_task\"]")"
-
-verification_task="$(create_task \
-  "Verify implementation" \
-  "Independently verify $objective. Run every required command and record exit codes and required test categories in the evidence envelope. Do not replace required commands with substitutes or request DEVELOPMENT_GATE_KEY; the coordinator runs lifecycle gates." \
-  "[\"$implementation_task\"]")"
-
-review_task="$(create_task \
-  "Independent code review" \
-  "Review the complete verified diff for $objective using the read-only code-reviewer role. You must not be an implementation owner. Record Orca run/task/dispatch provenance and classify findings. Critical or major findings require changes_requested. Do not request DEVELOPMENT_GATE_KEY; the coordinator runs the final gate." \
-  "[\"$verification_task\"]")"
-
-gate_response="$(run_orca orchestration gate-create \
-  --task "$implementation_task" \
-  --question "Approve the challenged plan before implementation?" \
-  --options '["approved","revise","blocked"]' \
-  --json)"
+challenger_task="$(create_task \
+  "Challenge exact plan and RFC" \
+  "Independently challenge the completed plan and the exact RFC at $rfc_path for: $objective. Use the plan-challenger role and remain read-only. Verify the RFC matches the plan, identify a simpler solution, ownership conflicts, missing contracts, unsafe failure paths, weak tests, and rollout risks. Return approve, revise, or block with evidence. Approval applies only to the reviewed RFC bytes; any later RFC change requires another challenge and confirmation." \
+  "[\"$rfc_task\"]")"
 
 planner_response="$(run_orca orchestration worker-start \
   --run "$run_id" \
@@ -138,21 +154,31 @@ planner_response="$(run_orca orchestration worker-start \
   --json)"
 
 cat <<EOF
-Orca development run created.
+Orca RFC planning run created.
 
-Run:            $run_id
-Planner task:   $planner_task
-Challenge task: $challenger_task
-Implementation: $implementation_task
-Verification:   $verification_task
-Code review:    $review_task
+Run:             $run_id
+Planner task:    $planner_task
+RFC author task: $rfc_task
+Challenge task:  $challenger_task
+Reserved RFC:    $rfc_path
 
-The implementation task is blocked by an approval gate.
-The supervised planner worker has started with agent: $planner_agent
+Only the planner worker has started. Implementation, verification, and review
+tasks must not be created until the challenged RFC is confirmed and committed as
+the governance baseline.
 
-Gate receipt:
-$gate_response
+After the RFC author and challenger finish, create the exact-digest confirmation gate:
+  make orca-confirm-rfc-create RUN_ID="$run_id" CHALLENGE_TASK_ID="$challenger_task" RFC="$rfc_path" CHALLENGE_RECEIPT="<challenge-receipt.json>"
+
+After the gate is resolved, collect the receipt and record the governance baseline:
+  make orca-confirm-rfc-collect RUN_ID="$run_id" TASK_ID="<confirmation-task-id>" CHALLENGE_TASK_ID="$challenger_task" CHALLENGE_RECEIPT="<challenge-receipt.json>" RFC="$rfc_path" GATE_ID="<gate-id>" RECEIPT="<confirmation-receipt.json>"
+  git add "$rfc_path" <approved-plan.json> <confirmation-receipt.json>
+  git commit -m "docs: accept RFC for $objective"
+  DEVELOPMENT_GATE_KEY="..." make sign-approved-plan RUN_ID="$run_id" PLAN="<approved-plan.json>" BASE_REF="<governance-commit>"
+
+Only after the receipt and governance baseline are preserved may the coordinator create
+implementation, verification, and review tasks.
 
 Planner receipt:
 $planner_response
 EOF
+reservation_active=0

--- a/bin/validate-agent-tooling
+++ b/bin/validate-agent-tooling
@@ -59,7 +59,11 @@ for root in .codex .claude; do
     grep -q 'Never approve or review your own' "$role_file" || fail "missing reviewer separation in $role_file"
   done
   grep -q '^tools: Read,Glob,Grep,LS$' "$root/agents/code-reviewer.md" || fail "code reviewer must remain read-only in $root"
+  grep -q '^name: rfc-author$' "$root/agents/rfc-author.md" || fail "missing RFC author role in $root"
+  grep -q 'coordinator-reserved RFC path' "$root/agents/rfc-author.md" || fail "missing RFC path ownership in $root"
 done
+
+cmp -s .codex/agents/rfc-author.md .claude/agents/rfc-author.md || fail "RFC author role parity drift"
 
 python3 - "$repo_root/.claude/settings.json" <<'PY'
 import json

--- a/bin/validate-development-process
+++ b/bin/validate-development-process
@@ -302,6 +302,235 @@ module = importlib.machinery.SourceFileLoader("orca_development_panel", sys.argv
 assert module.resolve_orca_command() == ["/path with spaces/orca", "--environment", "local"]
 PY
 
+rfc_fixture_root="$output_dir/rfc-confirmation"
+mkdir -p "$rfc_fixture_root/rfcs"
+cat >"$rfc_fixture_root/rfcs/0042-confirmation-test.md" <<'EOF'
+# RFC 0042: Confirmation Test
+
+- Status: Accepted
+
+## Summary
+
+Exercise the exact-digest confirmation contract.
+EOF
+rfc_digest="$(shasum -a 256 "$rfc_fixture_root/rfcs/0042-confirmation-test.md" | awk '{print $1}')"
+challenge_receipt="$rfc_fixture_root/challenge-receipt.json"
+cat >"$challenge_receipt" <<EOF
+{
+  "run_id": "run_test",
+  "task_id": "task_challenge",
+  "decision": "approved",
+  "rfc_file": "rfcs/0042-confirmation-test.md",
+  "rfc_sha256": "$rfc_digest",
+  "reviewed_at": "2026-08-20T09:59:00Z",
+  "reviewer": "independent-reviewer"
+}
+EOF
+challenge_receipt_digest="$(shasum -a 256 "$challenge_receipt" | awk '{print $1}')"
+
+mock_orca="$output_dir/mock-orca"
+cat >"$mock_orca" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case " $* " in
+  *" task-create "*) printf '%s\n' '{"result":{"task":{"id":"task_confirm"}}}' ;;
+  *" gate-create "*) printf '%s\n' '{"result":{"gate":{"id":"gate_confirm"}}}' ;;
+  *" gate-list "*)
+    digest="$(shasum -a 256 "$RFC_FIXTURE" | awk '{print $1}')"
+    printf '{"result":{"gates":[{"id":"gate_confirm","run_id":"%s","task_id":"%s","question":"Approve implementation of RFC rfcs/0042-confirmation-test.md with SHA-256 %s after approved challenge task task_challenge with receipt SHA-256 %s?","status":"%s","resolution":"%s","created_at":"%s","resolved_at":"%s"}]}}\n' \
+      "${GATE_RUN_ID-run_test}" "${GATE_TASK_ID-task_confirm}" "$digest" \
+      "$CHALLENGE_RECEIPT_DIGEST" \
+      "${GATE_STATUS-resolved}" "${GATE_RESOLUTION-approved}" \
+      "${GATE_CREATED_AT-2026-08-20T10:00:00Z}" "${GATE_RESOLVED_AT-2026-08-20T10:01:00Z}"
+    ;;
+  *) printf '%s\n' '{"ok":false}' >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$mock_orca"
+
+RFC_FIXTURE="$rfc_fixture_root/rfcs/0042-confirmation-test.md" CHALLENGE_RECEIPT_DIGEST="$challenge_receipt_digest" \
+ORCA_CLI_COMMAND="$mock_orca" python3 "$repo_root/bin/orca-confirm-rfc" \
+  --repo-root "$rfc_fixture_root" create --run run_test --challenge-task task_challenge \
+  --challenge-receipt "$challenge_receipt" --rfc rfcs/0042-confirmation-test.md \
+  >"$output_dir/rfc-create.json"
+grep -q '"confirmation_task_id": "task_confirm"' "$output_dir/rfc-create.json"
+grep -q '"gate_id": "gate_confirm"' "$output_dir/rfc-create.json"
+
+RFC_FIXTURE="$rfc_fixture_root/rfcs/0042-confirmation-test.md" CHALLENGE_RECEIPT_DIGEST="$challenge_receipt_digest" \
+ORCA_CLI_COMMAND="$mock_orca" python3 "$repo_root/bin/orca-confirm-rfc" \
+  --repo-root "$rfc_fixture_root" collect --run run_test --task task_confirm \
+  --challenge-task task_challenge --challenge-receipt "$challenge_receipt" --gate gate_confirm \
+  --rfc rfcs/0042-confirmation-test.md --output "$output_dir/rfc-receipt.json"
+grep -q '"resolution": "approved"' "$output_dir/rfc-receipt.json"
+
+cp "$rfc_fixture_root/rfcs/0042-confirmation-test.md" "$output_dir/original-rfc.md"
+sed -i.bak 's/Confirmation Test/Changed Confirmation Test/' "$rfc_fixture_root/rfcs/0042-confirmation-test.md"
+if RFC_FIXTURE="$output_dir/original-rfc.md" CHALLENGE_RECEIPT_DIGEST="$challenge_receipt_digest" ORCA_CLI_COMMAND="$mock_orca" \
+  python3 "$repo_root/bin/orca-confirm-rfc" --repo-root "$rfc_fixture_root" collect \
+  --run run_test --task task_confirm --challenge-task task_challenge \
+  --challenge-receipt "$challenge_receipt" --gate gate_confirm --rfc rfcs/0042-confirmation-test.md \
+  >/dev/null 2>&1; then
+  echo "Changed RFC digest unexpectedly reused an old confirmation gate." >&2
+  exit 1
+fi
+
+for gate_case in wrong_run wrong_task pending rejected bad_timestamp; do
+  case "$gate_case" in
+    wrong_run) gate_env=(GATE_RUN_ID=other_run) ;;
+    wrong_task) gate_env=(GATE_TASK_ID=other_task) ;;
+    pending) gate_env=(GATE_STATUS=pending GATE_RESOLUTION=) ;;
+    rejected) gate_env=(GATE_STATUS=resolved GATE_RESOLUTION=rejected) ;;
+    bad_timestamp) gate_env=(GATE_CREATED_AT=2026-08-20) ;;
+  esac
+  if env RFC_FIXTURE="$rfc_fixture_root/rfcs/0042-confirmation-test.md" CHALLENGE_RECEIPT_DIGEST="$challenge_receipt_digest" \
+    ORCA_CLI_COMMAND="$mock_orca" "${gate_env[@]}" \
+    python3 "$repo_root/bin/orca-confirm-rfc" --repo-root "$rfc_fixture_root" collect \
+    --run run_test --task task_confirm --challenge-task task_challenge \
+    --challenge-receipt "$challenge_receipt" --gate gate_confirm --rfc rfcs/0042-confirmation-test.md \
+    >/dev/null 2>&1; then
+    echo "RFC gate failure case unexpectedly succeeded: $gate_case" >&2
+    exit 1
+  fi
+done
+
+python3 - "$challenge_receipt" "$output_dir/rejected-challenge.json" <<'PY'
+import json
+import sys
+
+receipt = json.load(open(sys.argv[1], encoding="utf-8"))
+receipt["decision"] = "revise"
+json.dump(receipt, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if RFC_FIXTURE="$rfc_fixture_root/rfcs/0042-confirmation-test.md" CHALLENGE_RECEIPT_DIGEST="$challenge_receipt_digest" ORCA_CLI_COMMAND="$mock_orca" \
+  python3 "$repo_root/bin/orca-confirm-rfc" --repo-root "$rfc_fixture_root" create \
+  --run run_test --challenge-task task_challenge \
+  --challenge-receipt "$output_dir/rejected-challenge.json" \
+  --rfc rfcs/0042-confirmation-test.md >/dev/null 2>&1; then
+  echo "Non-approved challenge receipt unexpectedly created a confirmation gate." >&2
+  exit 1
+fi
+
+python3 - "$repo_root/bin/orca-confirm-rfc" "$rfc_fixture_root" <<'PY'
+import importlib.machinery
+import pathlib
+import sys
+
+module = importlib.machinery.SourceFileLoader("orca_confirm_rfc", sys.argv[1]).load_module()
+root = pathlib.Path(sys.argv[2])
+
+def rejected(path):
+    try:
+        module.load_rfc(root, path)
+    except SystemExit:
+        return
+    raise AssertionError(f"unexpectedly accepted {path}")
+
+for invalid in ("/tmp/rfcs/0042-test.md", "rfcs/../rfcs/0042-test.md"):
+    rejected(invalid)
+
+multiple = root / "rfcs/0044-multiple-status.md"
+multiple.write_text("# RFC\n\n- Status: Accepted\n- Status: Draft\n\n## Summary\n", encoding="utf-8")
+rejected("rfcs/0044-multiple-status.md")
+
+substring = root / "rfcs/0045-substring-status.md"
+substring.write_text("# RFC\n\nprefix - Status: Accepted suffix\n\n## Summary\n", encoding="utf-8")
+rejected("rfcs/0045-substring-status.md")
+
+directory = root / "rfcs/0046-directory.md"
+directory.mkdir()
+rejected("rfcs/0046-directory.md")
+
+symlink = root / "rfcs/0047-symlink.md"
+symlink.symlink_to(root / "rfcs/0042-confirmation-test.md")
+rejected("rfcs/0047-symlink.md")
+PY
+
+run_mock="$output_dir/mock-orca-run"
+run_log="$output_dir/orca-run-calls.jsonl"
+cat >"$run_mock" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+with open(os.environ["ORCA_RUN_LOG"], "a", encoding="utf-8") as log:
+    log.write(json.dumps(args) + "\n")
+if args[:2] == ["status", "--json"]:
+    payload = {"result": {"app": {"running": True}, "runtime": {"reachable": True}}}
+elif args[:2] == ["orchestration", "run-create"]:
+    payload = {"result": {"run": {"id": "run_flow"}}}
+elif args[:2] == ["orchestration", "task-create"]:
+    title = args[args.index("--task-title") + 1]
+    identifiers = {
+        "Understand and plan": "task_plan",
+        "Draft reserved RFC": "task_rfc",
+        "Challenge exact plan and RFC": "task_challenge",
+    }
+    payload = {"result": {"task": {"id": identifiers[title]}}}
+elif args[:2] == ["orchestration", "worker-start"]:
+    payload = {"result": {"dispatch": {"id": "dispatch_planner"}}}
+else:
+    raise SystemExit(f"unexpected command: {args}")
+print(json.dumps(payload))
+PY
+chmod +x "$run_mock"
+mkdir -p "$output_dir/run-worktree/rfcs"
+git -C "$output_dir/run-worktree" init -q
+(
+  cd "$output_dir/run-worktree"
+  ORCA_CLI_COMMAND="$run_mock" ORCA_RUN_LOG="$run_log" \
+    bash "$repo_root/bin/orca-development-run" "test objective" codex rfcs/0043-flow-test.md \
+    >"$output_dir/orca-development-run.out"
+)
+touch "$output_dir/run-worktree/rfcs/0044-collision.md"
+if (
+  cd "$output_dir/run-worktree"
+  ORCA_CLI_COMMAND="$run_mock" ORCA_RUN_LOG="$run_log" \
+    bash "$repo_root/bin/orca-development-run" "collision" codex rfcs/0044-collision.md \
+    >/dev/null 2>&1
+); then
+  echo "Existing RFC reservation collision unexpectedly succeeded." >&2
+  exit 1
+fi
+
+reservation_repo="$output_dir/reservation-repo"
+reservation_linked="$output_dir/reservation-linked"
+mkdir -p "$reservation_repo/rfcs"
+git -C "$reservation_repo" init -q
+git -C "$reservation_repo" config user.name validator
+git -C "$reservation_repo" config user.email validator@example.invalid
+git -C "$reservation_repo" commit --allow-empty -qm init
+git -C "$reservation_repo" worktree add -qb reservation-linked "$reservation_linked"
+mkdir -p "$reservation_linked/rfcs"
+(
+  cd "$reservation_repo"
+  ORCA_CLI_COMMAND="$run_mock" ORCA_RUN_LOG="$output_dir/reservation-run.log" \
+    bash "$repo_root/bin/orca-development-run" "reserve once" codex rfcs/0050-shared-lock.md \
+    >/dev/null
+)
+if (
+  cd "$reservation_linked"
+  ORCA_CLI_COMMAND="$run_mock" ORCA_RUN_LOG="$output_dir/reservation-linked.log" \
+    bash "$repo_root/bin/orca-development-run" "reserve twice" codex rfcs/0050-shared-lock.md \
+    >/dev/null 2>&1
+); then
+  echo "Linked worktree reused a repository-wide RFC reservation." >&2
+  exit 1
+fi
+python3 - "$run_log" <<'PY'
+import json
+import sys
+
+calls = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+task_calls = [call for call in calls if call[:2] == ["orchestration", "task-create"]]
+worker_calls = [call for call in calls if call[:2] == ["orchestration", "worker-start"]]
+assert len(task_calls) == 3, task_calls
+assert len(worker_calls) == 1, worker_calls
+assert worker_calls[0][worker_calls[0].index("--task") + 1] == "task_plan"
+assert not any("Implement" in " ".join(call) for call in calls)
+PY
+
 grep -q "repeat(auto-fit,minmax(150px,1fr))" "$trusted_panel"
 grep -q "@media (max-width:600px)" "$trusted_panel"
 

--- a/rfcs/0001-actor-aware-audit-identity.md
+++ b/rfcs/0001-actor-aware-audit-identity.md
@@ -1,0 +1,604 @@
+# RFC 0001: Actor-Aware Audit Identity
+
+- Status: Draft
+- Date: 2026-08-20
+- Owners: Platform and API teams
+- Reviewers: Authentication, data, SDK, UI, and service owners
+
+## Summary
+
+Replace the assumption that every `created_by` or `updated_by` value is a user ID
+with an additive actor-aware audit identity.
+
+Every externally exposed mutation of a persistent business resource must record the
+durable identity of the actor that performed it. Supported actors include users,
+project credentials, organization credentials, internal services, and system jobs.
+
+The migration preserves existing `created_by`, `updated_by`, `createdUser`, and
+`updatedUser` contracts while introducing explicit actor type and actor identifier
+fields. The rollout uses expand, dual-write, backfill, read-preference, and eventual
+contract migration phases.
+
+## Motivation
+
+The shared mutable model currently stores only numeric audit identifiers:
+
+```go
+type Mutable struct {
+    Status    RecordState
+    CreatedBy uint64
+    UpdatedBy uint64
+}
+```
+
+These identifiers are treated throughout the system as user IDs. That model is not
+valid for API-key and service-authenticated operations:
+
+- A user-authenticated operation has a user ID.
+- A project-key operation has a project credential ID, but no user ID.
+- An organization-key operation requires an organization credential ID.
+- An internal-service operation requires a stable service identity.
+- A background operation requires an explicit system identity.
+
+Using project or organization scope IDs as actor IDs would be incorrect. Scope tells
+us where an actor was authorized to operate; it does not identify which credential or
+service performed the operation.
+
+## Current State
+
+### Persistence
+
+The shared audit fields are defined in `pkg/models/gorm/audited.go`. They are embedded
+across persistent entities in the web, assistant, and endpoint services.
+
+The initial repository analysis found audited columns across approximately:
+
+- 48 assistant-api tables
+- 11 web-api tables
+- 10 endpoint-api tables
+
+The exact table inventory must be regenerated and reviewed before implementation.
+
+### Authentication
+
+`pkg/types/rapida_auth.go` exposes authentication types for:
+
+- `user`
+- `project`
+- `organization`
+- `service`
+
+However, the common `SimplePrinciple` contract exposes tenant scope and raw token
+information, but no durable actor identity.
+
+Project credentials already have generated database IDs in
+`api/web-api/internal/entity/organization.go`. That ID is currently discarded when a
+project credential is converted into `ProjectScope`.
+
+`ScopedAuthentication` in `protos/artifacts/web-api.proto` returns user, organization,
+project, and status information, but does not return the credential that authenticated
+the request.
+
+Organization scopes currently have no durable credential identity. Service assertions
+carry user, project, and organization scope but no stable calling-service identity.
+
+### Public Contracts
+
+Several API messages expose numeric `createdBy` and `updatedBy` fields. Some also expose
+`createdUser` and `updatedUser` projections.
+
+Current behavior is inconsistent:
+
+- Some read and list paths hydrate `createdUser`.
+- Many create and update paths return downstream responses without hydration.
+- `updatedUser` may be defined but not populated.
+- A user lookup represents the current user record, not an immutable event-time snapshot.
+
+## Goals
+
+1. Record the actual durable actor for every externally exposed persistent mutation.
+2. Distinguish actor identity from authorization scope and authentication transport.
+3. Support user, project credential, organization credential, service, and system actors.
+4. Avoid storing or forwarding raw API keys and originating authentication tokens.
+5. Preserve existing public fields and successful behavior during migration.
+6. Support incremental, independently reversible service rollouts.
+7. Make missing or unresolved actor enrichment observable without failing mutations.
+
+## Non-Goals
+
+- Replacing the existing external audit-log subsystem.
+- Adding audit fields to health checks, transient invocations, metrics submissions, or
+  response-only objects that do not represent persistent business resources.
+- Reconstructing historical API-key identity when reliable evidence does not exist.
+- Storing an immutable snapshot of complete user or credential metadata on every row.
+- Performing a single all-services cutover.
+
+## Terminology
+
+### Actor
+
+The durable principal that performed an operation.
+
+### Scope
+
+The organization and project within which the actor was authorized to operate.
+
+### Authentication Type
+
+The mechanism used to authenticate a request. Authentication type may help derive an
+actor but is not itself the actor identity.
+
+### Actor Projection
+
+Optional display information resolved from the durable actor identity, such as user name
+or credential name. Projections are best-effort and may change over time.
+
+## Requirements
+
+### Functional Requirements
+
+- User operations record the user ID.
+- Project-key operations record the project credential ID.
+- Organization-key operations record the organization credential ID.
+- Service operations record a provisioned stable service ID.
+- Background operations record an explicit system actor.
+- Creation and update identities are maintained independently.
+- Actor identity is derived on the server and cannot be supplied by the caller.
+- Actor resolution failure does not convert a successful mutation into a failure.
+
+### Compatibility Requirements
+
+- Existing protobuf field numbers and JSON names are never reused or changed.
+- Existing `createdBy`, `updatedBy`, `createdUser`, and `updatedUser` fields remain
+  available through the compatibility window.
+- New protobuf fields use new field numbers.
+- Existing response wrappers, success codes, error codes, and cardinality remain stable.
+- Direct service and gateway behavior remain compatible unless explicitly versioned.
+- SDK regeneration is coordinated across Go, Node.js, Python, React, and widget clients.
+
+### Security Requirements
+
+- Raw API keys are never stored as actor identifiers.
+- Raw tokens are not used in database indexes or cache keys.
+- Actor display information is tenant-authorized and minimizes personally identifiable
+  information.
+- Service identity is cryptographically bound to a signed assertion.
+- Organization and project IDs are not substituted for missing credential identity.
+
+## Proposed Design
+
+### Actor Contract
+
+Introduce a shared actor identity contract:
+
+```go
+type ActorType string
+
+const (
+    ActorTypeUser         ActorType = "user"
+    ActorTypeProject      ActorType = "project"
+    ActorTypeOrganization ActorType = "organization"
+    ActorTypeService      ActorType = "service"
+    ActorTypeSystem       ActorType = "system"
+    ActorTypeUnknown      ActorType = "unknown"
+)
+
+type ActorIdentity struct {
+    Type ActorType
+    ID   string
+}
+```
+
+Actor identifiers are strings. User and credential IDs can be encoded as decimal strings,
+while service identities can use stable names or UUIDs without another schema migration.
+
+Actor type names describe the principal class, not the authorization scope identifier or
+the credential implementation. Their identifiers are defined as follows:
+
+| Actor type | Actor ID | Must not use |
+| --- | --- | --- |
+| `user` | User ID | Session or access-token ID |
+| `project` | Project credential ID | Project ID or raw project key |
+| `organization` | Organization credential ID | Organization ID or raw organization key |
+| `service` | Provisioned stable service ID | Shared secret, token, user ID, or project ID |
+| `system` | Registered system-job ID | Empty or implicit identity |
+| `unknown` | Empty | Guessed user, credential, scope, or service identity |
+
+For example, `{type: "project", id: "123"}` means project credential `123` performed the
+operation. It does not mean project `123` performed the operation.
+
+### Approved Project Actor Decision
+
+For actor type `project`, `ActorIdentity.ID` is the durable project credential ID.
+The project ID remains a separate authorization-scope field on the resource or request
+context and is never used as the actor ID.
+
+This preserves the ability to distinguish multiple credentials belonging to the same
+project, investigate credential-specific activity, and retain attribution across key
+rotation or archival. Project credentials must therefore be archived rather than
+hard-deleted when historical actor resolution is required.
+
+### Principle Integration
+
+Do not add new methods directly to `SimplePrinciple`. That would immediately break every
+implementation and test mock.
+
+Add a companion contract:
+
+```go
+type ActorIdentityProvider interface {
+    AuditActor() (ActorIdentity, bool)
+}
+```
+
+Audit-writing code uses a centralized, fail-closed resolver:
+
+```go
+func ResolveAuditActor(auth SimplePrinciple) (ActorIdentity, error)
+```
+
+The resolver rejects authenticated mutation paths that claim to support actor-aware audit
+but do not provide a stable identity. Compatibility-only paths may explicitly use
+`unknown` while rollout is in progress.
+
+### Project Credentials
+
+Add project credential identity to the project authentication path:
+
+1. Add a credential ID field to `ProjectScope`.
+2. Select and map `project_credentials.id` during authorization.
+3. Add optional actor type and actor ID fields to `ScopedAuthentication`.
+4. Preserve the fields through the web authentication client and middleware.
+
+The raw project credential remains secret and is never persisted as audit metadata.
+
+### Organization Credentials
+
+An organization scope currently identifies only the organization. Before organization-key
+mutations become actor-aware, the platform must define a durable organization credential
+entity or equivalent stable identity.
+
+The organization ID alone is not a valid credential actor ID.
+
+### Service Identity
+
+Service assertions must include a signed stable identity such as `service_id` or `sub`.
+A shared signing secret and tenant scope are insufficient to identify which service acted.
+
+Internal delegation creates a new short-lived service assertion containing tenant scope
+and actor provenance. It must not forward the originating user or API-key credential.
+
+### System Identity
+
+Background workers use named system identities registered in configuration or code, for
+example `assistant-indexer` or `conversation-retention-job`. An empty actor is not treated
+as a system actor implicitly.
+
+## Persistence Design
+
+Add four nullable columns to every audited persistent resource table:
+
+```text
+created_actor_type varchar(32)
+created_actor_id   text
+updated_actor_type varchar(32)
+updated_actor_id   text
+```
+
+Keep the legacy columns unchanged:
+
+```text
+created_by bigint
+updated_by bigint
+```
+
+### Write Behavior
+
+| Actor | Legacy field | Actor type | Actor ID |
+| --- | --- | --- | --- |
+| User | User ID | `user` | User ID |
+| Project credential | `0` or unchanged compatibility value | `project` | Credential ID |
+| Organization credential | `0` or unchanged compatibility value | `organization` | Credential ID |
+| Service | `0` or configured compatibility user | `service` | Service ID |
+| System | `0` | `system` | System ID |
+
+Using a configured compatibility user for service writes is permitted only as a temporary,
+documented rollout mechanism. It must not be presented as the true actor.
+
+### Read Behavior
+
+Readers prefer actor-aware fields. If they are absent, readers derive a legacy projection:
+
+- Non-zero `created_by` or `updated_by` becomes a legacy user candidate.
+- Zero or missing legacy values become `unknown`.
+- Readers do not guess project, organization, or service identities.
+
+### Indexes
+
+Do not index every actor column by default. Add composite indexes only for demonstrated
+query patterns, such as:
+
+```text
+(organization_id, project_id, created_actor_type, created_actor_id)
+```
+
+Backfill and operational queries should use primary-key ranges instead of full-table actor
+indexes.
+
+## Public API Design
+
+Add an actor message with new protobuf field numbers:
+
+```proto
+message AuditActor {
+  string type = 1;
+  string id = 2;
+  optional string displayName = 3;
+}
+```
+
+Audited resources may add:
+
+```proto
+optional AuditActor createdActor = <new-field-number>;
+optional AuditActor updatedActor = <new-field-number>;
+```
+
+Legacy fields remain available:
+
+```text
+createdBy
+updatedBy
+createdUser
+updatedUser
+```
+
+### Projection Rules
+
+- `createdUser.id` must correspond to a user `createdActor` or legacy `createdBy`.
+- `updatedUser.id` must correspond to a user `updatedActor` or legacy `updatedBy`.
+- Non-user actors do not produce synthetic users.
+- Deleted or unavailable actors leave display fields absent.
+- Projection lookup failure is logged and measured but does not fail the resource operation.
+- Actor projections are current metadata, not immutable historical snapshots.
+
+## Migration Plan
+
+### Phase 0: Contract Inventory
+
+- Identify every externally exposed persistent create, update, archive, and delete path.
+- Record the canonical public edge for each path.
+- Identify the owning service, table, response message, and current audit behavior.
+- Add golden compatibility tests before changing contracts.
+
+The initial review identified approximately 46 create and update RPC paths, but this must
+be regenerated from the implementation branch.
+
+### Phase 1: Authentication Foundation
+
+- Add actor identity types and resolver.
+- Propagate project credential ID through scope authorization.
+- Introduce stable organization credential and service identities.
+- Add versioned authentication cache entries containing actor identity.
+- Replace raw-token cache keys with domain-separated HMAC fingerprints.
+- Add bounded cache TTL and credential invalidation behavior.
+
+### Phase 2: Schema Expansion
+
+- Add nullable actor columns without defaults.
+- Use short lock timeouts and independently deployable service migrations.
+- Do not backfill in the schema migration transaction.
+- Deploy actor-aware entity fields while keeping legacy fields intact.
+
+### Phase 3: Dual Write
+
+- User mutations write both legacy and actor-aware fields.
+- Non-user mutations write actor-aware fields and compatibility-safe legacy values.
+- Readers prefer actor-aware fields and fall back to legacy fields.
+- Add mismatch metrics when legacy and actor-aware user IDs disagree.
+
+### Phase 4: Backfill
+
+- Process bounded primary-key ranges.
+- Backfill verified historical user rows as `user`.
+- Mark ambiguous records as `unknown`.
+- Do not attempt to identify historical API keys from secrets, logs, or current credentials.
+- Make backfill idempotent, resumable, rate-limited, and observable.
+
+### Phase 5: Public Contract Expansion
+
+- Add `createdActor` and `updatedActor` to resource messages.
+- Regenerate and release SDKs.
+- Update UI components to render users, credentials, services, and system actors.
+- Keep nested actor display resolution best-effort and authorization-scoped.
+
+### Phase 6: Domain Rollout
+
+Recommended sequence:
+
+1. Assistant creation and update pilot.
+2. Remaining assistant resources.
+3. Endpoint resources.
+4. Web resources and credentials.
+5. Organization credentials and service/system operations.
+
+Each domain requires an independently approved plan, migration, tests, rollout switch,
+and rollback evidence.
+
+### Phase 7: Contract Cleanup
+
+After a full SDK and client compatibility window:
+
+- Mark legacy numeric audit fields as deprecated.
+- Stop adding new dependencies on `createdUser` and `updatedUser`.
+- Evaluate removal only through a separate RFC.
+
+This RFC does not approve removing legacy fields.
+
+## Failure Behavior
+
+- Missing actor identity fails closed for endpoints declared actor-aware.
+- During compatibility rollout, explicitly listed endpoints may write `unknown` and emit a
+  metric rather than fail.
+- Actor display resolution never fails a successful mutation or read.
+- Database actor-column write failure follows normal transaction rollback behavior.
+- Backfill failures stop the affected batch and preserve its checkpoint.
+- Cache entries missing actor identity are treated as misses when identity is required.
+
+## Observability
+
+Add metrics for:
+
+- Audit writes by actor type and service
+- Missing actor identity
+- Unknown actor writes
+- Legacy/actor field mismatches
+- Actor projection lookup failures
+- Authentication actor cache hits and misses
+- Backfill rows processed, skipped, failed, and remaining
+
+Logs must include actor type and a non-secret actor identifier. Logs must never contain
+raw credentials or originating tokens.
+
+## Testing Strategy
+
+### Shared Packages
+
+- Actor resolver success for every supported actor type
+- Missing identity and unsupported principal behavior
+- Compatibility behavior for principals without `ActorIdentityProvider`
+- No raw-token serialization or logging
+
+### Authentication
+
+- Project credential ID reaches `ProjectScope` and `ScopedAuthentication`
+- Organization credential and service IDs are stable and signed
+- Archived or rotated credentials invalidate cached identity
+- Old cache entries without actor identity are rejected where required
+- Tenant scope remains unchanged
+
+### Persistence
+
+- User dual-write success
+- Project credential dual-write success
+- Organization, service, and system writes
+- Update actor does not overwrite creation actor
+- Transaction rollback preserves both legacy and actor fields
+- Legacy read fallback
+- Unknown historical record behavior
+
+### API Compatibility
+
+- Existing protobuf and JSON golden responses remain compatible
+- New actor fields use new field numbers
+- Non-user actors do not populate `createdUser` or `updatedUser`
+- Projection failure does not change resource success
+- Direct service and gateway responses have declared parity
+
+### Migration
+
+- Up and down migrations for every service
+- Backfill idempotency and resume behavior
+- Mixed-version application compatibility
+- Rollback with actor columns present but unused
+- Representative production-size migration timing
+
+## Rollback
+
+Rollback occurs in stages:
+
+1. Disable actor-aware reads and return to legacy projections.
+2. Disable actor-aware writes while leaving nullable columns in place.
+3. Roll back authentication propagation if no actor-aware endpoint requires it.
+4. Stop backfill workers and preserve checkpoints.
+5. Drop actor columns only after the application rollback and retention window complete.
+
+Columns must not be dropped during an emergency application rollback.
+
+## Alternatives Considered
+
+### Repurpose `created_by` and `updated_by`
+
+Store either a user ID or credential ID in the existing fields and add only actor-type
+columns.
+
+Rejected because existing clients, GORM relationships, and user hydration assume these
+values are user IDs. Numeric namespaces may also collide.
+
+### Create a Global Actor Table
+
+Create a shared actor registry and reference it from all services.
+
+Deferred because it introduces cross-service lifecycle ownership, availability coupling,
+replication, and cleanup complexity. It may be reconsidered if actor metadata queries
+become a core platform capability.
+
+### Store Full Actor Snapshots Per Row
+
+Persist actor name, email, and credential metadata with every resource.
+
+Rejected because it duplicates personally identifiable information, complicates erasure
+and correction requirements, and significantly increases schema and write complexity.
+
+### Store Only Authentication Type
+
+Record that a request used a user token or API key without a stable actor ID.
+
+Rejected because it cannot identify which user, credential, or service performed the
+operation.
+
+### Reconstruct Actor Identity From Tokens
+
+Persist or replay API keys and service tokens to derive historical identity.
+
+Rejected for security, rotation, expiration, and reliability reasons.
+
+## Risks
+
+- Broad schema scope across independently deployed services
+- Partial rollout producing mixed legacy and actor-aware records
+- Public SDK churn from contract additions
+- Incorrect actor attribution from fallback logic
+- N+1 lookups and latency from actor projections
+- Cross-tenant or PII exposure from actor display metadata
+- Long-running backfills affecting database performance
+- Service assertions that identify scope but not the calling service
+
+These risks are mitigated through additive fields, phased service ownership, server-derived
+identity, best-effort projections, bounded backfills, metrics, and rollback switches.
+
+## Open Questions
+
+1. Is actor ID a string in all contracts, or should storage use separate numeric and text
+   representations?
+2. What durable entity owns organization credentials?
+3. What registry or identifier owns internal service identity?
+4. Which service is the canonical public edge for each exposed mutation?
+5. Which historical rows can be confidently classified as user-created?
+6. How long must legacy fields remain supported across SDKs?
+7. Should actor display metadata expose user email, or only ID and display name?
+8. Which endpoints may temporarily write `unknown` during rollout?
+9. Is deletion/archive actor identity stored in `updatedActor`, or should a separate
+   lifecycle-event audit record be required?
+10. Which domain is the approved pilot after assistant creation and update inventory is
+    complete?
+
+## Acceptance Criteria
+
+This RFC may move to `Accepted` when:
+
+- Actor taxonomy and identifier format are approved.
+- Project, organization, service, and system identity ownership is defined.
+- The externally exposed mutation inventory is reviewed by service owners.
+- Backward-compatible API and SDK strategy is approved.
+- Historical backfill policy is approved.
+- Pilot domain, rollout sequence, observability, and rollback are approved.
+- A plan challenger finds no unresolved critical or major issue.
+
+Implementation must not begin while this RFC remains `Draft`.
+
+## Decision Log
+
+| Date | Decision | Status |
+| --- | --- | --- |
+| 2026-08-20 | Actor type `project` stores the project credential ID; project ID remains authorization scope. | Approved |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,41 @@
+# Requests for Comments
+
+This directory contains design proposals for changes that affect multiple services,
+public contracts, persistent data, security boundaries, or operational behavior.
+
+## Lifecycle
+
+RFCs use the following statuses:
+
+- `Draft`: under discussion; implementation must not begin.
+- `Accepted`: final design bytes are ready for exact-digest confirmation; status alone does not authorize implementation.
+- `Implemented`: the accepted design has shipped.
+- `Superseded`: replaced by another RFC.
+- `Rejected`: considered but not selected.
+
+Material design changes discovered during implementation require the RFC to return to
+`Draft` or be superseded by a follow-up RFC.
+
+## Naming
+
+RFC files use a four-digit sequence followed by a short descriptive name:
+
+```text
+0001-actor-aware-audit-identity.md
+```
+
+The coordinator reserves the next unused path before creating an Orca development Run.
+Reservation is single-owner for that Run; a colliding or pre-existing path must be rejected.
+The RFC author may edit only that reserved file. The RFC index is updated separately after
+the RFC is accepted. Reservations use an atomic directory under Git metadata and remain
+until the exact-digest confirmation task is created; abandoned reservations require
+coordinator cleanup.
+
+An `Accepted` RFC is confirmed by exact SHA-256 through the Orca decision gate. Any byte
+change after confirmation requires another challenge and confirmation before implementation.
+
+## Index
+
+| RFC | Title | Status |
+| --- | --- | --- |
+| [0001](0001-actor-aware-audit-identity.md) | Actor-Aware Audit Identity | Draft |


### PR DESCRIPTION
## Summary

- Add RFC 0001 for actor-aware audit identity and migration strategy.
- Require non-trivial implementation work to reserve, author, challenge, and confirm an RFC first.
- Add an exact-digest Orca confirmation task and authoritative receipt collection.
- Prevent concurrent RFC-number reservation across linked Git worktrees.

## Approved Plan

- Acceptance criteria: implementation tasks are not created before exact RFC confirmation; the gate binds the accepted RFC digest, approved challenge task, and challenge receipt digest.
- In scope: development lifecycle docs, Codex/Claude roles and templates, Orca workflow helpers, validators, RFC policy, and RFC 0001.
- Out of scope: product API implementation and the existing lifecycle envelope/HMAC/panel schema.
- Ownership: RFC author owns only the reserved RFC file; challenger remains read-only; coordinator owns confirmation and implementation dispatch.
- Rollback or disablement: revert the tooling commit to restore the previous Orca task flow; RFC 0001 remains a Draft design artifact until separately accepted.

## RFC Confirmation

- RFC: `rfcs/0001-actor-aware-audit-identity.md`
- Status: Draft; no product implementation is included in this PR.
- Workflow contract: final implementation RFCs require an accepted exact digest, approved challenge receipt, and resolved Orca confirmation gate.

## Principles

- KISS: adds one reservation flow and one confirmation helper without rewriting existing hook schemas.
- YAGNI: product audit migration remains design-only.
- Single source of truth: exact RFC bytes and SHA-256 identify the confirmed design.
- Contracts: gate question and receipt bind Run, challenge task, challenge receipt hash, RFC path, and RFC digest.
- Failure safety: rejects path collisions, symlinks, invalid statuses, changed digests, rejected/pending gates, invalid timestamps, and mismatched provenance.
- Security: reservation locks use Git common metadata across linked worktrees; coordinator confirmation remains separate from implementation workers.
- Observability: generated JSON receipts preserve confirmation provenance and timestamps.

## Testing

- `make validate-development-toolkit`
- `python3 -m py_compile bin/orca-confirm-rfc`
- `bash -n bin/orca-development-run bin/validate-development-process`
- `git diff --cached --check`
- Commit hooks passed for both commits.

## Independent Code Review

- Reviewer: independent read-only explorer agent
- Decision: approved
- Critical findings: 0
- Major findings: 0
- Verified challenge receipt hash binding, repository-wide linked-worktree reservation, Codex/Claude parity, and validator coverage.

## Checklist

- [x] The exact plan and RFC workflow were independently challenged.
- [x] The confirmation gate binds the accepted RFC and challenge receipt digests.
- [x] The change is focused on development governance; product implementation is excluded.
- [x] Required validation commands passed.
- [x] An independent code reviewer approved the complete staged diff.
- [x] Critical and major review findings are resolved.
- [x] Rollback and operational behavior are documented.
- [x] No secrets or generated noise are committed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces an RFC-first development lifecycle with cross-worktree reservation and exact-digest confirmation tooling. The confirmation path currently accepts unauthenticated challenge assertions, and reservation cleanup can release paths still owned by partially created runs.

- Adds matching Codex and Claude RFC-author and challenger roles.
- Changes development-run creation to reserve an RFC and create only planning, authoring, and challenge tasks.
- Adds confirmation-gate creation and receipt collection for accepted RFC bytes.
- Extends lifecycle documentation, validation, and RFC policy.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

The PR is not safe to merge until challenge approval is obtained from an authoritative source and reservation cleanup preserves ownership after partial Orca creation.

The confirmation chain can certify a fabricated local challenge receipt, while a later Orca failure can remove the lock for a run whose RFC-owning tasks already exist; the documented startup command also needs a line continuation.

**Files Needing Attention:** bin/orca-confirm-rfc, bin/orca-development-run, DEVELOPMENT_PROCESS.md
</details>

<details open><summary><h3>Security Review</h3></summary>

The new confirmation helper accepts a caller-authored challenge receipt without retrieving or authenticating the challenge task's actual decision. Matching self-asserted fields are therefore sufficient to create and collect an apparently approved RFC confirmation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bin/orca-confirm-rfc | Adds exact-digest gate creation and collection, but treats caller-supplied challenge JSON as authoritative approval. |
| bin/orca-development-run | Adds RFC reservation and planning-task creation, but cleanup can release the reservation after persistent Orca resources already claim it. |
| bin/validate-development-process | Adds extensive confirmation and linked-worktree tests, though it does not cover authoritative challenge retrieval or post-run-create failure cleanup. |
| DEVELOPMENT_PROCESS.md | Documents the RFC-first lifecycle, with one broken multiline make example. |
| AGENTS.md | Defines the intended plan, RFC challenge, exact-digest confirmation, and implementation sequence. |
| rfcs/0001-actor-aware-audit-identity.md | Adds a design-only RFC for actor-aware audit identity and migration. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Reserve RFC path] --> B[Create planning run]
    B --> C[Plan task]
    C --> D[RFC author task]
    D --> E[Challenge task]
    E --> F[Load challenge receipt]
    F --> G[Create exact-digest gate]
    G --> H{Gate approved?}
    H -- No --> I[Stop implementation]
    H -- Yes --> J[Collect confirmation receipt]
    J --> K[Create implementation tasks]
    F -. unauthenticated local assertion .-> L[Approval bypass]
    B -. later command failure .-> M[EXIT trap releases live reservation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
bin/orca-confirm-rfc:111-120
**Unauthenticated challenge approval**

When a caller supplies fabricated but matching receipt fields, `load_challenge_receipt` treats the local JSON as authoritative and both confirmation stages validate against that same file, allowing implementation to be confirmed without an independent challenge approval.

**How this was verified:** The receipt path is caller-supplied, and no confirmation step retrieves or authenticates the challenge task's actual decision.

### Issue 2
bin/orca-development-run:36-42
**Live reservation released on failure**

When an Orca command fails after the run and RFC-owning tasks are created, `set -e` invokes this trap while `reservation_active` is still set, removing the lock for a live run and allowing another run to reserve the same RFC path.

### Issue 3
DEVELOPMENT_PROCESS.md:94-95
**Missing command continuation**

The missing continuation ends the `make` command before the required `RFC` assignment, so copying this example fails the target's argument validation instead of starting a governed run.

```suggestion
make orca-development-run OBJECTIVE="describe the desired outcome" AGENT=codex \
  RFC="rfcs/NNNN-short-name.md"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: require RFC confirmation before im..."](https://github.com/rapidaai/voice-ai/commit/2e0cf49bfc302880cdf7a6451a42c2d80e4ac3bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55235550)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->