### PR TITLE
feat: show copyable provider credential IDs

### DIFF
--- a/ui/src/app/components/base/modal/view-provider-credential-modal/__tests__/index.test.tsx
+++ b/ui/src/app/components/base/modal/view-provider-credential-modal/__tests__/index.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ViewProviderCredentialDialog } from '../index';
+
+type MockCredential = {
+  getId: () => string;
+  getName: () => string;
+  getProvider: () => string;
+  getCreateddate: () => undefined;
+  getLastuseddate: () => undefined;
+};
+
+const makeCredential = (
+  id: string,
+  name: string,
+  provider: string,
+): MockCredential => ({
+  getId: () => id,
+  getName: () => name,
+  getProvider: () => provider,
+  getCreateddate: () => undefined,
+  getLastuseddate: () => undefined,
+});
+
+let mockProviderCredentials: MockCredential[] = [];
+const mockWriteText = jest.fn();
+
+jest.mock('@rapidaai/react', () => ({
+  ConnectionConfig: { WithDebugger: jest.fn() },
+  DeleteProviderKey: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-credential', () => ({
+  useCurrentCredential: () => ({
+    authId: 'user-1',
+    projectId: 'project-1',
+    token: 'token-1',
+  }),
+}));
+
+jest.mock('@/hooks', () => ({
+  useRapidaStore: () => ({
+    showLoader: jest.fn(),
+    hideLoader: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/use-model', () => ({
+  useAllProviderCredentials: () => ({
+    providerCredentials: mockProviderCredentials,
+  }),
+}));
+
+jest.mock('@/context/provider-context', () => ({
+  useProviderContext: () => ({
+    reloadProviderCredentials: jest.fn(),
+  }),
+}));
+
+jest.mock('@/configs', () => ({
+  connectionConfig: {},
+}));
+
+jest.mock('@/utils/date', () => ({
+  toHumanReadableRelativeTime: jest.fn(() => 'recently'),
+}));
+
+jest.mock('@/app/components/carbon/modal', () => ({
+  Modal: ({ open, children }: any) => (open ? <div>{children}</div> : null),
+  ModalHeader: ({ label, title }: any) => (
+    <header>
+      <span>{label}</span>
+      <h2>{title}</h2>
+    </header>
+  ),
+  ModalBody: ({ children }: any) => <main>{children}</main>,
+  ModalFooter: ({ children }: any) => <footer>{children}</footer>,
+}));
+
+jest.mock('@/app/components/carbon/form', () => ({
+  Stack: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/components/carbon/button', () => ({
+  PrimaryButton: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+  TertiaryButton: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+  DangerButton: ({ children, renderIcon, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+  IconOnlyButton: ({ iconDescription, renderIcon, ...props }: any) => (
+    <button aria-label={iconDescription} {...props} />
+  ),
+}));
+
+describe('ViewProviderCredentialDialog', () => {
+  beforeEach(() => {
+    mockProviderCredentials = [];
+    mockWriteText.mockReset();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: mockWriteText },
+    });
+  });
+
+  it('renders the credential ID and copies it from the accessible action', async () => {
+    mockProviderCredentials = [
+      makeCredential('credential-openai-123', 'Production key', 'openai'),
+    ];
+
+    render(
+      <ViewProviderCredentialDialog
+        modalOpen
+        setModalOpen={jest.fn()}
+        currentProvider={{
+          code: 'openai',
+          name: 'OpenAI',
+          image: '/providers/openai.svg',
+          featureList: ['llm'],
+        }}
+        onSetupCredential={jest.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText('credential-openai-123'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy credential ID' }));
+
+    expect(mockWriteText).toHaveBeenCalledWith('credential-openai-123');
+  });
+
+  it('filters credentials that belong to a different provider', async () => {
+    mockProviderCredentials = [
+      makeCredential('credential-openai-123', 'OpenAI key', 'openai'),
+      makeCredential(
+        'credential-elevenlabs-456',
+        'ElevenLabs key',
+        'elevenlabs',
+      ),
+    ];
+
+    render(
+      <ViewProviderCredentialDialog
+        modalOpen
+        setModalOpen={jest.fn()}
+        currentProvider={{
+          code: 'openai',
+          name: 'OpenAI',
+          image: '/providers/openai.svg',
+          featureList: ['llm'],
+        }}
+        onSetupCredential={jest.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText('credential-openai-123'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('credential-elevenlabs-456'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('ElevenLabs key')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/components/base/modal/view-provider-credential-modal/index.tsx
+++ b/ui/src/app/components/base/modal/view-provider-credential-modal/index.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/app/components/carbon/button';
 import { Stack } from '@/app/components/carbon/form';
 import { TrashCan } from '@carbon/icons-react';
+import { CopyButton } from '@/app/components/carbon/button/copy-button';
 
 interface ViewProviderCredentialDialogProps extends ModalProps {
   currentProvider: RapidaProvider;
@@ -97,13 +98,13 @@ export const ViewProviderCredentialDialog: FC<
       <ModalBody>
         {currentProviderCredentials.length > 0 ? (
           <Stack gap={4}>
-            {currentProviderCredentials.map((x, idx) => (
+            {currentProviderCredentials.map(x => (
               <div
-                className="group border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
-                key={idx}
+                className="group border border-border-subtle bg-layer"
+                key={x.getId()}
               >
                 <div className="flex items-center px-4 py-3">
-                  <div className="border border-gray-200 dark:border-gray-700 flex items-center justify-center shrink-0 h-10 w-10 p-1 mr-3">
+                  <div className="border border-border-subtle bg-surface flex items-center justify-center shrink-0 h-10 w-10 p-1 mr-3">
                     <img
                       src={props.currentProvider.image}
                       alt={props.currentProvider.name}
@@ -113,7 +114,7 @@ export const ViewProviderCredentialDialog: FC<
                     <p className="text-sm font-semibold capitalize truncate">
                       {x.getName()}
                     </p>
-                    <div className="flex gap-2 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="flex gap-2 text-xs text-muted">
                       <span>
                         Updated{' '}
                         {x.getCreateddate() &&
@@ -137,29 +138,41 @@ export const ViewProviderCredentialDialog: FC<
                     Delete
                   </DangerButton>
                 </div>
+                <div className="flex items-center gap-3 border-t border-border-subtle px-4 py-2">
+                  <span className="shrink-0 text-xs font-medium text-muted">
+                    Credential ID
+                  </span>
+                  <code
+                    className="min-w-0 flex-1 truncate text-xs text-foreground"
+                    title={x.getId()}
+                  >
+                    {x.getId()}
+                  </code>
+                  <CopyButton
+                    className="h-7 w-7 shrink-0"
+                    copyDescription="Copy credential ID"
+                    copiedDescription="Credential ID copied"
+                  >
+                    {x.getId()}
+                  </CopyButton>
+                </div>
               </div>
             ))}
           </Stack>
         ) : (
           <div className="px-4 py-8 flex flex-col items-center text-center">
             <p className="text-sm font-semibold mb-1">No Credential</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            <p className="text-sm text-muted mb-4">
               No provider credential to display
             </p>
-            <TertiaryButton
-              size="sm"
-              onClick={() => props.onSetupCredential()}
-            >
+            <TertiaryButton size="sm" onClick={() => props.onSetupCredential()}>
               Setup Credential
             </TertiaryButton>
           </div>
         )}
       </ModalBody>
       <ModalFooter>
-        <PrimaryButton
-          size="lg"
-          onClick={() => props.setModalOpen(false)}
-        >
+        <PrimaryButton size="lg" onClick={() => props.setModalOpen(false)}>
           Got it
         </PrimaryButton>
       </ModalFooter>

--- a/ui/src/app/components/carbon/button/copy-button.tsx
+++ b/ui/src/app/components/carbon/button/copy-button.tsx
@@ -7,9 +7,16 @@ import { cn } from '@/utils';
 interface CopyButtonProps {
   children?: ReactNode;
   className?: string;
+  copyDescription?: string;
+  copiedDescription?: string;
 }
 
-export const CopyButton: FC<CopyButtonProps> = ({ children, className }) => {
+export const CopyButton: FC<CopyButtonProps> = ({
+  children,
+  className,
+  copyDescription = 'Copy',
+  copiedDescription = 'Copied',
+}) => {
   const [copied, setCopied] = useState(false);
 
   const copyItem = (item: any) => {
@@ -23,7 +30,7 @@ export const CopyButton: FC<CopyButtonProps> = ({ children, className }) => {
       kind="ghost"
       size="sm"
       renderIcon={copied ? Checkmark : Copy}
-      iconDescription={copied ? 'Copied' : 'Copy'}
+      iconDescription={copied ? copiedDescription : copyDescription}
       onClick={() => copyItem(children)}
       className={cn(copied && 'text-green-600', className)}
     />


### PR DESCRIPTION
## Summary
- display each provider credential ID in the integration credential list
- add an accessible copy action with copied-state feedback
- use semantic Carbon theme utilities and stable credential keys
- add focused tests for copying and provider filtering

## Validation
- `yarn test --watchAll=false --runTestsByPath src/app/components/base/modal/view-provider-credential-modal/__tests__/index.test.tsx`
- `yarn eslint src/app/components/base/modal/view-provider-credential-modal/index.tsx src/app/components/base/modal/view-provider-credential-modal/__tests__/index.test.tsx src/app/components/carbon/button/copy-button.tsx`
- `git diff --check`

## Note
- `yarn checkTs` is currently blocked by the repository-installed TypeScript/dependency version mismatch before application code is checked.
- This PR is intentionally stacked on #230.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR exposes provider credential IDs in the credential list, adds an accessible copy action with provider-specific feedback, adopts semantic theme utilities and stable list keys, and adds focused rendering, copy, and filtering tests.
- Displays and makes each credential ID copyable.
- Adds configurable accessible labels to the shared copy button.
- Replaces literal color classes with semantic theme tokens.
- Tests credential-ID copying and provider filtering.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The clipboard success state should be corrected before merging because the new credential action can tell users an ID was copied when the write actually failed.

The copy flow sets and announces its successful state before the Clipboard API operation completes and does not handle rejection, producing false feedback on a reachable browser failure path.

**Files Needing Attention:** ui/src/app/components/carbon/button/copy-button.tsx; ui/src/app/components/base/modal/view-provider-credential-modal/index.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ui/src/app/components/base/modal/view-provider-credential-modal/index.tsx | Adds credential-ID display and copying, semantic theme classes, stable credential keys, and minor formatting updates; the new copy action exposes optimistic success feedback from CopyButton. |
| ui/src/app/components/carbon/button/copy-button.tsx | Adds configurable accessible copy-state descriptions, but announces success before confirming the clipboard write. |
| ui/src/app/components/base/modal/view-provider-credential-modal/__tests__/index.test.tsx | Adds focused tests for rendering and copying IDs and excluding credentials from other providers, but does not exercise clipboard rejection. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ui/src/app/components/carbon/button/copy-button.tsx:30
**Clipboard success is reported prematurely**

When the clipboard write is rejected or unavailable, `copied` has already been set and the button announces “Credential ID copied,” causing false success feedback while nothing is copied and leaving the rejection unhandled.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: show copyable credential ids"](https://github.com/rapidaai/voice-ai/commit/abdd185146da079bfeaa1ee7002ee4cd767b5513) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55498227)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->