### PR TITLE
feat: resolve native SIP party identities

### DIFF
--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -7,7 +7,6 @@
 package sip_infra
 
 import (
-	"errors"
 	"time"
 
 	internal_core "github.com/rapidaai/api/assistant-api/sip/internal/core"
@@ -473,12 +472,4 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	}
 	config := configFromCore(coreConfig)
 	return &config, nil
-}
-
-func isCoreSIPError(err error) (*internal_core.SIPError, bool) {
-	var sipErr *internal_core.SIPError
-	if errors.As(err, &sipErr) {
-		return sipErr, true
-	}
-	return nil, false
 }

--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -476,10 +476,6 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	return &config, nil
 }
 
-func ExtractDIDFromURI(uri string) string {
-	return internal_core.ExtractDIDFromURI(uri)
-}
-
 func cloneMap(values map[string]interface{}) map[string]interface{} {
 	if len(values) == 0 {
 		return nil

--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -7,7 +7,6 @@
 package sip_infra
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -474,40 +473,6 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	}
 	config := configFromCore(coreConfig)
 	return &config, nil
-}
-
-func cloneMap(values map[string]interface{}) map[string]interface{} {
-	if len(values) == 0 {
-		return nil
-	}
-	copied := make(map[string]interface{}, len(values))
-	for key, value := range values {
-		copied[key] = value
-	}
-	return copied
-}
-
-func copyJSONCompatibleMap(raw map[string]string) map[string]string {
-	if len(raw) == 0 {
-		return nil
-	}
-	copied := make(map[string]string, len(raw))
-	for key, value := range raw {
-		copied[key] = value
-	}
-	return copied
-}
-
-func marshalJSONMap(value interface{}) map[string]interface{} {
-	raw, err := json.Marshal(value)
-	if err != nil {
-		return nil
-	}
-	var out map[string]interface{}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil
-	}
-	return out
 }
 
 func isCoreSIPError(err error) (*internal_core.SIPError, bool) {

--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -473,3 +473,9 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	config := configFromCore(coreConfig)
 	return &config, nil
 }
+
+// ExtractDIDFromURI is retained for downstream compatibility.
+// Deprecated: native SIP identity handling preserves parsed SIP addresses.
+func ExtractDIDFromURI(uri string) string {
+	return internal_core.ExtractDIDFromURI(uri)
+}

--- a/api/assistant-api/sip/infra/outbound_type.go
+++ b/api/assistant-api/sip/infra/outbound_type.go
@@ -7,6 +7,7 @@
 package sip_infra
 
 import (
+	"maps"
 	"time"
 
 	callcontext "github.com/rapidaai/api/assistant-api/internal/callcontext"
@@ -14,7 +15,6 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	internal_core "github.com/rapidaai/api/assistant-api/sip/internal/core"
 	"github.com/rapidaai/pkg/types"
-	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/protos"
 )
 
@@ -151,7 +151,7 @@ func (c OutboundConfig) toCore() internal_core.OutboundConfig {
 			Password: c.Auth.Password,
 			Realm:    c.Auth.Realm,
 		},
-		Headers:             utils.CloneMap(c.Headers),
+		Headers:             maps.Clone(c.Headers),
 		RingingTimeout:      c.RingingTimeout,
 		MaxCallDuration:     c.MaxCallDuration,
 		MediaTimeoutInitial: c.MediaTimeoutInitial,
@@ -206,7 +206,7 @@ func (c *Config) ToOutboundConfig() OutboundConfig {
 			Password: coreOutbound.Auth.Password,
 			Realm:    coreOutbound.Auth.Realm,
 		},
-		Headers:             utils.CloneMap(coreOutbound.Headers),
+		Headers:             maps.Clone(coreOutbound.Headers),
 		RingingTimeout:      coreOutbound.RingingTimeout,
 		MaxCallDuration:     coreOutbound.MaxCallDuration,
 		MediaTimeoutInitial: coreOutbound.MediaTimeoutInitial,
@@ -231,7 +231,7 @@ func NewOutboundInviteRequest(cfg *Config, toUser string, fromUser string) (Outb
 				Password: coreRequest.Config.Auth.Password,
 				Realm:    coreRequest.Config.Auth.Realm,
 			},
-			Headers:         utils.CloneMap(coreRequest.Config.Headers),
+			Headers:         maps.Clone(coreRequest.Config.Headers),
 			RingingTimeout:  coreRequest.Config.RingingTimeout,
 			MaxCallDuration: coreRequest.Config.MaxCallDuration,
 		},

--- a/api/assistant-api/sip/infra/outbound_type.go
+++ b/api/assistant-api/sip/infra/outbound_type.go
@@ -14,6 +14,7 @@ import (
 	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	internal_core "github.com/rapidaai/api/assistant-api/sip/internal/core"
 	"github.com/rapidaai/pkg/types"
+	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/protos"
 )
 
@@ -150,7 +151,7 @@ func (c OutboundConfig) toCore() internal_core.OutboundConfig {
 			Password: c.Auth.Password,
 			Realm:    c.Auth.Realm,
 		},
-		Headers:             copyJSONCompatibleMap(c.Headers),
+		Headers:             utils.CloneMap(c.Headers),
 		RingingTimeout:      c.RingingTimeout,
 		MaxCallDuration:     c.MaxCallDuration,
 		MediaTimeoutInitial: c.MediaTimeoutInitial,
@@ -205,7 +206,7 @@ func (c *Config) ToOutboundConfig() OutboundConfig {
 			Password: coreOutbound.Auth.Password,
 			Realm:    coreOutbound.Auth.Realm,
 		},
-		Headers:             copyJSONCompatibleMap(coreOutbound.Headers),
+		Headers:             utils.CloneMap(coreOutbound.Headers),
 		RingingTimeout:      coreOutbound.RingingTimeout,
 		MaxCallDuration:     coreOutbound.MaxCallDuration,
 		MediaTimeoutInitial: coreOutbound.MediaTimeoutInitial,
@@ -230,7 +231,7 @@ func NewOutboundInviteRequest(cfg *Config, toUser string, fromUser string) (Outb
 				Password: coreRequest.Config.Auth.Password,
 				Realm:    coreRequest.Config.Auth.Realm,
 			},
-			Headers:         copyJSONCompatibleMap(coreRequest.Config.Headers),
+			Headers:         utils.CloneMap(coreRequest.Config.Headers),
 			RingingTimeout:  coreRequest.Config.RingingTimeout,
 			MaxCallDuration: coreRequest.Config.MaxCallDuration,
 		},

--- a/api/assistant-api/sip/infra/pipeline_type.go
+++ b/api/assistant-api/sip/infra/pipeline_type.go
@@ -23,8 +23,9 @@ type SessionEstablishedPipeline struct {
 	Direction       CallDirection
 	AssistantID     uint64
 	Auth            types.SimplePrinciple
-	FromURI         string
-	ToURI           string
+	RequestURI      string
+	FromIdentity    string
+	ToIdentity      string
 	ConversationID  uint64
 }
 

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -45,8 +45,9 @@ func (s *Server) SetMiddlewares(middlewares []Middleware) {
 			infraCtx := &SIPRequestContext{
 				Method:          ctx.Method,
 				CallID:          ctx.CallID,
-				FromURI:         ctx.FromURI,
-				ToURI:           ctx.ToURI,
+				RequestURI:      ctx.RequestURI,
+				FromIdentity:    ctx.FromIdentity,
+				ToIdentity:      ctx.ToIdentity,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,
@@ -104,13 +105,13 @@ func (s *Server) SessionCount() int {
 	return s.inner.SessionCount()
 }
 
-func (s *Server) SetOnApplicationReady(fn func(session *Session, fromURI, toURI string) error) {
+func (s *Server) SetOnApplicationReady(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
 	if fn == nil {
 		s.inner.SetOnApplicationReady(nil)
 		return
 	}
-	s.inner.SetOnApplicationReady(func(session *internal_core.Session, fromURI, toURI string) error {
-		return fn(wrapSession(session), fromURI, toURI)
+	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+		return fn(wrapSession(session), requestURI, fromIdentity, toIdentity)
 	})
 }
 
@@ -124,13 +125,13 @@ func (s *Server) SetOnApplicationCleanup(fn func(session *Session)) {
 	})
 }
 
-func (s *Server) SetOnInvite(fn func(session *Session, fromURI, toURI string) error) {
+func (s *Server) SetOnInvite(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
 	if fn == nil {
 		s.inner.SetOnInvite(nil)
 		return
 	}
-	s.inner.SetOnInvite(func(session *internal_core.Session, fromURI, toURI string) error {
-		return fn(wrapSession(session), fromURI, toURI)
+	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+		return fn(wrapSession(session), requestURI, fromIdentity, toIdentity)
 	})
 }
 

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -48,6 +48,8 @@ func (s *Server) SetMiddlewares(middlewares []Middleware) {
 				RequestURI:      ctx.RequestURI,
 				FromIdentity:    ctx.FromIdentity,
 				ToIdentity:      ctx.ToIdentity,
+				FromURI:         ctx.FromIdentity,
+				ToURI:           ctx.ToIdentity,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,
@@ -105,13 +107,30 @@ func (s *Server) SessionCount() int {
 	return s.inner.SessionCount()
 }
 
-func (s *Server) SetOnApplicationReady(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
+// SetOnApplicationReady sets the legacy application-ready callback.
+// Deprecated: use SetOnApplicationReadyIdentity.
+func (s *Server) SetOnApplicationReady(fn func(session *Session, fromURI, toURI string) error) {
 	if fn == nil {
 		s.inner.SetOnApplicationReady(nil)
 		return
 	}
 	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
-		return fn(wrapSession(session), requestURI, fromIdentity, toIdentity)
+		return fn(wrapSession(session), fromIdentity, toIdentity)
+	})
+}
+
+// SetOnApplicationReadyIdentity sets the application-ready callback with explicit SIP identities.
+func (s *Server) SetOnApplicationReadyIdentity(fn func(session *Session, identity SIPRequestIdentity) error) {
+	if fn == nil {
+		s.inner.SetOnApplicationReady(nil)
+		return
+	}
+	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+		return fn(wrapSession(session), SIPRequestIdentity{
+			RequestURI:   requestURI,
+			FromIdentity: fromIdentity,
+			ToIdentity:   toIdentity,
+		})
 	})
 }
 
@@ -125,13 +144,30 @@ func (s *Server) SetOnApplicationCleanup(fn func(session *Session)) {
 	})
 }
 
-func (s *Server) SetOnInvite(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
+// SetOnInvite sets the legacy answered-INVITE callback.
+// Deprecated: use SetOnInviteIdentity.
+func (s *Server) SetOnInvite(fn func(session *Session, fromURI, toURI string) error) {
 	if fn == nil {
 		s.inner.SetOnInvite(nil)
 		return
 	}
 	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
-		return fn(wrapSession(session), requestURI, fromIdentity, toIdentity)
+		return fn(wrapSession(session), fromIdentity, toIdentity)
+	})
+}
+
+// SetOnInviteIdentity sets the answered-INVITE callback with explicit SIP identities.
+func (s *Server) SetOnInviteIdentity(fn func(session *Session, identity SIPRequestIdentity) error) {
+	if fn == nil {
+		s.inner.SetOnInvite(nil)
+		return
+	}
+	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+		return fn(wrapSession(session), SIPRequestIdentity{
+			RequestURI:   requestURI,
+			FromIdentity: fromIdentity,
+			ToIdentity:   toIdentity,
+		})
 	})
 }
 

--- a/api/assistant-api/sip/infra/server_type.go
+++ b/api/assistant-api/sip/infra/server_type.go
@@ -25,11 +25,15 @@ const (
 )
 
 type SIPRequestContext struct {
-	Method          string
-	CallID          string
-	RequestURI      string
-	FromIdentity    string
-	ToIdentity      string
+	Method       string
+	CallID       string
+	RequestURI   string
+	FromIdentity string
+	ToIdentity   string
+	// Deprecated: use FromIdentity.
+	FromURI string
+	// Deprecated: use ToIdentity.
+	ToURI           string
 	APIKey          string
 	AssistantID     string
 	Auth            types.SimplePrinciple
@@ -37,6 +41,12 @@ type SIPRequestContext struct {
 	Assistant       *internal_assistant_entity.Assistant
 	VaultCredential *protos.VaultCredential
 	Config          *Config
+}
+
+type SIPRequestIdentity struct {
+	RequestURI   string
+	FromIdentity string
+	ToIdentity   string
 }
 
 type Middleware func(ctx *SIPRequestContext) error
@@ -136,6 +146,8 @@ func (c *ServerConfig) toCore() *internal_core.ServerConfig {
 				RequestURI:      ctx.RequestURI,
 				FromIdentity:    ctx.FromIdentity,
 				ToIdentity:      ctx.ToIdentity,
+				FromURI:         ctx.FromIdentity,
+				ToURI:           ctx.ToIdentity,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,

--- a/api/assistant-api/sip/infra/server_type.go
+++ b/api/assistant-api/sip/infra/server_type.go
@@ -27,8 +27,9 @@ const (
 type SIPRequestContext struct {
 	Method          string
 	CallID          string
-	FromURI         string
-	ToURI           string
+	RequestURI      string
+	FromIdentity    string
+	ToIdentity      string
 	APIKey          string
 	AssistantID     string
 	Auth            types.SimplePrinciple
@@ -132,8 +133,9 @@ func (c *ServerConfig) toCore() *internal_core.ServerConfig {
 			infraCtx := &SIPRequestContext{
 				Method:          ctx.Method,
 				CallID:          ctx.CallID,
-				FromURI:         ctx.FromURI,
-				ToURI:           ctx.ToURI,
+				RequestURI:      ctx.RequestURI,
+				FromIdentity:    ctx.FromIdentity,
+				ToIdentity:      ctx.ToIdentity,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -446,11 +446,8 @@ func TestOutboundTypeConversions(t *testing.T) {
 	}
 }
 
-func TestOutboundTypeConversionsReturnWritableEmptyHeaders(t *testing.T) {
+func TestOutboundTypeConversionsPreserveNilHeaders(t *testing.T) {
 	coreOutboundConfig := (OutboundConfig{}).toCore()
 
-	require.NotNil(t, coreOutboundConfig.Headers)
-	assert.Empty(t, coreOutboundConfig.Headers)
-	coreOutboundConfig.Headers["X-Test"] = "ok"
-	assert.Equal(t, "ok", coreOutboundConfig.Headers["X-Test"])
+	assert.Nil(t, coreOutboundConfig.Headers)
 }

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -445,3 +445,12 @@ func TestOutboundTypeConversions(t *testing.T) {
 		t.Fatalf("outbound invite identity conversion mismatch: %#v", request.toCore().Identity)
 	}
 }
+
+func TestOutboundTypeConversionsReturnWritableEmptyHeaders(t *testing.T) {
+	coreOutboundConfig := (OutboundConfig{}).toCore()
+
+	require.NotNil(t, coreOutboundConfig.Headers)
+	assert.Empty(t, coreOutboundConfig.Headers)
+	coreOutboundConfig.Headers["X-Test"] = "ok"
+	assert.Equal(t, "ok", coreOutboundConfig.Headers["X-Test"])
+}

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	internal_core "github.com/rapidaai/api/assistant-api/sip/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigTypeConversionsPreserveFields(t *testing.T) {
@@ -249,8 +251,41 @@ func TestListenConfigAndServerConfigConversions(t *testing.T) {
 	}
 }
 
+func TestServerConfigMiddlewareConversionPreservesSIPIdentities(t *testing.T) {
+	var received *SIPRequestContext
+	serverConfig := (&ServerConfig{
+		Middlewares: []Middleware{func(ctx *SIPRequestContext) error {
+			received = ctx
+			ctx.AssistantID = "42"
+			return nil
+		}},
+	}).toCore()
+	require.Len(t, serverConfig.Middlewares, 1)
+
+	coreContext := &internal_core.SIPRequestContext{
+		RequestURI:   "sip:agent-42@sip.rapida.ai",
+		FromIdentity: "sip:alice@example.com;user=phone",
+		ToIdentity:   "sips:support@example.net",
+	}
+	err := serverConfig.Middlewares[0](coreContext)
+
+	require.NoError(t, err)
+	require.NotNil(t, received)
+	assert.Equal(t, coreContext.RequestURI, received.RequestURI)
+	assert.Equal(t, coreContext.FromIdentity, received.FromIdentity)
+	assert.Equal(t, coreContext.ToIdentity, received.ToIdentity)
+	assert.Equal(t, "42", coreContext.AssistantID)
+	assert.Equal(t, "sip:agent-42@sip.rapida.ai", coreContext.RequestURI)
+	assert.Equal(t, "sip:alice@example.com;user=phone", coreContext.FromIdentity)
+	assert.Equal(t, "sips:support@example.net", coreContext.ToIdentity)
+}
+
 func TestSIPRequestContextMiddleware(t *testing.T) {
-	requestContext := &SIPRequestContext{}
+	requestContext := &SIPRequestContext{
+		RequestURI:   "sip:agent-42@sip.rapida.ai",
+		FromIdentity: "sip:alice@example.com",
+		ToIdentity:   "sip:support@example.net",
+	}
 
 	var order []string
 	middlewares := []Middleware{
@@ -276,6 +311,11 @@ func TestSIPRequestContextMiddleware(t *testing.T) {
 	}
 	if requestContext.Config == nil || requestContext.Config.Server != "sip.example.com" {
 		t.Fatalf("unexpected middleware context: %#v", requestContext)
+	}
+	if requestContext.RequestURI != "sip:agent-42@sip.rapida.ai" ||
+		requestContext.FromIdentity != "sip:alice@example.com" ||
+		requestContext.ToIdentity != "sip:support@example.net" {
+		t.Fatalf("middleware changed SIP identities: %#v", requestContext)
 	}
 	expectedOrder := []string{"first", "second", "final"}
 	for i := range expectedOrder {

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -271,13 +271,21 @@ func TestServerConfigMiddlewareConversionPreservesSIPIdentities(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, received)
-	assert.Equal(t, coreContext.RequestURI, received.RequestURI)
-	assert.Equal(t, coreContext.FromIdentity, received.FromIdentity)
-	assert.Equal(t, coreContext.ToIdentity, received.ToIdentity)
+	assert.Equal(t, "sip:agent-42@sip.rapida.ai", received.RequestURI)
+	assert.Equal(t, "sip:alice@example.com;user=phone", received.FromIdentity)
+	assert.Equal(t, "sips:support@example.net", received.ToIdentity)
+	assert.Equal(t, "sip:alice@example.com;user=phone", received.FromURI)
+	assert.Equal(t, "sips:support@example.net", received.ToURI)
 	assert.Equal(t, "42", coreContext.AssistantID)
-	assert.Equal(t, "sip:agent-42@sip.rapida.ai", coreContext.RequestURI)
-	assert.Equal(t, "sip:alice@example.com;user=phone", coreContext.FromIdentity)
-	assert.Equal(t, "sips:support@example.net", coreContext.ToIdentity)
+}
+
+func TestDeprecatedSIPCompatibilitySurface(t *testing.T) {
+	var _ func(*Server, func(*Session, string, string) error) = (*Server).SetOnApplicationReady
+	var _ func(*Server, func(*Session, string, string) error) = (*Server).SetOnInvite
+	var _ func(*Server, func(*Session, SIPRequestIdentity) error) = (*Server).SetOnApplicationReadyIdentity
+	var _ func(*Server, func(*Session, SIPRequestIdentity) error) = (*Server).SetOnInviteIdentity
+
+	assert.Equal(t, "+15551234567", ExtractDIDFromURI("sip:15551234567@example.com"))
 }
 
 func TestSIPRequestContextMiddleware(t *testing.T) {

--- a/api/assistant-api/sip/integration/freeswitch_inbound_disconnect_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_inbound_disconnect_test.go
@@ -23,7 +23,7 @@ func TestFreeSWITCHInboundRemoteByeNormalClearing(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
+	harness.server.SetOnInviteIdentity(func(session *sip_infra.Session, _ sip_infra.SIPRequestIdentity) error {
 		answeredSessions <- session
 		return nil
 	})
@@ -60,7 +60,7 @@ func TestFreeSWITCHSystemDisconnectSendsBye(t *testing.T) {
 	registrationClient := harness.registrationClient()
 	answeredSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
+	harness.server.SetOnInviteIdentity(func(session *sip_infra.Session, _ sip_infra.SIPRequestIdentity) error {
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/integration/freeswitch_inbound_disconnect_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_inbound_disconnect_test.go
@@ -23,7 +23,7 @@ func TestFreeSWITCHInboundRemoteByeNormalClearing(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _ string) error {
+	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
 		answeredSessions <- session
 		return nil
 	})
@@ -60,7 +60,7 @@ func TestFreeSWITCHSystemDisconnectSendsBye(t *testing.T) {
 	registrationClient := harness.registrationClient()
 	answeredSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _ string) error {
+	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/integration/freeswitch_inbound_status_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_inbound_status_test.go
@@ -22,7 +22,7 @@ func TestFreeSWITCHRegistrationBasedInboundCall(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
+	harness.server.SetOnInviteIdentity(func(session *sip_infra.Session, _ sip_infra.SIPRequestIdentity) error {
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/integration/freeswitch_inbound_status_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_inbound_status_test.go
@@ -22,7 +22,7 @@ func TestFreeSWITCHRegistrationBasedInboundCall(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _ string) error {
+	harness.server.SetOnInvite(func(session *sip_infra.Session, _, _, _ string) error {
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/integration/freeswitch_twilio_elastic_trunk_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_twilio_elastic_trunk_test.go
@@ -46,9 +46,9 @@ func TestFreeSWITCHTwilioElasticTrunkInbound(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, fromURI, toURI string) error {
-		require.Contains(t, fromURI, freeSWITCHUser(twilioProfile.callerUser))
-		require.Contains(t, toURI, freeSWITCHUser(twilioProfile.inboundDID))
+	harness.server.SetOnInvite(func(session *sip_infra.Session, _, fromIdentity, toIdentity string) error {
+		require.Contains(t, fromIdentity, freeSWITCHUser(twilioProfile.callerUser))
+		require.Contains(t, toIdentity, freeSWITCHUser(twilioProfile.inboundDID))
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/integration/freeswitch_twilio_elastic_trunk_test.go
+++ b/api/assistant-api/sip/integration/freeswitch_twilio_elastic_trunk_test.go
@@ -46,9 +46,9 @@ func TestFreeSWITCHTwilioElasticTrunkInbound(t *testing.T) {
 	answeredSessions := make(chan *sip_infra.Session, 1)
 	remoteByeSessions := make(chan *sip_infra.Session, 1)
 
-	harness.server.SetOnInvite(func(session *sip_infra.Session, _, fromIdentity, toIdentity string) error {
-		require.Contains(t, fromIdentity, freeSWITCHUser(twilioProfile.callerUser))
-		require.Contains(t, toIdentity, freeSWITCHUser(twilioProfile.inboundDID))
+	harness.server.SetOnInviteIdentity(func(session *sip_infra.Session, identity sip_infra.SIPRequestIdentity) error {
+		require.Contains(t, identity.FromIdentity, freeSWITCHUser(twilioProfile.callerUser))
+		require.Contains(t, identity.ToIdentity, freeSWITCHUser(twilioProfile.inboundDID))
 		answeredSessions <- session
 		return nil
 	})

--- a/api/assistant-api/sip/internal/core/inbound_call.go
+++ b/api/assistant-api/sip/internal/core/inbound_call.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,7 +57,9 @@ func inboundInviteIdentityFromRequest(request *sip.Request) (inboundInviteIdenti
 		request.CallID().Value() == "" ||
 		request.From() == nil ||
 		request.From().Params == nil ||
-		request.To() == nil {
+		request.To() == nil ||
+		strings.TrimSpace(request.From().Address.Host) == "" ||
+		strings.TrimSpace(request.To().Address.Host) == "" {
 		return inboundInviteIdentity{}, false
 	}
 	fromTag, ok := request.From().Params.Get("tag")

--- a/api/assistant-api/sip/internal/core/inbound_call.go
+++ b/api/assistant-api/sip/internal/core/inbound_call.go
@@ -17,10 +17,11 @@ import (
 )
 
 type inboundInviteIdentity struct {
-	callID  string
-	fromTag string
-	fromURI string
-	toURI   string
+	callID       string
+	fromTag      string
+	requestURI   string
+	fromIdentity string
+	toIdentity   string
 }
 
 // Inbound owns the lifecycle for a single inbound SIP INVITE.
@@ -64,10 +65,11 @@ func inboundInviteIdentityFromRequest(request *sip.Request) (inboundInviteIdenti
 	}
 
 	return inboundInviteIdentity{
-		callID:  request.CallID().Value(),
-		fromTag: fromTag,
-		fromURI: request.From().Address.String(),
-		toURI:   request.To().Address.String(),
+		callID:       request.CallID().Value(),
+		fromTag:      fromTag,
+		requestURI:   request.Recipient.String(),
+		fromIdentity: request.From().Address.String(),
+		toIdentity:   request.To().Address.String(),
 	}, true
 }
 
@@ -320,7 +322,12 @@ func (inboundCall *Inbound) callInboundApplicationReadyHandler() error {
 	if applicationReadyHandler == nil {
 		return nil
 	}
-	return applicationReadyHandler(inboundCall.session, inboundCall.identity.fromURI, inboundCall.identity.toURI)
+	return applicationReadyHandler(
+		inboundCall.session,
+		inboundCall.identity.requestURI,
+		inboundCall.identity.fromIdentity,
+		inboundCall.identity.toIdentity,
+	)
 }
 
 // waitUntilAnswerReady applies the configured answer policy without changing call state.
@@ -425,7 +432,12 @@ func (inboundCall *Inbound) callInboundInviteHandler() error {
 	if inviteHandler == nil {
 		return nil
 	}
-	return inviteHandler(inboundCall.session, inboundCall.identity.fromURI, inboundCall.identity.toURI)
+	return inviteHandler(
+		inboundCall.session,
+		inboundCall.identity.requestURI,
+		inboundCall.identity.fromIdentity,
+		inboundCall.identity.toIdentity,
+	)
 }
 
 func (inboundCall *Inbound) cancelBeforeAnswer(reason LifecycleReason) bool {

--- a/api/assistant-api/sip/internal/core/inbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/inbound_call_test.go
@@ -484,6 +484,126 @@ func TestInboundCall_ApplicationReadyBeforeAnswerAndMediaStart(t *testing.T) {
 	assert.Equal(t, InboundSetupPhaseMediaFlowing, session.GetInboundSetupPhase())
 }
 
+func TestInboundCall_ReInviteDoesNotReplaceInitialPartyIdentities(t *testing.T) {
+	server := newServerForCommandTests(t)
+	server.SetMiddlewares([]Middleware{func(ctx *SIPRequestContext) error {
+		ctx.Config = bridgeTestConfig()
+		return nil
+	}})
+	callbackCount := 0
+	var capturedFromIdentity string
+	var capturedToIdentity string
+	server.SetOnInvite(func(_ *Session, _, fromIdentity, toIdentity string) error {
+		callbackCount++
+		capturedFromIdentity = fromIdentity
+		capturedToIdentity = toIdentity
+		return nil
+	})
+
+	initialRequest := newInboundInviteRequest("inbound-reinvite-identity")
+	initialRequest.From().Address = sip.Uri{Scheme: "sip", User: "original-caller", Host: "example.com"}
+	initialRequest.To().Address = sip.Uri{Scheme: "sip", User: "original-assistant", Host: "sip.rapida.ai"}
+	initialTransaction := newActiveAckableTestServerTx()
+	initialTransaction.PushACK(newACKRequest("inbound-reinvite-identity"))
+	server.handleInvite(initialRequest, initialTransaction)
+
+	require.Equal(t, 1, callbackCount)
+	require.Equal(t, 200, initialTransaction.lastStatus())
+	session, exists := server.GetSession("inbound-reinvite-identity")
+	require.True(t, exists)
+
+	reInvite := newInboundDialogSDPRequest(t, session, sip.INVITE, validInboundOfferSDP())
+	reInvite.From().Address = sip.Uri{Scheme: "sip", User: "changed-caller", Host: "example.net"}
+	reInvite.To().Address = sip.Uri{Scheme: "sip", User: "changed-assistant", Host: "sip.example.net"}
+	reInviteTransaction := newTestServerTx()
+	server.handleInvite(reInvite, reInviteTransaction)
+
+	require.Equal(t, 200, reInviteTransaction.lastStatus())
+	assert.Equal(t, 1, callbackCount)
+	assert.Equal(t, "sip:original-caller@example.com", capturedFromIdentity)
+	assert.Equal(t, "sip:original-assistant@sip.rapida.ai", capturedToIdentity)
+}
+
+func TestInboundCall_InviteWithReplacesUsesNewDialogPartyIdentities(t *testing.T) {
+	server := newServerForCommandTests(t)
+	server.SetMiddlewares([]Middleware{func(ctx *SIPRequestContext) error {
+		ctx.Config = bridgeTestConfig()
+		return nil
+	}})
+	replacedSession := registerConnectedInboundDialogSession(t, server, "replaced-dialog")
+
+	callbackCount := 0
+	var capturedRequestURI string
+	var capturedFromIdentity string
+	var capturedToIdentity string
+	server.SetOnInvite(func(_ *Session, requestURI, fromIdentity, toIdentity string) error {
+		callbackCount++
+		capturedRequestURI = requestURI
+		capturedFromIdentity = fromIdentity
+		capturedToIdentity = toIdentity
+		return nil
+	})
+
+	replacementRequest := newInboundInviteRequest("replacement-dialog")
+	replacementRequest.Recipient = sip.Uri{Scheme: "sip", User: "agent-42", Host: "sip.rapida.ai"}
+	replacementRequest.From().Address = sip.Uri{Scheme: "sip", User: "replacement-caller", Host: "example.net"}
+	replacementRequest.To().Address = sip.Uri{Scheme: "sip", User: "replacement-assistant", Host: "sip.example.net"}
+	replacementRequest.AppendHeader(sip.NewHeader("Replaces", replacedSession.GetCallID()+";to-tag=to-tag;from-tag=from-tag"))
+	replacementTransaction := newActiveAckableTestServerTx()
+	replacementTransaction.PushACK(newACKRequest("replacement-dialog"))
+
+	server.handleInvite(replacementRequest, replacementTransaction)
+
+	require.Equal(t, 200, replacementTransaction.lastStatus())
+	assert.Equal(t, 1, callbackCount)
+	assert.Equal(t, replacementRequest.Recipient.String(), capturedRequestURI)
+	assert.Equal(t, "sip:replacement-caller@example.net", capturedFromIdentity)
+	assert.Equal(t, "sip:replacement-assistant@sip.example.net", capturedToIdentity)
+	_, replacedExists := server.GetSession("replaced-dialog")
+	_, replacementExists := server.GetSession("replacement-dialog")
+	assert.True(t, replacedExists)
+	assert.True(t, replacementExists)
+}
+
+func TestInboundCall_REFERDoesNotReplaceInitialPartyIdentities(t *testing.T) {
+	server := newServerForCommandTests(t)
+	server.SetMiddlewares([]Middleware{func(ctx *SIPRequestContext) error {
+		ctx.Config = bridgeTestConfig()
+		return nil
+	}})
+	callbackCount := 0
+	var capturedFromIdentity string
+	var capturedToIdentity string
+	server.SetOnInvite(func(_ *Session, _, fromIdentity, toIdentity string) error {
+		callbackCount++
+		capturedFromIdentity = fromIdentity
+		capturedToIdentity = toIdentity
+		return nil
+	})
+
+	initialRequest := newInboundInviteRequest("inbound-refer-identity")
+	initialRequest.From().Address = sip.Uri{Scheme: "sip", User: "original-caller", Host: "example.com"}
+	initialRequest.To().Address = sip.Uri{Scheme: "sip", User: "original-assistant", Host: "sip.rapida.ai"}
+	initialTransaction := newActiveAckableTestServerTx()
+	initialTransaction.PushACK(newACKRequest("inbound-refer-identity"))
+	server.handleInvite(initialRequest, initialTransaction)
+
+	require.Equal(t, 1, callbackCount)
+	session, exists := server.GetSession("inbound-refer-identity")
+	require.True(t, exists)
+
+	referRequest := newInboundDialogRequest(t, session, sip.REFER)
+	referRequest.AppendHeader(sip.NewHeader("Refer-To", "<sip:transfer-target@example.net>"))
+	referTransaction := newTestServerTx()
+	server.handleRefer(referRequest, referTransaction)
+
+	require.Equal(t, 603, referTransaction.lastStatus())
+	assert.Equal(t, 1, callbackCount)
+	assert.Equal(t, "sip:original-caller@example.com", capturedFromIdentity)
+	assert.Equal(t, "sip:original-assistant@sip.rapida.ai", capturedToIdentity)
+	assert.Equal(t, 1, server.SessionCount())
+}
+
 func TestInboundCall_ProvisionalResponsesBeforeAnswer(t *testing.T) {
 	server := newServerForCommandTests(t)
 	server.SetMiddlewares([]Middleware{func(ctx *SIPRequestContext) error {

--- a/api/assistant-api/sip/internal/core/inbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/inbound_call_test.go
@@ -33,15 +33,19 @@ func TestInboundCall_InvalidSDPRejectsWithoutSession(t *testing.T) {
 
 func TestInboundCall_InvalidIdentityRejectsWithoutSession(t *testing.T) {
 	cases := []struct {
-		name          string
-		callID        string
-		removeHeader  string
-		removeFromTag bool
+		name             string
+		callID           string
+		removeHeader     string
+		removeFromTag    bool
+		emptyFromAddress bool
+		emptyToAddress   bool
 	}{
 		{name: "missing call id", callID: "inbound-missing-call-id", removeHeader: "Call-ID"},
 		{name: "missing from", callID: "inbound-missing-from", removeHeader: "From"},
 		{name: "missing from tag", callID: "inbound-missing-from-tag", removeFromTag: true},
 		{name: "missing to", callID: "inbound-missing-to", removeHeader: "To"},
+		{name: "empty from address", callID: "inbound-empty-from-address", emptyFromAddress: true},
+		{name: "empty to address", callID: "inbound-empty-to-address", emptyToAddress: true},
 	}
 
 	for _, tc := range cases {
@@ -52,6 +56,12 @@ func TestInboundCall_InvalidIdentityRejectsWithoutSession(t *testing.T) {
 			}
 			if tc.removeFromTag && request.From() != nil && request.From().Params != nil {
 				delete(request.From().Params, "tag")
+			}
+			if tc.emptyFromAddress {
+				request.From().Address = sip.Uri{Scheme: "sip"}
+			}
+			if tc.emptyToAddress {
+				request.To().Address = sip.Uri{Scheme: "sip"}
 			}
 			transaction := newTestServerTx()
 

--- a/api/assistant-api/sip/internal/core/inbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/inbound_call_test.go
@@ -67,6 +67,20 @@ func TestInboundCall_InvalidIdentityRejectsWithoutSession(t *testing.T) {
 	}
 }
 
+func TestInboundInviteIdentityFromRequestPreservesRoutingAndPartyIdentities(t *testing.T) {
+	request := newInboundInviteRequest("identity-snapshot")
+	request.Recipient = sip.Uri{Scheme: "sip", User: "agent-42", Host: "sip.rapida.ai"}
+	request.From().Address = sip.Uri{Scheme: "sip", User: "alice", Host: "example.com"}
+	request.To().Address = sip.Uri{Scheme: "sips", User: "support", Host: "example.net"}
+
+	identity, ok := inboundInviteIdentityFromRequest(request)
+
+	require.True(t, ok)
+	assert.Equal(t, request.Recipient.String(), identity.requestURI)
+	assert.Equal(t, request.From().Address.String(), identity.fromIdentity)
+	assert.Equal(t, request.To().Address.String(), identity.toIdentity)
+}
+
 func TestInboundCall_ConfigRejectDoesNotCreateSession(t *testing.T) {
 	server := newServerForCommandTests(t)
 	server.SetMiddlewares([]Middleware{func(ctx *SIPRequestContext) error {
@@ -426,18 +440,27 @@ func TestInboundCall_ApplicationReadyBeforeAnswerAndMediaStart(t *testing.T) {
 	}})
 	phaseOrder := make([]string, 0, 2)
 	transaction := newActiveAckableTestServerTx()
-	server.SetOnApplicationReady(func(session *Session, _, _ string) error {
+	request := newInboundInviteRequest("inbound-ready-before-answer")
+	expectedRequestURI := request.Recipient.String()
+	expectedFromIdentity := request.From().Address.String()
+	expectedToIdentity := request.To().Address.String()
+	server.SetOnApplicationReady(func(session *Session, requestURI, fromIdentity, toIdentity string) error {
 		phaseOrder = append(phaseOrder, "application_ready")
 		assert.Equal(t, 180, transaction.lastStatus())
 		assert.Equal(t, InboundSetupPhaseMediaAllocated, session.GetInboundSetupPhase())
+		assert.Equal(t, expectedRequestURI, requestURI)
+		assert.Equal(t, expectedFromIdentity, fromIdentity)
+		assert.Equal(t, expectedToIdentity, toIdentity)
 		return nil
 	})
-	server.SetOnInvite(func(session *Session, _, _ string) error {
+	server.SetOnInvite(func(session *Session, requestURI, fromIdentity, toIdentity string) error {
 		phaseOrder = append(phaseOrder, "call_start")
 		assert.Equal(t, InboundSetupPhaseMediaFlowing, session.GetInboundSetupPhase())
+		assert.Equal(t, expectedRequestURI, requestURI)
+		assert.Equal(t, expectedFromIdentity, fromIdentity)
+		assert.Equal(t, expectedToIdentity, toIdentity)
 		return nil
 	})
-	request := newInboundInviteRequest("inbound-ready-before-answer")
 	transaction.PushACK(newACKRequest("inbound-ready-before-answer"))
 
 	server.handleInvite(request, transaction)
@@ -509,7 +532,7 @@ func TestInboundCall_RetransmitsRingingUntilAnswer(t *testing.T) {
 		return nil
 	}})
 	applicationReady := make(chan struct{})
-	server.SetOnApplicationReady(func(_ *Session, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
 		<-applicationReady
 		return nil
 	})
@@ -547,7 +570,7 @@ func TestInboundCall_WaitsForApplicationReadyBeforeAnswer(t *testing.T) {
 		return nil
 	}})
 	applicationReady := make(chan struct{})
-	server.SetOnApplicationReady(func(_ *Session, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
 		<-applicationReady
 		return nil
 	})
@@ -625,7 +648,7 @@ func TestInboundCall_AnswersAfterApplicationReadyWithoutAssistantAudio(t *testin
 		return nil
 	}})
 	applicationReadyCalled := false
-	server.SetOnApplicationReady(func(_ *Session, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
 		applicationReadyCalled = true
 		return nil
 	})
@@ -700,10 +723,10 @@ func TestInboundCall_ApplicationReadinessFailureRejectsBeforeAnswer(t *testing.T
 		ctx.Config = bridgeTestConfig()
 		return nil
 	}})
-	server.SetOnApplicationReady(func(_ *Session, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
 		return errors.New("assistant not ready")
 	})
-	server.SetOnInvite(func(_ *Session, _, _ string) error {
+	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
 		t.Fatal("onInvite should not run when application readiness fails")
 		return nil
 	})
@@ -730,14 +753,14 @@ func TestInboundCall_ACKTimeoutCleansPreparedApplication(t *testing.T) {
 	}})
 	cleanupCount := 0
 	var capturedSession *Session
-	server.SetOnApplicationReady(func(session *Session, _, _ string) error {
+	server.SetOnApplicationReady(func(session *Session, _, _, _ string) error {
 		capturedSession = session
 		return nil
 	})
 	server.SetOnApplicationCleanup(func(_ *Session) {
 		cleanupCount++
 	})
-	server.SetOnInvite(func(_ *Session, _, _ string) error {
+	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
 		t.Fatal("onInvite should not run when ACK timeout fails")
 		return nil
 	})
@@ -976,10 +999,11 @@ func loadInboundIdentity(t *testing.T, inboundCall *Inbound) {
 	require.NotNil(t, inboundCall.request.From())
 	require.NotNil(t, inboundCall.request.To())
 	inboundCall.identity = inboundInviteIdentity{
-		callID:  inboundCall.request.CallID().Value(),
-		fromTag: "fromtag",
-		fromURI: inboundCall.request.From().Address.String(),
-		toURI:   inboundCall.request.To().Address.String(),
+		callID:       inboundCall.request.CallID().Value(),
+		fromTag:      "fromtag",
+		requestURI:   inboundCall.request.Recipient.String(),
+		fromIdentity: inboundCall.request.From().Address.String(),
+		toIdentity:   inboundCall.request.To().Address.String(),
 	}
 	inboundCall.inviteKey = inboundInviteKey{callID: inboundCall.identity.callID, fromTag: inboundCall.identity.fromTag}
 }

--- a/api/assistant-api/sip/internal/core/inbound_config.go
+++ b/api/assistant-api/sip/internal/core/inbound_config.go
@@ -47,11 +47,12 @@ func NewInboundConfig(server *Server, identity inboundInviteIdentity, mediaOffer
 	}
 
 	requestContext := &SIPRequestContext{
-		Method:  "INVITE",
-		CallID:  identity.callID,
-		FromURI: identity.fromURI,
-		ToURI:   identity.toURI,
-		SDPInfo: mediaOffer.sdpInfo,
+		Method:       "INVITE",
+		CallID:       identity.callID,
+		RequestURI:   identity.requestURI,
+		FromIdentity: identity.fromIdentity,
+		ToIdentity:   identity.toIdentity,
+		SDPInfo:      mediaOffer.sdpInfo,
 	}
 	for _, middleware := range middlewares {
 		if err := middleware(requestContext); err != nil {

--- a/api/assistant-api/sip/internal/core/outbound_call.go
+++ b/api/assistant-api/sip/internal/core/outbound_call.go
@@ -298,10 +298,18 @@ func (outboundCall *Outbound) callOutboundInviteHandler(answerTime time.Time) er
 		return nil
 	}
 
-	info := outboundCall.session.GetInfo()
 	outboundCall.server.logger.Infow("Starting onInvite handler for outbound call",
 		"call_id", outboundCall.session.GetCallID())
-	if err := inviteHandler(outboundCall.session, info.RemoteURI, info.LocalURI, info.RemoteURI); err != nil {
+	inviteRequest := outboundCall.dialog.InviteRequest()
+	if inviteRequest == nil {
+		return fmt.Errorf("outbound INVITE request is unavailable")
+	}
+	if err := inviteHandler(
+		outboundCall.session,
+		inviteRequest.Recipient.String(),
+		outboundCall.request.Identity.FromUser,
+		outboundCall.request.Identity.ToUser,
+	); err != nil {
 		return err
 	}
 	outboundCall.server.logger.Infow("onInvite handler completed",

--- a/api/assistant-api/sip/internal/core/outbound_call.go
+++ b/api/assistant-api/sip/internal/core/outbound_call.go
@@ -301,7 +301,7 @@ func (outboundCall *Outbound) callOutboundInviteHandler(answerTime time.Time) er
 	info := outboundCall.session.GetInfo()
 	outboundCall.server.logger.Infow("Starting onInvite handler for outbound call",
 		"call_id", outboundCall.session.GetCallID())
-	if err := inviteHandler(outboundCall.session, info.LocalURI, info.RemoteURI); err != nil {
+	if err := inviteHandler(outboundCall.session, info.RemoteURI, info.LocalURI, info.RemoteURI); err != nil {
 		return err
 	}
 	outboundCall.server.logger.Infow("onInvite handler completed",

--- a/api/assistant-api/sip/internal/core/outbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/outbound_call_test.go
@@ -39,6 +39,55 @@ func TestNewOutboundCall_OwnsLifecycleDependencies(t *testing.T) {
 	assert.Equal(t, request, outboundCall.request)
 }
 
+func TestOutboundCallInviteHandlerUsesAuthoritativeRequestIdentity(t *testing.T) {
+	server := &Server{logger: bridgeTestLogger()}
+	request, err := NewOutboundInviteRequest(testOutboundConfig(), "customer-alias", "assistant-line")
+	require.NoError(t, err)
+	inviteRequest := sip.NewRequest(sip.INVITE, sip.Uri{
+		Scheme: "sip",
+		User:   request.Identity.ToUser,
+		Host:   request.Config.Address,
+		Port:   request.Config.Port,
+	})
+	session := &Session{info: SessionInfo{CallID: "outbound-authoritative-identity"}}
+	dialog := &outboundDialog{
+		dialogSession: &sipgo.DialogClientSession{
+			Dialog: sipgo.Dialog{InviteRequest: inviteRequest},
+		},
+	}
+
+	server.SetOnInvite(func(callbackSession *Session, requestURI, fromIdentity, toIdentity string) error {
+		assert.Same(t, session, callbackSession)
+		assert.Equal(t, inviteRequest.Recipient.String(), requestURI)
+		assert.Equal(t, "assistant-line", fromIdentity)
+		assert.Equal(t, "customer-alias", toIdentity)
+		return nil
+	})
+	outboundCall := NewOutbound(server, session, dialog, nil, request)
+
+	err = outboundCall.callOutboundInviteHandler(time.Now())
+
+	require.NoError(t, err)
+	assert.Empty(t, session.GetInfo().LocalURI)
+	assert.Empty(t, session.GetInfo().RemoteURI)
+}
+
+func TestOutboundCallInviteHandlerRejectsMissingInviteRequest(t *testing.T) {
+	server := &Server{logger: bridgeTestLogger()}
+	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
+		t.Fatal("onInvite must not run without the outbound INVITE request")
+		return nil
+	})
+	request, err := NewOutboundInviteRequest(testOutboundConfig(), "customer-alias", "assistant-line")
+	require.NoError(t, err)
+	outboundCall := NewOutbound(server, &Session{info: SessionInfo{CallID: "missing-invite-request"}}, &outboundDialog{}, nil, request)
+
+	err = outboundCall.callOutboundInviteHandler(time.Now())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outbound INVITE request is unavailable")
+}
+
 func TestOutboundMediaApplyAnswerEnablesSymmetricRTPForPrivateSDPWhenConfigured(t *testing.T) {
 	rtpHandler := newTestRTPHandler()
 	media := &outboundMedia{

--- a/api/assistant-api/sip/internal/core/pipeline.go
+++ b/api/assistant-api/sip/internal/core/pipeline.go
@@ -34,8 +34,9 @@ type SessionEstablishedPipeline struct {
 	Direction       CallDirection
 	AssistantID     uint64
 	Auth            types.SimplePrinciple
-	FromURI         string
-	ToURI           string
+	RequestURI      string
+	FromIdentity    string
+	ToIdentity      string
 	ConversationID  uint64 // Non-zero for outbound (already created by channel pipeline)
 }
 

--- a/api/assistant-api/sip/internal/core/server.go
+++ b/api/assistant-api/sip/internal/core/server.go
@@ -43,11 +43,12 @@ const (
 //	RouteMiddleware → resolves assistant route, sets Auth and Assistant
 //	VaultMiddleware → fetches SIP config from vault, sets VaultCredential
 type SIPRequestContext struct {
-	Method  string // SIP method (INVITE, REGISTER, BYE, etc.)
-	CallID  string
-	FromURI string
-	ToURI   string
-	SDPInfo *SDPMediaInfo
+	Method       string // SIP method (INVITE, REGISTER, BYE, etc.)
+	CallID       string
+	RequestURI   string
+	FromIdentity string
+	ToIdentity   string
+	SDPInfo      *SDPMediaInfo
 
 	// Route/auth fields resolved by middleware.
 	APIKey      string
@@ -116,9 +117,9 @@ type Server struct {
 	middlewares []Middleware
 
 	// Event callbacks
-	onApplicationReady   func(session *Session, fromURI, toURI string) error
+	onApplicationReady   func(session *Session, requestURI, fromIdentity, toIdentity string) error
 	onApplicationCleanup func(session *Session)
-	onInvite             func(session *Session, fromURI, toURI string) error
+	onInvite             func(session *Session, requestURI, fromIdentity, toIdentity string) error
 	onBye                func(session *Session) error
 	onCancel             func(session *Session) error
 	onError              func(session *Session, err error)
@@ -470,7 +471,7 @@ func (s *Server) SessionCount() int {
 	return len(s.sessions)
 }
 
-func (s *Server) SetOnApplicationReady(fn func(session *Session, fromURI, toURI string) error) {
+func (s *Server) SetOnApplicationReady(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onApplicationReady = fn
@@ -483,7 +484,7 @@ func (s *Server) SetOnApplicationCleanup(fn func(session *Session)) {
 }
 
 // SetOnInvite sets the callback for answered INVITE requests.
-func (s *Server) SetOnInvite(fn func(session *Session, fromURI, toURI string) error) {
+func (s *Server) SetOnInvite(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onInvite = fn

--- a/api/assistant-api/sip/internal/core/types.go
+++ b/api/assistant-api/sip/internal/core/types.go
@@ -605,28 +605,3 @@ func parseHeadersValue(value any) map[string]string {
 	}
 	return nil
 }
-
-// ExtractDIDFromURI extracts the user part from a SIP URI as a phone number (DID).
-// Strips URI parameters (e.g. ;user=phone) that some providers append.
-func ExtractDIDFromURI(uri string) string {
-	raw := strings.TrimPrefix(strings.TrimPrefix(uri, "sip:"), "sips:")
-	parts := strings.SplitN(raw, "@", 2)
-	if len(parts) == 0 || parts[0] == "" {
-		return ""
-	}
-	user := parts[0]
-	// Strip URI parameters (e.g. "+15551234567;user=phone" → "+15551234567")
-	if idx := strings.IndexByte(user, ';'); idx >= 0 {
-		user = user[:idx]
-	}
-	// Skip credential pairs (assistantID:apiKey)
-	if strings.Contains(user, ":") {
-		return ""
-	}
-	// Normalize to E.164: add "+" prefix for phone numbers
-	if len(user) > 5 && user[0] != '+' {
-		user = "+" + user
-	}
-
-	return user
-}

--- a/api/assistant-api/sip/internal/core/types.go
+++ b/api/assistant-api/sip/internal/core/types.go
@@ -605,3 +605,18 @@ func parseHeadersValue(value any) map[string]string {
 	}
 	return nil
 }
+
+// ExtractDIDFromURI is retained for compatibility with the public SIP facade.
+// Deprecated: native SIP identity handling preserves parsed SIP addresses.
+func ExtractDIDFromURI(uri string) string {
+	raw := strings.TrimPrefix(strings.TrimPrefix(uri, "sip:"), "sips:")
+	user, _, _ := strings.Cut(raw, "@")
+	user, _, _ = strings.Cut(user, ";")
+	if user == "" || strings.Contains(user, ":") {
+		return ""
+	}
+	if len(user) > 5 && user[0] != '+' {
+		user = "+" + user
+	}
+	return user
+}

--- a/api/assistant-api/sip/internal/core/types_test.go
+++ b/api/assistant-api/sip/internal/core/types_test.go
@@ -200,32 +200,6 @@ func TestParseConfigFromVault_InvalidHeadersIgnored(t *testing.T) {
 	assert.Nil(t, cfg.CustomHeaders)
 }
 
-func TestExtractDIDFromURI_PhoneNumber(t *testing.T) {
-	did := ExtractDIDFromURI("sip:15551234567@pstn.twilio.com")
-	assert.Equal(t, "+15551234567", did)
-}
-
-func TestExtractDIDFromURI_AlreadyE164(t *testing.T) {
-	did := ExtractDIDFromURI("sip:+15551234567@pstn.twilio.com")
-	assert.Equal(t, "+15551234567", did)
-}
-
-func TestExtractDIDFromURI_SkipsCredentialPair(t *testing.T) {
-	did := ExtractDIDFromURI("sip:12345:apikey@host.com")
-	assert.Equal(t, "", did)
-}
-
-func TestExtractDIDFromURI_Empty(t *testing.T) {
-	did := ExtractDIDFromURI("")
-	assert.Equal(t, "", did)
-}
-
-func TestExtractDIDFromURI_ShortUser(t *testing.T) {
-	// Users with 5 or fewer chars don't get "+" prefix
-	did := ExtractDIDFromURI("sip:ext42@pbx.local")
-	assert.Equal(t, "ext42", did)
-}
-
 func TestApplyOperationalDefaults_FillsUnset(t *testing.T) {
 	cfg := &Config{Server: "host.com"}
 	cfg.ApplyOperationalDefaults(5060, TransportTCP, 10000, 20000)

--- a/api/assistant-api/sip/middleware/route_middleware.go
+++ b/api/assistant-api/sip/middleware/route_middleware.go
@@ -76,26 +76,21 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 		}
 	}
 	return func(ctx *sip_infra.SIPRequestContext) error {
-		raw := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(ctx.RequestURI), "sip:"), "sips:")
-		parts := strings.SplitN(raw, "@", 2)
-		if len(parts) == 0 || !validator.NotBlank(parts[0]) {
-			return &sip_infra.SIPError{Code: 404, Message: "No routable SIP user found in Request-URI", Err: sip_infra.ErrAuthRequired}
-		}
-		user := strings.TrimSpace(parts[0])
-		if idx := strings.IndexByte(user, ';'); idx >= 0 {
-			user = strings.TrimSpace(user[:idx])
-		}
-		if !validator.NotBlank(user) {
+		requestURIWithoutScheme := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(ctx.RequestURI), "sip:"), "sips:")
+		routeUserWithParameters, _, _ := strings.Cut(requestURIWithoutScheme, "@")
+		routeUser, _, _ := strings.Cut(strings.TrimSpace(routeUserWithParameters), ";")
+		routeUser = strings.TrimSpace(routeUser)
+		if !validator.NotBlank(routeUser) {
 			return &sip_infra.SIPError{Code: 404, Message: "No routable SIP user found in Request-URI", Err: sip_infra.ErrAuthRequired}
 		}
 
 		routeKind := "did"
-		routeValue := user
-		if strings.HasPrefix(user, "agent-") {
+		routeValue := routeUser
+		if strings.HasPrefix(routeUser, "agent-") {
 			routeKind = "agent"
-			routeValue = strings.TrimSpace(user[len("agent-"):])
-		} else if strings.HasPrefix(user, "did-") {
-			routeValue = strings.TrimSpace(user[len("did-"):])
+			routeValue = strings.TrimSpace(routeUser[len("agent-"):])
+		} else if strings.HasPrefix(routeUser, "did-") {
+			routeValue = strings.TrimSpace(routeUser[len("did-"):])
 		}
 		if !validator.NotBlank(routeValue) || strings.Contains(routeValue, ":") {
 			return &sip_infra.SIPError{Code: 404, Message: "Invalid SIP route user", Err: sip_infra.ErrAuthRequired}

--- a/api/assistant-api/sip/middleware/route_middleware.go
+++ b/api/assistant-api/sip/middleware/route_middleware.go
@@ -76,23 +76,17 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 		}
 	}
 	return func(ctx *sip_infra.SIPRequestContext) error {
-		user := ""
-		for _, uri := range []string{ctx.ToURI, ctx.FromURI} {
-			raw := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(uri), "sip:"), "sips:")
-			parts := strings.SplitN(raw, "@", 2)
-			if len(parts) == 0 || !validator.NotBlank(parts[0]) {
-				continue
-			}
-			user = strings.TrimSpace(parts[0])
-			if idx := strings.IndexByte(user, ';'); idx >= 0 {
-				user = strings.TrimSpace(user[:idx])
-			}
-			if validator.NotBlank(user) {
-				break
-			}
+		raw := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(ctx.RequestURI), "sip:"), "sips:")
+		parts := strings.SplitN(raw, "@", 2)
+		if len(parts) == 0 || !validator.NotBlank(parts[0]) {
+			return &sip_infra.SIPError{Code: 404, Message: "No routable SIP user found in Request-URI", Err: sip_infra.ErrAuthRequired}
+		}
+		user := strings.TrimSpace(parts[0])
+		if idx := strings.IndexByte(user, ';'); idx >= 0 {
+			user = strings.TrimSpace(user[:idx])
 		}
 		if !validator.NotBlank(user) {
-			return &sip_infra.SIPError{Code: 404, Message: "No routable SIP user found in SIP URI", Err: sip_infra.ErrAuthRequired}
+			return &sip_infra.SIPError{Code: 404, Message: "No routable SIP user found in Request-URI", Err: sip_infra.ErrAuthRequired}
 		}
 
 		routeKind := "did"

--- a/api/assistant-api/sip/middleware/route_middleware.go
+++ b/api/assistant-api/sip/middleware/route_middleware.go
@@ -113,15 +113,15 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 			if err != nil {
 				m.logger.Warnw("SIP: invalid agent route",
 					"call_id", ctx.CallID,
-					"route_value", routeValue,
-					"error", err)
+					"route_kind", routeKind,
+					"reason", "invalid_assistant_id")
 				return &sip_infra.SIPError{Code: 404, Message: "Invalid assistant route", Err: sip_infra.ErrAuthRequired}
 			}
 			if !validator.NonZero(parsedAssistantID) {
 				m.logger.Warnw("SIP: invalid agent route",
 					"call_id", ctx.CallID,
-					"route_value", routeValue,
-					"error", "assistant id is zero")
+					"route_kind", routeKind,
+					"reason", "zero_assistant_id")
 				return &sip_infra.SIPError{Code: 404, Message: "Invalid assistant route", Err: sip_infra.ErrAuthRequired}
 			}
 
@@ -162,7 +162,8 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 			if tx.Error != nil {
 				m.logger.Warnw("SIP: DID route lookup failed",
 					"call_id", ctx.CallID,
-					"did", routeValue,
+					"route_kind", routeKind,
+					"result", "not_found",
 					"error", tx.Error)
 				return &sip_infra.SIPError{Code: 404, Message: "No assistant found for this SIP route", Err: sip_infra.ErrAuthRequired}
 			}
@@ -174,7 +175,7 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 			m.logger.Warnw("SIP: route returned incomplete scope",
 				"call_id", ctx.CallID,
 				"route_kind", routeKind,
-				"route_value", routeValue,
+				"result", "incomplete_scope",
 				"assistant_id", assistantID,
 				"project_id", projectID,
 				"organization_id", organizationID)
@@ -210,7 +211,7 @@ func NewRouteMiddleware(options ...func(*middlewareOption)) sip_infra.Middleware
 		m.logger.Infow("SIP: routed inbound call",
 			"call_id", ctx.CallID,
 			"route_kind", routeKind,
-			"route_value", routeValue,
+			"result", "resolved",
 			"assistant_id", assistantID)
 
 		return nil

--- a/api/assistant-api/sip/middleware/route_middleware_test.go
+++ b/api/assistant-api/sip/middleware/route_middleware_test.go
@@ -29,7 +29,7 @@ func TestRouteMiddleware_AgentRoute(t *testing.T) {
 
 	ctx := &sip_infra.SIPRequestContext{
 		CallID:       "call-agent",
-		RequestURI:   "sip:agent-42@sip.rapida.ai",
+		RequestURI:   "sip:agent-42;transport=tcp@sip.rapida.ai",
 		FromIdentity: "sip:caller@example.com",
 		ToIdentity:   "sip:assistant@example.com",
 	}

--- a/api/assistant-api/sip/middleware/route_middleware_test.go
+++ b/api/assistant-api/sip/middleware/route_middleware_test.go
@@ -27,7 +27,12 @@ func TestRouteMiddleware_AgentRoute(t *testing.T) {
 	db := newRouteTestDB(t)
 	require.NoError(t, db.Exec("INSERT INTO assistants (id, project_id, organization_id) VALUES (?, ?, ?)", 42, 7, 8).Error)
 
-	ctx := &sip_infra.SIPRequestContext{CallID: "call-agent", ToURI: "sip:agent-42@sip.rapida.ai"}
+	ctx := &sip_infra.SIPRequestContext{
+		CallID:       "call-agent",
+		RequestURI:   "sip:agent-42@sip.rapida.ai",
+		FromIdentity: "sip:caller@example.com",
+		ToIdentity:   "sip:assistant@example.com",
+	}
 	middleware := NewRouteMiddleware(
 		WithContext(context.Background()),
 		WithLogger(newRouteTestLogger(t)),
@@ -42,6 +47,8 @@ func TestRouteMiddleware_AgentRoute(t *testing.T) {
 	assert.Equal(t, "42", ctx.AssistantID)
 	assert.NotNil(t, ctx.Auth)
 	assert.NotNil(t, ctx.Assistant)
+	assert.Equal(t, "sip:caller@example.com", ctx.FromIdentity)
+	assert.Equal(t, "sip:assistant@example.com", ctx.ToIdentity)
 }
 
 func TestRouteMiddleware_DIDRoute(t *testing.T) {
@@ -50,7 +57,7 @@ func TestRouteMiddleware_DIDRoute(t *testing.T) {
 	require.NoError(t, db.Exec("INSERT INTO assistant_phone_deployments (id, assistant_id, telephony_provider, status) VALUES (?, ?, ?, ?)", 100, 43, "sip", type_enums.RECORD_ACTIVE.String()).Error)
 	require.NoError(t, db.Exec("INSERT INTO assistant_deployment_telephony_options (assistant_deployment_telephony_id, key, value) VALUES (?, ?, ?)", 100, "phone", "+15551234567").Error)
 
-	ctx := &sip_infra.SIPRequestContext{CallID: "call-did", ToURI: "sip:did-+15551234567@sip.rapida.ai"}
+	ctx := &sip_infra.SIPRequestContext{CallID: "call-did", RequestURI: "sip:did-+15551234567@sip.rapida.ai"}
 	middleware := NewRouteMiddleware(
 		WithContext(context.Background()),
 		WithLogger(newRouteTestLogger(t)),
@@ -73,7 +80,7 @@ func TestRouteMiddleware_PlainDIDRoute(t *testing.T) {
 	require.NoError(t, db.Exec("INSERT INTO assistant_phone_deployments (id, assistant_id, telephony_provider, status) VALUES (?, ?, ?, ?)", 101, 44, "sip", type_enums.RECORD_ACTIVE.String()).Error)
 	require.NoError(t, db.Exec("INSERT INTO assistant_deployment_telephony_options (assistant_deployment_telephony_id, key, value) VALUES (?, ?, ?)", 101, "phone", "+15551234568").Error)
 
-	ctx := &sip_infra.SIPRequestContext{CallID: "call-plain", ToURI: "sip:+15551234568@sip.rapida.ai"}
+	ctx := &sip_infra.SIPRequestContext{CallID: "call-plain", RequestURI: "sip:+15551234568@sip.rapida.ai"}
 	middleware := NewRouteMiddleware(
 		WithContext(context.Background()),
 		WithLogger(newRouteTestLogger(t)),
@@ -89,11 +96,11 @@ func TestRouteMiddleware_PlainDIDRoute(t *testing.T) {
 	assert.NotNil(t, ctx.Assistant)
 }
 
-func TestRouteMiddleware_FallbackFromURI(t *testing.T) {
+func TestRouteMiddleware_DoesNotRouteFromIdentity(t *testing.T) {
 	db := newRouteTestDB(t)
 	require.NoError(t, db.Exec("INSERT INTO assistants (id, project_id, organization_id) VALUES (?, ?, ?)", 45, 13, 14).Error)
 
-	ctx := &sip_infra.SIPRequestContext{CallID: "call-from", FromURI: "sip:agent-45@sip.rapida.ai"}
+	ctx := &sip_infra.SIPRequestContext{CallID: "call-from", FromIdentity: "sip:agent-45@sip.rapida.ai"}
 	middleware := NewRouteMiddleware(
 		WithContext(context.Background()),
 		WithLogger(newRouteTestLogger(t)),
@@ -104,14 +111,40 @@ func TestRouteMiddleware_FallbackFromURI(t *testing.T) {
 	)
 	err := middleware(ctx)
 
-	require.NoError(t, err)
-	assert.Equal(t, "45", ctx.AssistantID)
-	assert.NotNil(t, ctx.Assistant)
+	require.Error(t, err)
+	var sipErr *sip_infra.SIPError
+	require.ErrorAs(t, err, &sipErr)
+	assert.Equal(t, 404, sipErr.Code)
+	assert.Empty(t, ctx.AssistantID)
+	assert.Nil(t, ctx.Assistant)
+}
+
+func TestRouteMiddleware_DoesNotRouteToIdentity(t *testing.T) {
+	db := newRouteTestDB(t)
+	require.NoError(t, db.Exec("INSERT INTO assistants (id, project_id, organization_id) VALUES (?, ?, ?)", 46, 15, 16).Error)
+
+	ctx := &sip_infra.SIPRequestContext{CallID: "call-to", ToIdentity: "sip:agent-46@sip.rapida.ai"}
+	middleware := NewRouteMiddleware(
+		WithContext(context.Background()),
+		WithLogger(newRouteTestLogger(t)),
+		WithPostgres(routeTestPostgres{db: db}),
+		WithAssistantService(routeTestAssistantService{assistants: map[uint64]*internal_assistant_entity.Assistant{
+			46: newRouteTestAssistant(15),
+		}}),
+	)
+	err := middleware(ctx)
+
+	require.Error(t, err)
+	var sipErr *sip_infra.SIPError
+	require.ErrorAs(t, err, &sipErr)
+	assert.Equal(t, 404, sipErr.Code)
+	assert.Empty(t, ctx.AssistantID)
+	assert.Nil(t, ctx.Assistant)
 }
 
 func TestRouteMiddleware_RejectsCredentialPair(t *testing.T) {
 	db := newRouteTestDB(t)
-	ctx := &sip_infra.SIPRequestContext{CallID: "call-invalid", ToURI: "sip:12345:apikey@sip.rapida.ai"}
+	ctx := &sip_infra.SIPRequestContext{CallID: "call-invalid", RequestURI: "sip:12345:apikey@sip.rapida.ai"}
 
 	middleware := NewRouteMiddleware(
 		WithContext(context.Background()),

--- a/api/assistant-api/sip/pipeline/media.go
+++ b/api/assistant-api/sip/pipeline/media.go
@@ -37,31 +37,31 @@ func newSessionPreparationError(reason sip_infra.LifecycleReason, err error) *se
 	return &sessionPreparationError{reason: reason, err: err}
 }
 
-func (d *Dispatcher) handleSessionEstablished(ctx context.Context, v sip_infra.SessionEstablishedPipeline) {
-	prepared, err := d.prepareSession(ctx, v)
+func (d *Dispatcher) handleSessionEstablished(ctx context.Context, stage sip_infra.SessionEstablishedPipeline) {
+	prepared, err := d.prepareSession(ctx, stage)
 	if err != nil {
-		d.logger.Error("Pipeline: session preparation failed", "call_id", v.ID, "error", err)
-		d.endCall(v.Session, sessionPreparationReason(err))
+		d.logger.Error("Pipeline: session preparation failed", "call_id", stage.ID, "error", err)
+		d.endCall(stage.Session, sessionPreparationReason(err))
 		return
 	}
 	d.startPreparedSession(ctx, prepared)
 }
 
-func (d *Dispatcher) PrepareSession(ctx context.Context, v sip_infra.SessionEstablishedPipeline) error {
-	prepared, err := d.prepareSession(ctx, v)
+func (d *Dispatcher) PrepareSession(ctx context.Context, stage sip_infra.SessionEstablishedPipeline) error {
+	prepared, err := d.prepareSession(ctx, stage)
 	if err != nil {
 		return err
 	}
 	d.preparedMu.Lock()
-	d.preparedSessions[v.ID] = prepared
+	d.preparedSessions[stage.ID] = prepared
 	d.preparedMu.Unlock()
 	return nil
 }
 
-func (d *Dispatcher) StartPreparedSession(ctx context.Context, v sip_infra.SessionEstablishedPipeline) error {
-	prepared := d.popPreparedSession(v.ID)
+func (d *Dispatcher) StartPreparedSession(ctx context.Context, stage sip_infra.SessionEstablishedPipeline) error {
+	prepared := d.popPreparedSession(stage.ID)
 	if prepared == nil {
-		return fmt.Errorf("prepared SIP session not found for call %s", v.ID)
+		return fmt.Errorf("prepared SIP session not found for call %s", stage.ID)
 	}
 	d.startPreparedSession(ctx, prepared)
 	return nil
@@ -83,39 +83,39 @@ func (d *Dispatcher) popPreparedSession(callID string) *preparedSession {
 	return prepared
 }
 
-func (d *Dispatcher) prepareSession(ctx context.Context, v sip_infra.SessionEstablishedPipeline) (*preparedSession, error) {
+func (d *Dispatcher) prepareSession(ctx context.Context, stage sip_infra.SessionEstablishedPipeline) (*preparedSession, error) {
 	d.logger.Infow("Pipeline: SessionEstablished",
-		"call_id", v.ID,
-		"direction", v.Direction,
-		"assistant_id", v.AssistantID,
-		"conversation_id", v.ConversationID)
+		"call_id", stage.ID,
+		"direction", stage.Direction,
+		"assistant_id", stage.AssistantID,
+		"conversation_id", stage.ConversationID)
 
-	conversationID := v.ConversationID
+	conversationID := stage.ConversationID
 	if conversationID == 0 {
 		var err error
-		conversationID, err = d.createConversation(ctx, v)
+		conversationID, err = d.createConversation(ctx, stage)
 		if err != nil {
-			d.logger.Error("Pipeline: create conversation failed", "call_id", v.ID, "error", err)
+			d.logger.Error("Pipeline: create conversation failed", "call_id", stage.ID, "error", err)
 			return nil, newSessionPreparationError(sip_infra.LifecycleReasonPipelineConversationFailed, err)
 		}
-		v.Session.SetConversationID(conversationID)
+		stage.Session.SetConversationID(conversationID)
 	}
 
-	cc, err := d.ensureCallContext(ctx, v, conversationID)
+	cc, err := d.ensureCallContext(ctx, stage, conversationID)
 	if err != nil {
-		d.logger.Warnw("Pipeline: ensure call context failed", "call_id", v.ID, "error", err)
+		d.logger.Warnw("Pipeline: ensure call context failed", "call_id", stage.ID, "error", err)
 	}
 
-	setup, err := d.setupCall(ctx, v, conversationID, cc)
+	setup, err := d.setupCall(ctx, stage, conversationID, cc)
 	if err != nil {
-		d.logger.Error("Pipeline: call setup failed", "call_id", v.ID, "error", err)
+		d.logger.Error("Pipeline: call setup failed", "call_id", stage.ID, "error", err)
 		return nil, newSessionPreparationError(sip_infra.LifecycleReasonPipelineSetupFailed, err)
 	}
 
-	observer := d.createObserver(ctx, setup, v.Auth)
+	observer := d.createObserver(ctx, setup, stage.Auth)
 	codec := ""
 	sampleRate := ""
-	if negotiated := v.Session.GetNegotiatedCodec(); negotiated != nil {
+	if negotiated := stage.Session.GetNegotiatedCodec(); negotiated != nil {
 		codec = negotiated.Name
 		sampleRate = fmt.Sprintf("%d", negotiated.ClockRate)
 	}
@@ -127,16 +127,16 @@ func (d *Dispatcher) prepareSession(ctx context.Context, v sip_infra.SessionEsta
 			ConversationID: setup.ConversationID,
 		},
 		observability.RecordMetadata{
-			Metadata: observability.ClientMetadata("", "", string(v.Direction), "sip", v.ID, "", codec, sampleRate),
+			Metadata: observability.ClientMetadata("", "", string(stage.Direction), "sip", stage.ID, "", codec, sampleRate),
 		},
 		observability.RecordEvent{
 			Component: observability.ComponentCall,
 			Event:     observability.CallSessionConnected,
 			Attributes: observability.Attributes{
 				"provider":   "sip",
-				"direction":  string(v.Direction),
-				"call_id":    v.ID,
-				"context_id": v.ID,
+				"direction":  string(stage.Direction),
+				"call_id":    stage.ID,
+				"context_id": stage.ID,
 			},
 		},
 		observability.RecordMetric{
@@ -148,37 +148,37 @@ func (d *Dispatcher) prepareSession(ctx context.Context, v sip_infra.SessionEsta
 		},
 	)
 	var runtime PreparedCallRuntime
-	if v.Direction == sip_infra.CallDirectionInbound {
+	if stage.Direction == sip_infra.CallDirectionInbound {
 		var err error
-		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction), v.FromIdentity, v.ToIdentity)
+		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, stage.Session, setup, observer, stage.VaultCredential, stage.Config, string(stage.Direction), stage.FromIdentity, stage.ToIdentity)
 		if err != nil {
 			observer.Close(ctx)
-			d.logger.Error("Pipeline: runtime preparation failed", "call_id", v.ID, "error", err)
+			d.logger.Error("Pipeline: runtime preparation failed", "call_id", stage.ID, "error", err)
 			return nil, newSessionPreparationError(sip_infra.LifecycleReasonPipelineSetupFailed, err)
 		}
-		if err := preparedRuntime.StartBeforeAnswer(ctx, inboundRuntimeReadyTimeout(v.Config)); err != nil {
+		if err := preparedRuntime.StartBeforeAnswer(ctx, inboundRuntimeReadyTimeout(stage.Config)); err != nil {
 			preparedRuntime.Close(ctx)
 			observer.Close(ctx)
-			d.logger.Error("Pipeline: runtime pre-answer start failed", "call_id", v.ID, "error", err)
+			d.logger.Error("Pipeline: runtime pre-answer start failed", "call_id", stage.ID, "error", err)
 			return nil, newSessionPreparationError(sip_infra.LifecycleReasonPipelineSetupFailed, err)
 		}
 		runtime = preparedRuntime
 	}
-	return &preparedSession{stage: v, setup: setup, observer: observer, runtime: runtime}, nil
+	return &preparedSession{stage: stage, setup: setup, observer: observer, runtime: runtime}, nil
 }
 
 func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *preparedSession) {
-	v := prepared.stage
+	stage := prepared.stage
 	setup := prepared.setup
 	observer := prepared.observer
 	go func() {
 		startTime := time.Now()
-		contextID := v.Session.GetContextID()
+		contextID := stage.Session.GetContextID()
 		if contextID == "" && setup.CallContext != nil {
 			contextID = setup.CallContext.ContextID
 		}
 		if contextID == "" {
-			contextID = v.ID
+			contextID = stage.ID
 		}
 
 		observer.Record(
@@ -192,8 +192,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 				Event:     observability.CallStarted,
 				Attributes: observability.Attributes{
 					"provider":  "sip",
-					"direction": string(v.Direction),
-					"call_id":   v.ID,
+					"direction": string(stage.Direction),
+					"call_id":   stage.ID,
 				},
 			},
 			observability.RecordWebhook{
@@ -202,10 +202,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 				Payload: observability.CallStartedWebhookPayload{
 					V1WebhookPayloadBase: observability.NewV1WebhookPayload(nil),
 					Provider:             "sip",
-					CallID:               v.ID,
+					CallID:               stage.ID,
 					To:                   setup.CallContext.CallerNumber,
 					From:                 setup.CallContext.FromNumber,
-					Direction:            string(v.Direction),
+					Direction:            string(stage.Direction),
 					ContextID:            contextID,
 				},
 			},
@@ -221,7 +221,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 		defer func() {
 			if r := recover(); r != nil {
 				reason := fmt.Sprintf("panic: %v", r)
-				d.logger.Error("Pipeline: onCallStart panicked", "call_id", v.ID, "panic", r)
+				d.logger.Error("Pipeline: onCallStart panicked", "call_id", stage.ID, "panic", r)
 				observer.Record(ctx, observability.ConversationScope{
 					AssistantScope: observability.AssistantScope{AssistantID: setup.AssistantID},
 					ConversationID: setup.ConversationID,
@@ -230,8 +230,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Message: "SIP pipeline call start panicked",
 					Attributes: observability.Attributes{
 						"provider":  "sip",
-						"direction": string(v.Direction),
-						"call_id":   v.ID,
+						"direction": string(stage.Direction),
+						"call_id":   stage.ID,
 						"panic":     fmt.Sprintf("%v", r),
 					},
 				})
@@ -245,8 +245,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Event:     observability.CallFailed,
 						Attributes: observability.Attributes{
 							"provider":    "sip",
-							"direction":   string(v.Direction),
-							"call_id":     v.ID,
+							"direction":   string(stage.Direction),
+							"call_id":     stage.ID,
 							"reason":      reason,
 							"status":      observability.MetricCallStatusFailed,
 							"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -260,10 +260,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 								"status": observability.MetricCallStatusFailed,
 							}),
 							Provider:   "sip",
-							CallID:     v.ID,
+							CallID:     stage.ID,
 							To:         setup.CallContext.CallerNumber,
 							From:       setup.CallContext.FromNumber,
-							Direction:  string(v.Direction),
+							Direction:  string(stage.Direction),
 							ContextID:  contextID,
 							Reason:     reason,
 							DurationMs: fmt.Sprintf("%d", durationMs),
@@ -281,15 +281,15 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						}},
 					})
 				observer.Close(ctx)
-				d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+				d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 			}
 		}()
 		if prepared.runtime != nil {
 			if err := prepared.runtime.Start(ctx); err != nil {
-				if targetVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
+				if targetVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
 					if target, ok := targetVal.(string); ok && target != "" {
 						transferStatus := "failed"
-						if statusVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
+						if statusVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
 							if s, ok := statusVal.(string); ok {
 								transferStatus = s
 							}
@@ -303,8 +303,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Event:     observability.SIPTransferRequested,
 							Attributes: observability.Attributes{
 								"provider":  "sip",
-								"direction": string(v.Direction),
-								"call_id":   v.ID,
+								"direction": string(stage.Direction),
+								"call_id":   stage.ID,
 								"target":    target,
 								"reason":    transferStatus,
 							},
@@ -319,8 +319,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 								Event:     observability.CallFailed,
 								Attributes: observability.Attributes{
 									"provider":    "sip",
-									"direction":   string(v.Direction),
-									"call_id":     v.ID,
+									"direction":   string(stage.Direction),
+									"call_id":     stage.ID,
 									"reason":      reason,
 									"status":      observability.MetricCallStatusFailed,
 									"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -334,10 +334,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 										"status": observability.MetricCallStatusFailed,
 									}),
 									Provider:   "sip",
-									CallID:     v.ID,
+									CallID:     stage.ID,
 									To:         setup.CallContext.CallerNumber,
 									From:       setup.CallContext.FromNumber,
-									Direction:  string(v.Direction),
+									Direction:  string(stage.Direction),
 									ContextID:  contextID,
 									Reason:     reason,
 									DurationMs: fmt.Sprintf("%d", durationMs),
@@ -355,7 +355,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 								}},
 							})
 						observer.Close(ctx)
-						d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+						d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 						return
 					}
 				}
@@ -370,8 +370,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Event:     observability.CallFailed,
 						Attributes: observability.Attributes{
 							"provider":    "sip",
-							"direction":   string(v.Direction),
-							"call_id":     v.ID,
+							"direction":   string(stage.Direction),
+							"call_id":     stage.ID,
 							"reason":      reason,
 							"status":      observability.MetricCallStatusFailed,
 							"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -385,10 +385,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 								"status": observability.MetricCallStatusFailed,
 							}),
 							Provider:   "sip",
-							CallID:     v.ID,
+							CallID:     stage.ID,
 							To:         setup.CallContext.CallerNumber,
 							From:       setup.CallContext.FromNumber,
-							Direction:  string(v.Direction),
+							Direction:  string(stage.Direction),
 							ContextID:  contextID,
 							Reason:     reason,
 							DurationMs: fmt.Sprintf("%d", durationMs),
@@ -406,13 +406,13 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						}},
 					})
 				observer.Close(ctx)
-				d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+				d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 				return
 			}
-			if targetVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
+			if targetVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
 				if target, ok := targetVal.(string); ok && target != "" {
 					transferStatus := "failed"
-					if statusVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
+					if statusVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
 						if s, ok := statusVal.(string); ok {
 							transferStatus = s
 						}
@@ -427,8 +427,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Event:     observability.SIPTransferRequested,
 							Attributes: observability.Attributes{
 								"provider":  "sip",
-								"direction": string(v.Direction),
-								"call_id":   v.ID,
+								"direction": string(stage.Direction),
+								"call_id":   stage.ID,
 								"target":    target,
 								"reason":    transferStatus,
 							},
@@ -438,8 +438,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Event:     observability.CallEnded,
 							Attributes: observability.Attributes{
 								"provider":    "sip",
-								"direction":   string(v.Direction),
-								"call_id":     v.ID,
+								"direction":   string(stage.Direction),
+								"call_id":     stage.ID,
 								"reason":      "transfer_" + transferStatus,
 								"status":      observability.MetricCallStatusComplete,
 								"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -451,10 +451,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Payload: observability.CallEndedWebhookPayload{
 								V1WebhookPayloadBase: observability.NewV1WebhookPayload(nil),
 								Provider:             "sip",
-								CallID:               v.ID,
+								CallID:               stage.ID,
 								To:                   setup.CallContext.CallerNumber,
 								From:                 setup.CallContext.FromNumber,
-								Direction:            string(v.Direction),
+								Direction:            string(stage.Direction),
 								ContextID:            contextID,
 								DurationMs:           fmt.Sprintf("%d", durationMs),
 								Reason:               "transfer_" + transferStatus,
@@ -473,7 +473,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							}},
 						})
 					observer.Close(ctx)
-					d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+					d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 					return
 				}
 			}
@@ -487,8 +487,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Event:     observability.CallEnded,
 					Attributes: observability.Attributes{
 						"provider":    "sip",
-						"direction":   string(v.Direction),
-						"call_id":     v.ID,
+						"direction":   string(stage.Direction),
+						"call_id":     stage.ID,
 						"reason":      "talk_completed",
 						"status":      observability.MetricCallStatusComplete,
 						"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -500,10 +500,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Payload: observability.CallEndedWebhookPayload{
 						V1WebhookPayloadBase: observability.NewV1WebhookPayload(nil),
 						Provider:             "sip",
-						CallID:               v.ID,
+						CallID:               stage.ID,
 						To:                   setup.CallContext.CallerNumber,
 						From:                 setup.CallContext.FromNumber,
-						Direction:            string(v.Direction),
+						Direction:            string(stage.Direction),
 						ContextID:            contextID,
 						DurationMs:           fmt.Sprintf("%d", durationMs),
 						Reason:               "talk_completed",
@@ -522,22 +522,22 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					}},
 				})
 			observer.Close(ctx)
-			d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+			d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 			return
 		}
 
-		runtime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction), v.FromIdentity, v.ToIdentity)
+		runtime, err := d.prepareSIPCallRuntime(ctx, stage.Session, setup, observer, stage.VaultCredential, stage.Config, string(stage.Direction), stage.FromIdentity, stage.ToIdentity)
 		if err != nil {
-			if v.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !v.Session.IsEnded() {
-				state := v.Session.GetState()
+			if stage.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !stage.Session.IsEnded() {
+				state := stage.Session.GetState()
 				if state != sip_infra.CallStateTransferring && state != sip_infra.CallStateBridgeConnected {
-					d.endCall(v.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
+					d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
 				}
 			}
-			if targetVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
+			if targetVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
 				if target, ok := targetVal.(string); ok && target != "" {
 					transferStatus := "failed"
-					if statusVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
+					if statusVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
 						if s, ok := statusVal.(string); ok {
 							transferStatus = s
 						}
@@ -551,8 +551,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Event:     observability.SIPTransferRequested,
 						Attributes: observability.Attributes{
 							"provider":  "sip",
-							"direction": string(v.Direction),
-							"call_id":   v.ID,
+							"direction": string(stage.Direction),
+							"call_id":   stage.ID,
 							"target":    target,
 							"reason":    transferStatus,
 						},
@@ -567,8 +567,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Event:     observability.CallFailed,
 							Attributes: observability.Attributes{
 								"provider":    "sip",
-								"direction":   string(v.Direction),
-								"call_id":     v.ID,
+								"direction":   string(stage.Direction),
+								"call_id":     stage.ID,
 								"reason":      reason,
 								"status":      observability.MetricCallStatusFailed,
 								"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -582,10 +582,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 									"status": observability.MetricCallStatusFailed,
 								}),
 								Provider:   "sip",
-								CallID:     v.ID,
+								CallID:     stage.ID,
 								To:         setup.CallContext.CallerNumber,
 								From:       setup.CallContext.FromNumber,
-								Direction:  string(v.Direction),
+								Direction:  string(stage.Direction),
 								ContextID:  contextID,
 								Reason:     reason,
 								DurationMs: fmt.Sprintf("%d", durationMs),
@@ -603,7 +603,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							}},
 						})
 					observer.Close(ctx)
-					d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+					d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 					return
 				}
 			}
@@ -618,8 +618,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Event:     observability.CallFailed,
 					Attributes: observability.Attributes{
 						"provider":    "sip",
-						"direction":   string(v.Direction),
-						"call_id":     v.ID,
+						"direction":   string(stage.Direction),
+						"call_id":     stage.ID,
 						"reason":      reason,
 						"status":      observability.MetricCallStatusFailed,
 						"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -633,10 +633,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							"status": observability.MetricCallStatusFailed,
 						}),
 						Provider:   "sip",
-						CallID:     v.ID,
+						CallID:     stage.ID,
 						To:         setup.CallContext.CallerNumber,
 						From:       setup.CallContext.FromNumber,
-						Direction:  string(v.Direction),
+						Direction:  string(stage.Direction),
 						ContextID:  contextID,
 						Reason:     reason,
 						DurationMs: fmt.Sprintf("%d", durationMs),
@@ -654,20 +654,20 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					}},
 				})
 			observer.Close(ctx)
-			d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+			d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 			return
 		}
 		if err := runtime.Start(ctx); err != nil {
-			if v.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !v.Session.IsEnded() {
-				state := v.Session.GetState()
+			if stage.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !stage.Session.IsEnded() {
+				state := stage.Session.GetState()
 				if state != sip_infra.CallStateTransferring && state != sip_infra.CallStateBridgeConnected {
-					d.endCall(v.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
+					d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
 				}
 			}
-			if targetVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
+			if targetVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
 				if target, ok := targetVal.(string); ok && target != "" {
 					transferStatus := "failed"
-					if statusVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
+					if statusVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
 						if s, ok := statusVal.(string); ok {
 							transferStatus = s
 						}
@@ -681,8 +681,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Event:     observability.SIPTransferRequested,
 						Attributes: observability.Attributes{
 							"provider":  "sip",
-							"direction": string(v.Direction),
-							"call_id":   v.ID,
+							"direction": string(stage.Direction),
+							"call_id":   stage.ID,
 							"target":    target,
 							"reason":    transferStatus,
 						},
@@ -697,8 +697,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							Event:     observability.CallFailed,
 							Attributes: observability.Attributes{
 								"provider":    "sip",
-								"direction":   string(v.Direction),
-								"call_id":     v.ID,
+								"direction":   string(stage.Direction),
+								"call_id":     stage.ID,
 								"reason":      reason,
 								"status":      observability.MetricCallStatusFailed,
 								"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -712,10 +712,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 									"status": observability.MetricCallStatusFailed,
 								}),
 								Provider:   "sip",
-								CallID:     v.ID,
+								CallID:     stage.ID,
 								To:         setup.CallContext.CallerNumber,
 								From:       setup.CallContext.FromNumber,
-								Direction:  string(v.Direction),
+								Direction:  string(stage.Direction),
 								ContextID:  contextID,
 								Reason:     reason,
 								DurationMs: fmt.Sprintf("%d", durationMs),
@@ -733,7 +733,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							}},
 						})
 					observer.Close(ctx)
-					d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+					d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 					return
 				}
 			}
@@ -748,8 +748,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Event:     observability.CallFailed,
 					Attributes: observability.Attributes{
 						"provider":    "sip",
-						"direction":   string(v.Direction),
-						"call_id":     v.ID,
+						"direction":   string(stage.Direction),
+						"call_id":     stage.ID,
 						"reason":      reason,
 						"status":      observability.MetricCallStatusFailed,
 						"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -763,10 +763,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 							"status": observability.MetricCallStatusFailed,
 						}),
 						Provider:   "sip",
-						CallID:     v.ID,
+						CallID:     stage.ID,
 						To:         setup.CallContext.CallerNumber,
 						From:       setup.CallContext.FromNumber,
-						Direction:  string(v.Direction),
+						Direction:  string(stage.Direction),
 						ContextID:  contextID,
 						Reason:     reason,
 						DurationMs: fmt.Sprintf("%d", durationMs),
@@ -784,19 +784,19 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					}},
 				})
 			observer.Close(ctx)
-			d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+			d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 			return
 		}
-		if v.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !v.Session.IsEnded() {
-			state := v.Session.GetState()
+		if stage.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !stage.Session.IsEnded() {
+			state := stage.Session.GetState()
 			if state != sip_infra.CallStateTransferring && state != sip_infra.CallStateBridgeConnected {
-				d.endCall(v.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
+				d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineTalkCompleted)
 			}
 		}
-		if targetVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
+		if targetVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferTarget); ok {
 			if target, ok := targetVal.(string); ok && target != "" {
 				transferStatus := "failed"
-				if statusVal, ok := v.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
+				if statusVal, ok := stage.Session.GetMetadata(sip_infra.MetadataBridgeTransferStatus); ok {
 					if s, ok := statusVal.(string); ok {
 						transferStatus = s
 					}
@@ -810,8 +810,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 					Event:     observability.SIPTransferRequested,
 					Attributes: observability.Attributes{
 						"provider":  "sip",
-						"direction": string(v.Direction),
-						"call_id":   v.ID,
+						"direction": string(stage.Direction),
+						"call_id":   stage.ID,
 						"target":    target,
 						"reason":    transferStatus,
 					},
@@ -826,8 +826,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Event:     observability.CallEnded,
 						Attributes: observability.Attributes{
 							"provider":    "sip",
-							"direction":   string(v.Direction),
-							"call_id":     v.ID,
+							"direction":   string(stage.Direction),
+							"call_id":     stage.ID,
 							"reason":      reason,
 							"status":      observability.MetricCallStatusComplete,
 							"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -839,10 +839,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						Payload: observability.CallEndedWebhookPayload{
 							V1WebhookPayloadBase: observability.NewV1WebhookPayload(nil),
 							Provider:             "sip",
-							CallID:               v.ID,
+							CallID:               stage.ID,
 							To:                   setup.CallContext.CallerNumber,
 							From:                 setup.CallContext.FromNumber,
-							Direction:            string(v.Direction),
+							Direction:            string(stage.Direction),
 							ContextID:            contextID,
 							DurationMs:           fmt.Sprintf("%d", durationMs),
 							Reason:               reason,
@@ -861,7 +861,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 						}},
 					})
 				observer.Close(ctx)
-				d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+				d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 				return
 			}
 		}
@@ -876,8 +876,8 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 				Event:     observability.CallEnded,
 				Attributes: observability.Attributes{
 					"provider":    "sip",
-					"direction":   string(v.Direction),
-					"call_id":     v.ID,
+					"direction":   string(stage.Direction),
+					"call_id":     stage.ID,
 					"reason":      reason,
 					"status":      observability.MetricCallStatusComplete,
 					"duration_ms": fmt.Sprintf("%d", durationMs),
@@ -889,10 +889,10 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 				Payload: observability.CallEndedWebhookPayload{
 					V1WebhookPayloadBase: observability.NewV1WebhookPayload(nil),
 					Provider:             "sip",
-					CallID:               v.ID,
+					CallID:               stage.ID,
 					To:                   setup.CallContext.CallerNumber,
 					From:                 setup.CallContext.FromNumber,
-					Direction:            string(v.Direction),
+					Direction:            string(stage.Direction),
 					ContextID:            contextID,
 					DurationMs:           fmt.Sprintf("%d", durationMs),
 					Reason:               reason,
@@ -911,7 +911,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 				}},
 			})
 		observer.Close(ctx)
-		d.endCall(v.Session, sip_infra.LifecycleReasonPipelineCallEnd)
+		d.endCall(stage.Session, sip_infra.LifecycleReasonPipelineCallEnd)
 	}()
 }
 

--- a/api/assistant-api/sip/pipeline/media.go
+++ b/api/assistant-api/sip/pipeline/media.go
@@ -150,7 +150,7 @@ func (d *Dispatcher) prepareSession(ctx context.Context, v sip_infra.SessionEsta
 	var runtime PreparedCallRuntime
 	if v.Direction == sip_infra.CallDirectionInbound {
 		var err error
-		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction))
+		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction), v.FromIdentity, v.ToIdentity)
 		if err != nil {
 			observer.Close(ctx)
 			d.logger.Error("Pipeline: runtime preparation failed", "call_id", v.ID, "error", err)
@@ -526,7 +526,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 			return
 		}
 
-		runtime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction))
+		runtime, err := d.prepareSIPCallRuntime(ctx, v.Session, setup, observer, v.VaultCredential, v.Config, string(v.Direction), v.FromIdentity, v.ToIdentity)
 		if err != nil {
 			if v.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !v.Session.IsEnded() {
 				state := v.Session.GetState()

--- a/api/assistant-api/sip/pipeline/media.go
+++ b/api/assistant-api/sip/pipeline/media.go
@@ -150,7 +150,7 @@ func (d *Dispatcher) prepareSession(ctx context.Context, stage sip_infra.Session
 	var runtime PreparedCallRuntime
 	if stage.Direction == sip_infra.CallDirectionInbound {
 		var err error
-		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, stage.Session, setup, observer, stage.VaultCredential, stage.Config, string(stage.Direction), stage.FromIdentity, stage.ToIdentity)
+		preparedRuntime, err := d.prepareSIPCallRuntime(ctx, stage, setup, observer)
 		if err != nil {
 			observer.Close(ctx)
 			d.logger.Error("Pipeline: runtime preparation failed", "call_id", stage.ID, "error", err)
@@ -526,7 +526,7 @@ func (d *Dispatcher) startPreparedSession(ctx context.Context, prepared *prepare
 			return
 		}
 
-		runtime, err := d.prepareSIPCallRuntime(ctx, stage.Session, setup, observer, stage.VaultCredential, stage.Config, string(stage.Direction), stage.FromIdentity, stage.ToIdentity)
+		runtime, err := d.prepareSIPCallRuntime(ctx, stage, setup, observer)
 		if err != nil {
 			if stage.Session.GetInfo().Direction == sip_infra.CallDirectionOutbound && !stage.Session.IsEnded() {
 				state := stage.Session.GetState()

--- a/api/assistant-api/sip/pipeline/runtime.go
+++ b/api/assistant-api/sip/pipeline/runtime.go
@@ -80,7 +80,28 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_inf
 		return nil, fmt.Errorf("session_ended_before_start")
 	}
 	auth := session.GetAuth()
-	resolvedCallContext := d.resolveSIPCallContext(session, setup, direction, fromIdentity, toIdentity)
+	resolvedCallContext := setup.CallContext
+	if resolvedCallContext == nil {
+		d.logger.Warnw("setup.CallContext missing - reconstructing from session", "call_id", callID)
+		resolvedCallContext = reconstructCallContext(auth, setup.AssistantID, setup.ConversationID, direction, callID, callID, fromIdentity, toIdentity)
+		resolvedCallContext.AssistantProviderId = setup.AssistantProviderId
+		if setup.ProjectID != 0 {
+			resolvedCallContext.ProjectID = setup.ProjectID
+		}
+		if setup.OrganizationID != 0 {
+			resolvedCallContext.OrganizationID = setup.OrganizationID
+		}
+	} else {
+		if resolvedCallContext.AssistantProviderId == 0 {
+			resolvedCallContext.AssistantProviderId = setup.AssistantProviderId
+		}
+		if resolvedCallContext.ProjectID == 0 {
+			resolvedCallContext.ProjectID = setup.ProjectID
+		}
+		if resolvedCallContext.OrganizationID == 0 {
+			resolvedCallContext.OrganizationID = setup.OrganizationID
+		}
+	}
 	talkContext, cancelTalk := context.WithCancel(session.Context())
 
 	go func() {
@@ -197,46 +218,6 @@ func inboundRuntimeReadyTimeout(config *sip_infra.Config) time.Duration {
 		return config.InboundMaxRingDuration
 	}
 	return 30 * time.Second
-}
-
-func (d *Dispatcher) resolveSIPCallContext(session *sip_infra.Session, setup *CallSetupResult, direction, fromIdentity, toIdentity string) *callcontext.CallContext {
-	callID := session.GetCallID()
-	if setup.CallContext != nil {
-		call := setup.CallContext
-		if call.AssistantProviderId == 0 {
-			call.AssistantProviderId = setup.AssistantProviderId
-		}
-		if call.ProjectID == 0 {
-			call.ProjectID = setup.ProjectID
-		}
-		if call.OrganizationID == 0 {
-			call.OrganizationID = setup.OrganizationID
-		}
-		return call
-	}
-
-	d.logger.Warnw("setup.CallContext missing - reconstructing from session", "call_id", callID)
-	call := &callcontext.CallContext{
-		AssistantID:         setup.AssistantID,
-		ConversationID:      setup.ConversationID,
-		AssistantProviderId: setup.AssistantProviderId,
-		AuthToken:           setup.AuthToken,
-		AuthType:            setup.AuthType,
-		Direction:           direction,
-		Provider:            "sip",
-		ChannelUUID:         callID,
-		ContextID:           callID,
-		ProjectID:           setup.ProjectID,
-		OrganizationID:      setup.OrganizationID,
-	}
-	if direction == string(sip_infra.CallDirectionOutbound) {
-		call.CallerNumber = toIdentity
-		call.FromNumber = fromIdentity
-	} else {
-		call.CallerNumber = fromIdentity
-		call.FromNumber = toIdentity
-	}
-	return call
 }
 
 func (d *Dispatcher) configureSIPTransfer(ctx context.Context, session *sip_infra.Session, sipConfig *sip_infra.Config, call *callcontext.CallContext, transferStreamer internal_type.SIPTransferStreamer) {

--- a/api/assistant-api/sip/pipeline/runtime.go
+++ b/api/assistant-api/sip/pipeline/runtime.go
@@ -73,7 +73,8 @@ func (runtime *sipPreparedCallRuntime) Close(_ context.Context) {
 	_ = runtime.streamer.Close()
 }
 
-func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_infra.Session, setup *CallSetupResult, observer observability.Recorder, vaultCred interface{}, sipConfig *sip_infra.Config, direction, fromIdentity, toIdentity string) (*sipPreparedCallRuntime, error) {
+func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, stage sip_infra.SessionEstablishedPipeline, setup *CallSetupResult, observer observability.Recorder) (*sipPreparedCallRuntime, error) {
+	session := stage.Session
 	callID := session.GetCallID()
 	if session.IsEnded() {
 		d.logger.Warnw("Session already ended before call runtime preparation", "call_id", callID)
@@ -83,7 +84,7 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_inf
 	resolvedCallContext := setup.CallContext
 	if resolvedCallContext == nil {
 		d.logger.Warnw("setup.CallContext missing - reconstructing from session", "call_id", callID)
-		resolvedCallContext = reconstructCallContext(auth, setup.AssistantID, setup.ConversationID, direction, callID, callID, fromIdentity, toIdentity)
+		resolvedCallContext = reconstructCallContext(auth, setup.AssistantID, setup.ConversationID, string(stage.Direction), callID, callID, stage.FromIdentity, stage.ToIdentity)
 		resolvedCallContext.AssistantProviderId = setup.AssistantProviderId
 		if setup.ProjectID != 0 {
 			resolvedCallContext.ProjectID = setup.ProjectID
@@ -120,10 +121,8 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_inf
 	default:
 	}
 
-	var vaultCredential *protos.VaultCredential
-	if v, ok := vaultCred.(*protos.VaultCredential); ok {
-		vaultCredential = v
-	} else {
+	vaultCredential := stage.VaultCredential
+	if vaultCredential == nil {
 		vaultCredential = session.GetVaultCredential()
 	}
 	streamer, err := internal_telephony.New(
@@ -146,7 +145,7 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_inf
 		return nil, fmt.Errorf("session_ended_after_streamer")
 	}
 
-	d.configureSIPTransfer(ctx, session, sipConfig, resolvedCallContext, streamer)
+	d.configureSIPTransfer(ctx, session, stage.Config, resolvedCallContext, streamer)
 	talker, err := internal_adapter.New(
 		internal_adapter.WithSource(utils.PhoneCall),
 		internal_adapter.WithContext(talkContext),
@@ -174,7 +173,7 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_inf
 		cancelTalk:  cancelTalk,
 		streamer:    streamer,
 		talker:      talker,
-		direction:   direction,
+		direction:   string(stage.Direction),
 	}, nil
 }
 

--- a/api/assistant-api/sip/pipeline/runtime.go
+++ b/api/assistant-api/sip/pipeline/runtime.go
@@ -73,14 +73,14 @@ func (runtime *sipPreparedCallRuntime) Close(_ context.Context) {
 	_ = runtime.streamer.Close()
 }
 
-func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_infra.Session, setup *CallSetupResult, observer observability.Recorder, vaultCred interface{}, sipConfig *sip_infra.Config, direction string) (*sipPreparedCallRuntime, error) {
+func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, session *sip_infra.Session, setup *CallSetupResult, observer observability.Recorder, vaultCred interface{}, sipConfig *sip_infra.Config, direction, fromIdentity, toIdentity string) (*sipPreparedCallRuntime, error) {
 	callID := session.GetCallID()
 	if session.IsEnded() {
 		d.logger.Warnw("Session already ended before call runtime preparation", "call_id", callID)
 		return nil, fmt.Errorf("session_ended_before_start")
 	}
 	auth := session.GetAuth()
-	resolvedCallContext := d.resolveSIPCallContext(session, setup, direction)
+	resolvedCallContext := d.resolveSIPCallContext(session, setup, direction, fromIdentity, toIdentity)
 	talkContext, cancelTalk := context.WithCancel(session.Context())
 
 	go func() {
@@ -199,7 +199,7 @@ func inboundRuntimeReadyTimeout(config *sip_infra.Config) time.Duration {
 	return 30 * time.Second
 }
 
-func (d *Dispatcher) resolveSIPCallContext(session *sip_infra.Session, setup *CallSetupResult, direction string) *callcontext.CallContext {
+func (d *Dispatcher) resolveSIPCallContext(session *sip_infra.Session, setup *CallSetupResult, direction, fromIdentity, toIdentity string) *callcontext.CallContext {
 	callID := session.GetCallID()
 	if setup.CallContext != nil {
 		call := setup.CallContext
@@ -216,12 +216,7 @@ func (d *Dispatcher) resolveSIPCallContext(session *sip_infra.Session, setup *Ca
 	}
 
 	d.logger.Warnw("setup.CallContext missing - reconstructing from session", "call_id", callID)
-	info := session.GetInfo()
-	clientPhone := sip_infra.ExtractDIDFromURI(info.RemoteURI)
-	if clientPhone == "" {
-		clientPhone = info.RemoteURI
-	}
-	return &callcontext.CallContext{
+	call := &callcontext.CallContext{
 		AssistantID:         setup.AssistantID,
 		ConversationID:      setup.ConversationID,
 		AssistantProviderId: setup.AssistantProviderId,
@@ -229,13 +224,19 @@ func (d *Dispatcher) resolveSIPCallContext(session *sip_infra.Session, setup *Ca
 		AuthType:            setup.AuthType,
 		Direction:           direction,
 		Provider:            "sip",
-		CallerNumber:        clientPhone,
-		FromNumber:          sip_infra.ExtractDIDFromURI(info.LocalURI),
 		ChannelUUID:         callID,
 		ContextID:           callID,
 		ProjectID:           setup.ProjectID,
 		OrganizationID:      setup.OrganizationID,
 	}
+	if direction == string(sip_infra.CallDirectionOutbound) {
+		call.CallerNumber = toIdentity
+		call.FromNumber = fromIdentity
+	} else {
+		call.CallerNumber = fromIdentity
+		call.FromNumber = toIdentity
+	}
+	return call
 }
 
 func (d *Dispatcher) configureSIPTransfer(ctx context.Context, session *sip_infra.Session, sipConfig *sip_infra.Config, call *callcontext.CallContext, transferStreamer internal_type.SIPTransferStreamer) {

--- a/api/assistant-api/sip/pipeline/session.go
+++ b/api/assistant-api/sip/pipeline/session.go
@@ -30,9 +30,9 @@ func (d *Dispatcher) createConversation(ctx context.Context, stage sip_infra.Ses
 		dirEnum = type_enums.DIRECTION_OUTBOUND
 	}
 
-	callerNumber := sip_infra.ExtractDIDFromURI(stage.FromURI)
-	if callerNumber == "" {
-		callerNumber = stage.FromURI
+	callerNumber := stage.FromIdentity
+	if stage.Direction == sip_infra.CallDirectionOutbound {
+		callerNumber = stage.ToIdentity
 	}
 
 	assistant := stage.Session.GetAssistant()
@@ -69,7 +69,7 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 	if stage.Direction == sip_infra.CallDirectionOutbound {
 		contextID := stage.Session.GetContextID()
 		if contextID == "" {
-			return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, "", stage.FromURI, stage.ToURI), nil
+			return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, "", stage.FromIdentity, stage.ToIdentity), nil
 		}
 		if claimed, err := d.callContextStore.Claim(ctx, contextID); err == nil {
 			return claimed, nil
@@ -77,7 +77,7 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 		if loaded, err := d.callContextStore.Get(ctx, contextID); err == nil {
 			return loaded, nil
 		}
-		return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, contextID, stage.FromURI, stage.ToURI), nil
+		return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, contextID, stage.FromIdentity, stage.ToIdentity), nil
 	}
 
 	callContext := &callcontext.CallContext{
@@ -87,8 +87,8 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 		AuthType:       stage.Auth.Type().String(),
 		Direction:      dirStr,
 		Provider:       "sip",
-		CallerNumber:   extractDIDOrRaw(stage.FromURI),
-		FromNumber:     extractDIDOrRaw(stage.ToURI),
+		CallerNumber:   stage.FromIdentity,
+		FromNumber:     stage.ToIdentity,
 		ChannelUUID:    callID,
 	}
 	if pid := stage.Auth.GetCurrentProjectId(); pid != nil {
@@ -185,8 +185,8 @@ func reconstructCallContext(
 	direction string,
 	callID string,
 	contextID string,
-	fromURI string,
-	toURI string,
+	fromIdentity string,
+	toIdentity string,
 ) *callcontext.CallContext {
 	callContext := &callcontext.CallContext{
 		AssistantID:    assistantID,
@@ -199,11 +199,11 @@ func reconstructCallContext(
 		ContextID:      contextID,
 	}
 	if direction == string(sip_infra.CallDirectionOutbound) {
-		callContext.CallerNumber = extractDIDOrRaw(toURI)
-		callContext.FromNumber = extractDIDOrRaw(fromURI)
+		callContext.CallerNumber = toIdentity
+		callContext.FromNumber = fromIdentity
 	} else {
-		callContext.CallerNumber = extractDIDOrRaw(fromURI)
-		callContext.FromNumber = extractDIDOrRaw(toURI)
+		callContext.CallerNumber = fromIdentity
+		callContext.FromNumber = toIdentity
 	}
 	if pid := auth.GetCurrentProjectId(); pid != nil {
 		callContext.ProjectID = *pid
@@ -212,14 +212,4 @@ func reconstructCallContext(
 		callContext.OrganizationID = *oid
 	}
 	return callContext
-}
-
-func extractDIDOrRaw(uri string) string {
-	if uri == "" {
-		return ""
-	}
-	if did := sip_infra.ExtractDIDFromURI(uri); did != "" {
-		return did
-	}
-	return uri
 }

--- a/api/assistant-api/sip/pipeline/session.go
+++ b/api/assistant-api/sip/pipeline/session.go
@@ -30,9 +30,9 @@ func (d *Dispatcher) createConversation(ctx context.Context, stage sip_infra.Ses
 		dirEnum = type_enums.DIRECTION_OUTBOUND
 	}
 
-	callerNumber := stage.FromIdentity
+	conversationIdentifier := stage.FromIdentity
 	if stage.Direction == sip_infra.CallDirectionOutbound {
-		callerNumber = stage.ToIdentity
+		conversationIdentifier = stage.ToIdentity
 	}
 
 	assistant := stage.Session.GetAssistant()
@@ -55,7 +55,7 @@ func (d *Dispatcher) createConversation(ctx context.Context, stage sip_infra.Ses
 		return 0, fmt.Errorf("assistant conversation service not configured")
 	}
 	conversation, err := d.assistantConversationService.CreateConversation(
-		ctx, stage.Auth, callerNumber, assistantID, assistantProviderID, dirEnum, utils.PhoneCall,
+		ctx, stage.Auth, conversationIdentifier, assistantID, assistantProviderID, dirEnum, utils.PhoneCall,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create conversation: %w", err)

--- a/api/assistant-api/sip/pipeline/session_test.go
+++ b/api/assistant-api/sip/pipeline/session_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package sip_pipeline
+
+import (
+	"testing"
+
+	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
+	"github.com/rapidaai/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconstructCallContextInboundPreservesSIPIdentities(t *testing.T) {
+	auth := &types.ProjectScope{}
+
+	call := reconstructCallContext(
+		auth,
+		42,
+		84,
+		string(sip_infra.CallDirectionInbound),
+		"call-inbound",
+		"context-inbound",
+		"sip:alice@example.com;user=phone",
+		"sip:agent-42@sip.rapida.ai",
+	)
+
+	assert.Equal(t, "sip:alice@example.com;user=phone", call.CallerNumber)
+	assert.Equal(t, "sip:agent-42@sip.rapida.ai", call.FromNumber)
+}
+
+func TestReconstructCallContextOutboundPreservesResolvedIdentities(t *testing.T) {
+	auth := &types.ProjectScope{}
+
+	call := reconstructCallContext(
+		auth,
+		42,
+		84,
+		string(sip_infra.CallDirectionOutbound),
+		"call-outbound",
+		"context-outbound",
+		"sip:assistant@example.com",
+		"sip:bob@example.net",
+	)
+
+	assert.Equal(t, "sip:bob@example.net", call.CallerNumber)
+	assert.Equal(t, "sip:assistant@example.com", call.FromNumber)
+}

--- a/api/assistant-api/sip/pipeline/session_test.go
+++ b/api/assistant-api/sip/pipeline/session_test.go
@@ -7,11 +7,13 @@
 package sip_pipeline
 
 import (
+	"context"
 	"testing"
 
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	"github.com/rapidaai/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReconstructCallContextInboundPreservesSIPIdentities(t *testing.T) {
@@ -32,20 +34,34 @@ func TestReconstructCallContextInboundPreservesSIPIdentities(t *testing.T) {
 	assert.Equal(t, "sip:agent-42@sip.rapida.ai", call.FromNumber)
 }
 
-func TestReconstructCallContextOutboundPreservesResolvedIdentities(t *testing.T) {
+func TestEnsureCallContextOutboundFallbackPreservesResolvedRequestIdentities(t *testing.T) {
 	auth := &types.ProjectScope{}
+	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
+		Config: &sip_infra.Config{
+			Server:            "sip.example.com",
+			Port:              5060,
+			Transport:         sip_infra.TransportUDP,
+			RTPPortRangeStart: 10000,
+			RTPPortRangeEnd:   10020,
+		},
+		Direction: sip_infra.CallDirectionOutbound,
+		CallID:    "call-outbound",
+		Auth:      auth,
+	})
+	require.NoError(t, err)
+	dispatcher := &Dispatcher{}
 
-	call := reconstructCallContext(
-		auth,
-		42,
-		84,
-		string(sip_infra.CallDirectionOutbound),
-		"call-outbound",
-		"context-outbound",
-		"sip:assistant@example.com",
-		"sip:bob@example.net",
-	)
+	call, err := dispatcher.ensureCallContext(context.Background(), sip_infra.SessionEstablishedPipeline{
+		ID:           "call-outbound",
+		Session:      session,
+		Direction:    sip_infra.CallDirectionOutbound,
+		AssistantID:  42,
+		Auth:         auth,
+		FromIdentity: "assistant-line",
+		ToIdentity:   "customer-alias",
+	}, 84)
 
-	assert.Equal(t, "sip:bob@example.net", call.CallerNumber)
-	assert.Equal(t, "sip:assistant@example.com", call.FromNumber)
+	require.NoError(t, err)
+	assert.Equal(t, "customer-alias", call.CallerNumber)
+	assert.Equal(t, "assistant-line", call.FromNumber)
 }

--- a/api/assistant-api/sip/pipeline/transfer_test.go
+++ b/api/assistant-api/sip/pipeline/transfer_test.go
@@ -698,11 +698,17 @@ func TestTransferRace_UserHangupCancelsDialAttempt(t *testing.T) {
 	assert.True(t, failedCalled.Load(), "OnFailed should fire when transfer cannot complete")
 }
 
-func TestExecuteTransfer_PassesParentContextToTransferBridgeLeg(t *testing.T) {
+func TestExecuteTransfer_NewLegUsesTransferTargetAndConfiguredCallerIdentity(t *testing.T) {
 	t.Parallel()
 
 	inbound := newTransferTestSession(t)
 	outbound := newTransferTestOutboundSession(t)
+	parentCall := &callcontext.CallContext{
+		CallerNumber: "sip:original-caller@example.com",
+		FromNumber:   "sip:original-assistant@sip.rapida.ai",
+	}
+	config := newTransferTestConfig()
+	config.CallerID = "transfer-assistant"
 
 	var capturedTarget string
 	var capturedFrom string
@@ -727,13 +733,17 @@ func TestExecuteTransfer_PassesParentContextToTransferBridgeLeg(t *testing.T) {
 	d.executeTransfer(context.Background(), sip_infra.TransferInitiatedPipeline{
 		ID:        inbound.GetCallID(),
 		Session:   inbound,
-		Targets:   []string{"918031405561", "918031405562"},
-		Config:    newTransferTestConfig(),
-		TargetURI: "918031405561",
+		Targets:   []string{"transfer-target", "fallback-target"},
+		Config:    config,
+		TargetURI: "transfer-target",
 	})
 
-	assert.Equal(t, "918031405561", capturedTarget)
-	assert.Equal(t, "917943446750", capturedFrom)
+	assert.Equal(t, "transfer-target", capturedTarget)
+	assert.Equal(t, "transfer-assistant", capturedFrom)
+	assert.NotEqual(t, parentCall.CallerNumber, capturedTarget)
+	assert.NotEqual(t, parentCall.FromNumber, capturedFrom)
+	assert.Equal(t, "sip:original-caller@example.com", parentCall.CallerNumber)
+	assert.Equal(t, "sip:original-assistant@sip.rapida.ai", parentCall.FromNumber)
 	assert.Equal(t, inbound.GetCallID(), capturedOptions.ParentCallID)
 	assert.Equal(t, 1, capturedOptions.Attempt)
 	assert.Equal(t, 2, capturedOptions.TotalAttempts)

--- a/api/assistant-api/sip/pipeline/transfer_test.go
+++ b/api/assistant-api/sip/pipeline/transfer_test.go
@@ -703,10 +703,6 @@ func TestExecuteTransfer_NewLegUsesTransferTargetAndConfiguredCallerIdentity(t *
 
 	inbound := newTransferTestSession(t)
 	outbound := newTransferTestOutboundSession(t)
-	parentCall := &callcontext.CallContext{
-		CallerNumber: "sip:original-caller@example.com",
-		FromNumber:   "sip:original-assistant@sip.rapida.ai",
-	}
 	config := newTransferTestConfig()
 	config.CallerID = "transfer-assistant"
 
@@ -740,10 +736,6 @@ func TestExecuteTransfer_NewLegUsesTransferTargetAndConfiguredCallerIdentity(t *
 
 	assert.Equal(t, "transfer-target", capturedTarget)
 	assert.Equal(t, "transfer-assistant", capturedFrom)
-	assert.NotEqual(t, parentCall.CallerNumber, capturedTarget)
-	assert.NotEqual(t, parentCall.FromNumber, capturedFrom)
-	assert.Equal(t, "sip:original-caller@example.com", parentCall.CallerNumber)
-	assert.Equal(t, "sip:original-assistant@sip.rapida.ai", parentCall.FromNumber)
 	assert.Equal(t, inbound.GetCallID(), capturedOptions.ParentCallID)
 	assert.Equal(t, 1, capturedOptions.Attempt)
 	assert.Equal(t, 2, capturedOptions.TotalAttempts)

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -134,9 +134,9 @@ func (m *SIPEngine) Connect(ctx context.Context) error {
 			),
 		},
 	)
-	server.SetOnApplicationReady(m.onApplicationReady)
+	server.SetOnApplicationReadyIdentity(m.onApplicationReady)
 	server.SetOnApplicationCleanup(m.onApplicationCleanup)
-	server.SetOnInvite(m.onInvite)
+	server.SetOnInviteIdentity(m.onInvite)
 	server.SetOnBye(m.onBye)
 	server.SetOnCancel(m.onCancel)
 	server.SetOnError(m.onError)
@@ -229,8 +229,8 @@ func (m *SIPEngine) GetServer() *sip_infra.Server {
 	return m.server
 }
 
-func (m *SIPEngine) onApplicationReady(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) error {
-	stage, err := m.sessionEstablishedStage(session, requestURI, fromIdentity, toIdentity)
+func (m *SIPEngine) onApplicationReady(session *sip_infra.Session, identity sip_infra.SIPRequestIdentity) error {
+	stage, err := m.sessionEstablishedStage(session, identity)
 	if err != nil {
 		return err
 	}
@@ -247,8 +247,8 @@ func (m *SIPEngine) onApplicationCleanup(session *sip_infra.Session) {
 	m.dispatcher.DiscardPreparedSession(m.ctx, session.GetCallID())
 }
 
-func (m *SIPEngine) onInvite(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) error {
-	stage, err := m.sessionEstablishedStage(session, requestURI, fromIdentity, toIdentity)
+func (m *SIPEngine) onInvite(session *sip_infra.Session, identity sip_infra.SIPRequestIdentity) error {
+	stage, err := m.sessionEstablishedStage(session, identity)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, requestURI, fromIdentit
 	return nil
 }
 
-func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) (sip_infra.SessionEstablishedPipeline, error) {
+func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, identity sip_infra.SIPRequestIdentity) (sip_infra.SessionEstablishedPipeline, error) {
 	if session == nil {
 		return sip_infra.SessionEstablishedPipeline{}, fmt.Errorf("session is nil")
 	}
@@ -291,9 +291,9 @@ func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, requestU
 		Direction:       info.Direction,
 		AssistantID:     assistant.Id,
 		Auth:            auth,
-		RequestURI:      requestURI,
-		FromIdentity:    fromIdentity,
-		ToIdentity:      toIdentity,
+		RequestURI:      identity.RequestURI,
+		FromIdentity:    identity.FromIdentity,
+		ToIdentity:      identity.ToIdentity,
 		ConversationID:  session.GetConversationID(),
 	}, nil
 }

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -229,8 +229,8 @@ func (m *SIPEngine) GetServer() *sip_infra.Server {
 	return m.server
 }
 
-func (m *SIPEngine) onApplicationReady(session *sip_infra.Session, fromURI, toURI string) error {
-	stage, err := m.sessionEstablishedStage(session, fromURI, toURI)
+func (m *SIPEngine) onApplicationReady(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) error {
+	stage, err := m.sessionEstablishedStage(session, requestURI, fromIdentity, toIdentity)
 	if err != nil {
 		return err
 	}
@@ -247,8 +247,8 @@ func (m *SIPEngine) onApplicationCleanup(session *sip_infra.Session) {
 	m.dispatcher.DiscardPreparedSession(m.ctx, session.GetCallID())
 }
 
-func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) error {
-	stage, err := m.sessionEstablishedStage(session, fromURI, toURI)
+func (m *SIPEngine) onInvite(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) error {
+	stage, err := m.sessionEstablishedStage(session, requestURI, fromIdentity, toIdentity)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (m *SIPEngine) onInvite(session *sip_infra.Session, fromURI, toURI string) 
 	return nil
 }
 
-func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, fromURI, toURI string) (sip_infra.SessionEstablishedPipeline, error) {
+func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, requestURI, fromIdentity, toIdentity string) (sip_infra.SessionEstablishedPipeline, error) {
 	if session == nil {
 		return sip_infra.SessionEstablishedPipeline{}, fmt.Errorf("session is nil")
 	}
@@ -291,8 +291,9 @@ func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, fromURI,
 		Direction:       info.Direction,
 		AssistantID:     assistant.Id,
 		Auth:            auth,
-		FromURI:         fromURI,
-		ToURI:           toURI,
+		RequestURI:      requestURI,
+		FromIdentity:    fromIdentity,
+		ToIdentity:      toIdentity,
 		ConversationID:  session.GetConversationID(),
 	}, nil
 }

--- a/rfcs/0003-native-sip-assistant-phone-resolution.md
+++ b/rfcs/0003-native-sip-assistant-phone-resolution.md
@@ -1,0 +1,837 @@
+# RFC 0003: Native SIP Party Identity Resolution
+
+- Status: Draft
+- Date: 2026-08-22
+- Owners: Assistant API Native SIP, Assistant Authentication
+- Reviewers: SIP, Telephony, UI, Security, and SRE owners
+
+## Abstract
+
+This RFC defines how native SIP resolves and propagates the two parties of a call.
+
+SIP provides three different addressing concepts that MUST remain separate:
+
+- Request-URI identifies where the request is routed.
+- The `From` header identifies the logical initiator.
+- The `To` header identifies the logical recipient.
+
+Rapida MUST capture the `From` and `To` header addresses from the dialog-forming SIP request
+and preserve them without phone-number validation, normalization, or DID inference.
+
+For inbound calls:
+
+- `client.phone` is the `From` header address.
+- `client.assistant_phone` is the `To` header address.
+
+For outbound calls:
+
+- `client.phone` is the resolved remote destination.
+- `client.assistant_phone` is the resolved local originating identity.
+
+Request-URI is used only for routing. It MUST NOT populate either party identity.
+
+This contract applies equally when the dialog-forming request represents a direct call, a new
+call created after `REFER`, or a replacement/transfer INVITE. Each new SIP dialog resolves its
+own parties from its own dialog-forming request.
+
+This RFC changes only native SIP identity handling and the assistant-authentication UI key.
+Other telephony providers, public APIs, protobuf contracts, and database schemas are
+unchanged.
+
+## Status of This Memo
+
+This document is a design proposal. Implementation MUST NOT begin while its status is
+`Draft`.
+
+Before implementation, the final RFC bytes MUST pass independent challenge and exact-digest
+confirmation according to `DEVELOPMENT_PROCESS.md`. Any byte change after confirmation
+requires another challenge and confirmation.
+
+## Conformance Language
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document describe normative requirements.
+
+## Problem Statement
+
+The native SIP implementation currently carries values named `FromURI` and `ToURI`, then
+attempts to extract a DID or phone number from those values. A defensive reconstruction path
+also derives the assistant-side value from `SessionInfo.LocalURI`.
+
+That behavior conflates two independent concerns:
+
+1. SIP request routing.
+2. SIP party identity.
+
+A SIP identity can be a telephone number, extension, assistant address, route-specific name,
+or another valid SIP user. Direct calls, transferred calls, and referred calls do not
+guarantee numeric identities.
+
+The system therefore MUST NOT decide whether a SIP party identity looks like a phone number.
+It must capture the identities supplied by SIP, map them according to call direction, and
+preserve them for the lifetime of the call.
+
+## Protocol Model
+
+### Request-URI
+
+The Request-URI identifies the user or service to which the current request is routed.
+
+Rapida MAY use Request-URI to select an assistant, deployment, or route. Request-URI MUST NOT
+populate `client.phone`, `client.assistant_phone`, `CallContext.CallerNumber`, or
+`CallContext.FromNumber`.
+
+### From Header
+
+The `From` header identifies the logical initiator of the dialog-forming request.
+
+Rapida MUST capture the parsed header address:
+
+```go
+request.From().Address.String()
+```
+
+The display name and header parameters, including the dialog tag, are not part of the party
+identity stored by this RFC.
+
+### To Header
+
+The `To` header identifies the logical recipient of the dialog-forming request.
+
+Rapida MUST capture the parsed header address:
+
+```go
+request.To().Address.String()
+```
+
+The display name and header parameters, including the dialog tag, are not part of the party
+identity stored by this RFC.
+
+### Identity Representation
+
+The captured `From` and `To` addresses are opaque SIP party identities.
+
+The implementation MUST NOT:
+
+- require digits;
+- require or remove a leading `+`;
+- apply E.164 validation;
+- strip `agent-`, `did-`, or any other prefix;
+- remove a host, port, URI parameter, or URI header;
+- convert a SIP URI to only its user component;
+- infer a country code;
+- reject an identity because it is non-numeric; or
+- substitute a deployment phone number.
+
+The implementation MUST use the parsed address object's `String()` representation and then
+preserve that result unchanged through downstream call state.
+
+Examples of valid opaque identities include:
+
+```text
+sip:+15551234567@carrier.example
+sip:15551234567@carrier.example;user=phone
+sip:agent-42@sip.rapida.ai
+sip:alice@example.com
+tel:+442079460123
+```
+
+This RFC does not assert that every value stored under a legacy `phone`-named field is a PSTN
+number. For native SIP, those fields carry SIP party identities.
+
+## Scope
+
+### In Scope
+
+- Capturing `From` and `To` header addresses from native SIP dialog-forming requests.
+- Carrying Request-URI separately for routing.
+- Direction-aware mapping of the captured party identities into call context.
+- Consistent behavior for direct, referred, transferred, and replacement calls.
+- Removal of native SIP phone-number validation and DID extraction.
+- Removal of native SIP identity reconstruction from local or remote session URIs.
+- Preservation of existing outbound request behavior.
+- Canonical `client.assistant_phone` authentication UI configuration.
+- Backend and UI tests directly covering these changes.
+
+### Out of Scope
+
+- Twilio, Vonage, Vobiz, Exotel, Telnyx, generic SIP webhook, and Asterisk adapters.
+- Changes to provider webhook parsing or payloads.
+- Non-native-SIP call behavior.
+- Changes to SIP route formats or route selection results.
+- Changes to media, codecs, registration, or transport handling.
+- Number validation or normalization.
+- Inspection of `P-Asserted-Identity`, `P-Called-Party-ID`, `History-Info`, `Diversion`, or
+  provider-specific headers.
+- Database or protobuf migrations.
+- Public REST or SDK contract changes.
+- Compatibility support for `client.assistantPhone`.
+
+## Terminology
+
+### Dialog-Forming Request
+
+The initial SIP request that creates a new dialog and native SIP call context. This is normally
+an `INVITE`, including an INVITE generated as the result of referral or transfer processing.
+
+### From Identity
+
+The parsed address from the dialog-forming request's `From` header.
+
+### To Identity
+
+The parsed address from the dialog-forming request's `To` header.
+
+### Route Identity
+
+The Request-URI used to route the request. Route identity is not a party identity.
+
+### Existing Dialog Request
+
+A request, including a re-INVITE, that belongs to an already established dialog. It does not
+create a new call identity snapshot.
+
+## Protocol Invariants
+
+1. Request-URI MUST be used only for routing.
+2. Every native SIP call context MUST be based on one dialog-forming request.
+3. The call's From identity MUST come from that request's parsed `From` header address.
+4. The call's To identity MUST come from that request's parsed `To` header address.
+5. Party identities MUST be treated as opaque values.
+6. Party identities MUST NOT be validated as phone numbers.
+7. Party identities MUST NOT be derived from Request-URI.
+8. Party identities MUST NOT be reconstructed from `SessionInfo.LocalURI` or
+   `SessionInfo.RemoteURI`.
+9. Party identities MUST remain immutable after the call context is created.
+10. Requests within an existing dialog MUST NOT replace the stored party identities.
+11. A new dialog created by referral, transfer, or replacement MUST resolve identities from
+    its own dialog-forming request.
+12. Metadata writers MUST use call context only and MUST NOT inspect SIP state.
+
+## Canonical Internal Contract
+
+### SIP Request Identity
+
+The native SIP inbound identity MUST contain three distinct fields:
+
+```go
+type inboundInviteIdentity struct {
+    callID       string
+    fromTag      string
+    requestURI  string
+    fromIdentity string
+    toIdentity   string
+}
+```
+
+The semantic source of each field is fixed:
+
+| Field | Source |
+| --- | --- |
+| `requestURI` | `request.Recipient.String()` |
+| `fromIdentity` | `request.From().Address.String()` |
+| `toIdentity` | `request.To().Address.String()` |
+
+Equivalent exported boundary fields MUST use these names:
+
+```go
+RequestURI   string
+FromIdentity string
+ToIdentity   string
+```
+
+New code MUST NOT introduce `FromURI` or `ToURI` fields for these values. Existing ambiguous
+fields MUST be renamed within the native SIP boundary as part of this change.
+
+### Direction-Aware Call Context Mapping
+
+The mapping is:
+
+| Direction | `CallContext.CallerNumber` | `CallContext.FromNumber` |
+| --- | --- | --- |
+| Inbound | `FromIdentity` | `ToIdentity` |
+| Outbound | resolved remote destination | resolved local `fromNumber` |
+
+For inbound native SIP:
+
+```go
+callContext.CallerNumber = stage.FromIdentity
+callContext.FromNumber = stage.ToIdentity
+```
+
+No extraction helper or fallback is permitted.
+
+For outbound native SIP, the existing channel pipeline remains authoritative for the remote
+destination and local `fromNumber`. SIP response headers and session URIs MUST NOT overwrite
+the outbound call context.
+
+### Metadata Mapping
+
+Metadata writers MUST apply this mapping:
+
+| Call context field | Metadata key | Presence rule |
+| --- | --- | --- |
+| `CallerNumber` | `client.phone` | Emit when non-empty |
+| `FromNumber` | `client.assistant_phone` | Emit when non-empty |
+
+The existing metadata names are retained for compatibility even though native SIP values may
+be non-numeric SIP identities.
+
+### Authentication Key
+
+The only supported assistant authentication source is:
+
+```text
+client.assistant_phone
+```
+
+The authentication UI MUST save `assistant_phone` as the client variable name.
+
+The implementation MUST NOT add a `client.assistantPhone` compatibility alias. Existing
+incorrect configurations must be corrected by their owners.
+
+## Inbound Call Protocol
+
+### Initial INVITE Capture
+
+When native SIP accepts an initial INVITE, it MUST:
+
+1. Preserve existing mandatory SIP request validation.
+2. Capture Request-URI as `requestURI` for routing.
+3. Capture `request.From().Address.String()` as `fromIdentity`.
+4. Capture `request.To().Address.String()` as `toIdentity`.
+5. Pass all three values to inbound middleware.
+
+The captured identity strings MUST NOT be transformed after capture.
+
+### Routing
+
+Routing middleware MUST use `RequestURI` as its primary route input.
+
+Routing middleware MUST NOT use `FromIdentity` as a route fallback.
+
+If legacy routing still requires `ToIdentity`, that behavior MUST be documented and tested as
+a routing-only compatibility path. It MUST NOT change either captured party identity.
+
+Route parsing and assistant lookup MUST NOT rewrite `FromIdentity` or `ToIdentity`.
+
+### Context Construction
+
+After routing and authentication succeed, the session-established pipeline MUST carry:
+
+```go
+RequestURI   string
+FromIdentity string
+ToIdentity   string
+```
+
+Inbound call context construction MUST set:
+
+```go
+CallerNumber = FromIdentity
+FromNumber   = ToIdentity
+```
+
+The same mapping MUST be used by normal construction and any defensive reconstruction path.
+
+### Existing Dialog Requests
+
+ACK, BYE, CANCEL, UPDATE, INFO, and re-INVITE handling MUST NOT change the party identities
+stored for the call.
+
+The original dialog-forming request remains authoritative for that call context.
+
+## Direct Call Protocol
+
+A direct call to a Rapida SIP address is handled like every other inbound initial INVITE.
+
+Example:
+
+```text
+INVITE sip:agent-42@sip.rapida.ai SIP/2.0
+From: <sip:alice@example.com>;tag=caller-tag
+To: <sip:agent-42@sip.rapida.ai>
+```
+
+Result:
+
+```text
+RequestURI                   = sip:agent-42@sip.rapida.ai
+FromIdentity                 = sip:alice@example.com
+ToIdentity                   = sip:agent-42@sip.rapida.ai
+CallContext.CallerNumber     = sip:alice@example.com
+CallContext.FromNumber       = sip:agent-42@sip.rapida.ai
+client.phone                 = sip:alice@example.com
+client.assistant_phone       = sip:agent-42@sip.rapida.ai
+```
+
+The non-numeric assistant identity is valid and MUST NOT be omitted or rewritten.
+
+## Referral and Transfer Protocol
+
+### REFER Request
+
+A `REFER` request instructs a recipient to contact the resource identified by `Refer-To`.
+
+Receiving or sending REFER MUST NOT immediately mutate the current call context's
+`CallerNumber` or `FromNumber`. The existing dialog retains its original party identities
+until it terminates.
+
+`Refer-To` is a transfer target, not the From or To identity of the existing call. It MUST NOT
+be written into the existing call context.
+
+### New INVITE Caused by REFER
+
+If REFER processing creates a new outbound or inbound INVITE, that INVITE creates a distinct
+call leg and identity snapshot.
+
+The new call leg MUST resolve its identities according to its own direction:
+
+- new inbound leg: `FromIdentity` to `CallerNumber`, `ToIdentity` to `FromNumber`;
+- new outbound leg: existing outbound destination and `fromNumber` resolution.
+
+The new call leg MUST NOT inherit the old leg's `FromIdentity` or `ToIdentity` unless those
+same values are explicitly present in the new dialog-forming request or outbound call request.
+
+### INVITE with Replaces
+
+An INVITE containing `Replaces` creates a new dialog intended to replace an existing dialog.
+
+The replacement INVITE MUST create its own identity snapshot from its own `From` and `To`
+headers. The referenced dialog's identities MUST NOT overwrite the replacement dialog's
+identities.
+
+### Blind and Attended Transfer
+
+Blind and attended transfers MUST follow the same call-leg rule:
+
+- each existing dialog keeps its original immutable party identities;
+- each new dialog resolves its own identities once;
+- correlation between call legs does not imply identity inheritance; and
+- transfer targets remain routing inputs until they become part of a new dialog-forming
+  request.
+
+## Outbound Call Protocol
+
+Outbound behavior remains unchanged because Rapida initiates the call and already owns the
+two application-level identities.
+
+The outbound pipeline MUST continue to:
+
+1. Use the resolved destination as `CallContext.CallerNumber`.
+2. Use the explicit `fromNumber`, or the existing outbound deployment fallback, as
+   `CallContext.FromNumber`.
+3. Use those values to construct outbound SIP signaling.
+4. Preserve the call context values for authentication and metadata.
+
+SIP responses, Contact values, dialog remote targets, and later in-dialog requests MUST NOT
+overwrite the outbound call context identities.
+
+## Failure Semantics
+
+| Condition | Required behavior |
+| --- | --- |
+| Initial request lacks a required `From` or `To` header | Preserve existing malformed-request rejection |
+| Parsed `From` address is empty | Preserve existing malformed-request behavior |
+| Parsed `To` address is empty | Preserve existing malformed-request behavior |
+| Identity is non-numeric | Accept and preserve it |
+| Identity uses `sip`, `sips`, or `tel` | Accept the parsed address representation |
+| Request-URI differs from `ToIdentity` | Route with Request-URI and preserve `ToIdentity` |
+| Existing-dialog request has different displayed headers | Do not mutate stored identities |
+| New transfer leg is created | Resolve a new identity snapshot for the new leg |
+| Call context reconstruction is required | Use propagated From/To identities, never session URIs |
+
+No identity format may cause a panic or an otherwise valid call failure.
+
+## Message Flows
+
+### Inbound Direct or PSTN-Originated SIP Call
+
+```text
+Initial INVITE
+    -> capture RequestURI
+    -> capture FromIdentity from From.Address.String()
+    -> capture ToIdentity from To.Address.String()
+    -> route using RequestURI
+    -> preserve identities through middleware
+    -> propagate identities through session establishment
+    -> CallerNumber = FromIdentity
+    -> FromNumber = ToIdentity
+    -> emit client.phone and client.assistant_phone
+```
+
+### REFER-Based Transfer
+
+```text
+Existing dialog receives REFER
+    -> keep existing call-context identities unchanged
+    -> treat Refer-To as transfer routing target
+    -> create a new dialog-forming INVITE when transfer proceeds
+    -> resolve the new call leg from its own From/To headers or outbound inputs
+```
+
+### INVITE with Replaces
+
+```text
+Replacement INVITE arrives
+    -> capture its RequestURI, FromIdentity, and ToIdentity
+    -> create a new call-leg identity snapshot
+    -> correlate with the replaced dialog
+    -> do not copy party identities from the replaced dialog
+```
+
+## Service Impact and Required Updates
+
+### Impact Matrix
+
+| Service or component | Impact | Required update |
+| --- | --- | --- |
+| `assistant-api`: SIP core | Required | Capture distinct RequestURI, FromIdentity, and ToIdentity values from the dialog-forming request. |
+| `assistant-api`: SIP infra | Required | Preserve all three values across core/infra conversions. |
+| `assistant-api`: SIP middleware | Required | Route using RequestURI and preserve FromIdentity and ToIdentity unchanged. |
+| `assistant-api`: SIP pipeline | Required | Map identities by direction and remove DID extraction or session-URI fallback. |
+| `assistant-api`: SIP transfer | Verification required | Keep existing-leg identities immutable and resolve every new leg independently. |
+| `assistant-api`: telephony metadata | Verification required | Continue emitting values only from call context. |
+| `assistant-api`: authentication | Verification required | Read only canonical `client.assistant_phone`; add no alias. |
+| `ui`: authentication configuration | Required | Save `assistant_phone` instead of `assistantPhone`. |
+| Non-SIP telephony providers | No implementation change | Preserve current behavior; do not modify provider adapters. |
+| `web-api` | No impact | No route, schema, or authentication contract change. |
+| `integration-api` | No impact | No caller or model-provider change. |
+| `endpoint-api` | No impact | No endpoint runtime contract change. |
+| `document-api` | No impact | No document contract change. |
+| Database and migrations | No impact | Continue using existing conversation metadata storage. |
+| Public protobuf, REST, and SDK contracts | No impact | Preserve all wire fields and names. |
+
+### Required File Boundaries
+
+| Area | Allowed paths | Responsibility |
+| --- | --- | --- |
+| SIP core | `api/assistant-api/sip/internal/core/` | Capture and own the immutable identity snapshot. |
+| SIP infra | `api/assistant-api/sip/infra/` | Preserve identity fields across package boundaries. |
+| SIP middleware | `api/assistant-api/sip/middleware/` | Route independently from party identity. |
+| SIP pipeline | `api/assistant-api/sip/pipeline/` | Apply direction-aware call-context mapping. |
+| SIP transfer | Existing SIP transfer files and tests | Verify call-leg identity isolation. |
+| Telephony metadata | Existing base/observability files only if tests expose a mismatch | Preserve call-context-only metadata emission. |
+| Authentication UI | `ui/src/app/pages/assistant/actions/configure-assistant-authentication/` | Save the canonical key. |
+
+The following are out of scope:
+
+- non-SIP provider adapter directories;
+- STT, TTS, VAD, end-of-speech, and noise-reduction internals;
+- integration-api LLM caller code;
+- database migrations;
+- public protobuf definitions;
+- global variable aliasing; and
+- unrelated SIP media, codec, or registration changes.
+
+If implementation requires another path, work MUST stop until the plan and RFC are revised and
+reconfirmed.
+
+## External and Wire Compatibility
+
+This RFC introduces no SIP wire-format change and no public API change.
+
+- Incoming SIP headers are consumed as already received.
+- Outgoing SIP construction remains unchanged.
+- The outbound public request field remains `fromNumber`.
+- Protobuf field names and numbers remain unchanged.
+- REST routes and JSON response shapes remain unchanged.
+- No SDK regeneration is required.
+- No non-SIP provider payload changes are required.
+
+The intentional behavior change is internal representation:
+
+- native SIP party identities are no longer reduced to numeric DID values;
+- full parsed `From` and `To` addresses are preserved;
+- Request-URI no longer supplies call metadata; and
+- transfer-created call legs resolve independently.
+
+## Persistence and Migration
+
+No database migration is required.
+
+Conversation metadata continues to use the existing `client.phone` and
+`client.assistant_phone` keys. New native SIP calls may store full SIP or TEL identities where
+older behavior stored a numeric user or another inferred value.
+
+Historical metadata is not rewritten.
+
+There is no compatibility alias or dual-write period for `client.assistantPhone`.
+
+## Security Considerations
+
+- Request-URI cannot directly set authentication identity metadata.
+- Header identities are captured only after existing SIP parsing and request acceptance.
+- Identity strings remain data and MUST NOT be executed, dialed, or used as URLs by
+  authentication code.
+- Authentication cannot access arbitrary SIP headers through this change.
+- Existing tenant-scoped routing and authorization remain authoritative.
+- Logs and metrics MUST NOT contain full party identities.
+
+This RFC records SIP-provided logical identities. It does not claim that the headers
+cryptographically verify a PSTN phone-number owner.
+
+## Privacy Considerations
+
+SIP party identities may contain phone numbers, usernames, hosts, or routing information.
+
+- New logs and metrics MUST record only bounded outcome fields.
+- Raw From, To, and Request-URI values MUST NOT be added to logs or metric labels.
+- Existing metadata authorization remains unchanged.
+- No new cross-service propagation is introduced.
+
+## Observability
+
+The capture boundary SHOULD record bounded state without identity values.
+
+Recommended fields:
+
+- `direction=inbound|outbound`;
+- `provider=sip`;
+- `identity_source=sip_headers|outbound_request`;
+- `from_identity_present=true|false`;
+- `to_identity_present=true|false`;
+- `route_identity_present=true|false`; and
+- `dialog_origin=direct|refer|replace|unknown` when already known by the call flow.
+
+No label or attribute introduced by this RFC may contain an unbounded identity string.
+
+## Implementation Plan
+
+### Phase 1: Separate Identity Types
+
+1. Replace ambiguous inbound `fromURI` and `toURI` fields with `requestURI`, `fromIdentity`,
+   and `toIdentity`.
+2. Populate them from `request.Recipient`, `request.From().Address`, and
+   `request.To().Address` respectively.
+3. Add equivalent exported fields to core/infra request context types.
+
+### Phase 2: Separate Routing
+
+1. Route using `RequestURI`.
+2. Remove `FromIdentity` from route fallback behavior.
+3. Preserve any required legacy `ToIdentity` routing fallback as routing-only behavior.
+4. Prove through tests that routing does not mutate party identities.
+
+### Phase 3: Propagate Identity Snapshot
+
+1. Add `RequestURI`, `FromIdentity`, and `ToIdentity` to core and infra
+   `SessionEstablishedPipeline`.
+2. Copy all fields through every conversion and construction site.
+3. Keep the fields immutable after initial call construction.
+
+### Phase 4: Map Call Context
+
+1. Set inbound caller identity from `stage.FromIdentity`.
+2. Set inbound assistant identity from `stage.ToIdentity`.
+3. Update defensive reconstruction to use the same fields.
+4. Remove inbound use of `ExtractDIDFromURI` and session URI fallbacks.
+5. Preserve outbound behavior.
+
+### Phase 5: Transfer Verification
+
+1. Verify REFER does not mutate existing call context.
+2. Verify a new REFER-created call leg resolves its own identity snapshot.
+3. Verify an INVITE with Replaces resolves its own identity snapshot.
+4. Verify in-dialog requests do not modify stored identities.
+
+### Phase 6: Authentication UI
+
+1. Save `assistant_phone` instead of `assistantPhone`.
+2. Add UI regression tests.
+3. Add no runtime compatibility alias.
+
+## Testing and Verification
+
+### SIP Core Tests
+
+Required cases:
+
+- captures full parsed From address;
+- captures full parsed To address;
+- captures Request-URI separately;
+- preserves numeric, non-numeric, SIP, SIPS, and TEL identities;
+- preserves URI parameters and URI headers produced by the parser;
+- excludes display names and From/To header parameters;
+- rejects requests missing mandatory From or To headers using existing behavior; and
+- performs no phone-number validation.
+
+### SIP Middleware Tests
+
+Required cases:
+
+- routes from RequestURI;
+- does not route from FromIdentity;
+- preserves FromIdentity and ToIdentity;
+- keeps any approved legacy To-based route fallback isolated from metadata; and
+- rejects unknown routes using existing behavior.
+
+### SIP Pipeline Tests
+
+Required cases:
+
+- inbound maps FromIdentity to `CallerNumber`;
+- inbound maps ToIdentity to `FromNumber`;
+- direct Rapida SIP identities are preserved;
+- normal and reconstruction paths produce identical mappings;
+- LocalURI and RemoteURI do not populate reconstructed call identities;
+- outbound behavior remains unchanged; and
+- initialization and conversation metadata agree.
+
+### Transfer Tests
+
+Required cases:
+
+- REFER does not mutate existing call context;
+- a new call leg created after REFER uses its own identity snapshot;
+- INVITE with Replaces uses its own identity snapshot;
+- the replaced call retains its identities until termination; and
+- re-INVITE does not modify identities.
+
+### UI Tests
+
+Required cases:
+
+- Assistant Phone saves `assistant_phone`;
+- the label remains unchanged; and
+- no new configuration saves `assistantPhone`.
+
+### Required Commands
+
+```bash
+go test ./api/assistant-api/sip/internal/core/...
+go test ./api/assistant-api/sip/infra/...
+go test ./api/assistant-api/sip/middleware/...
+go test ./api/assistant-api/sip/pipeline/...
+go test ./api/assistant-api/internal/channel/telephony/internal/base/...
+yarn --cwd ui test --watchAll=false --runTestsByPath \
+  src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+yarn --cwd ui checkTs
+yarn --cwd ui eslint \
+  src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts \
+  src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+yarn --cwd ui prettier --check \
+  src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts \
+  src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+git diff --check
+```
+
+## Rollout
+
+The implementation is code-only and requires no cross-service migration ordering.
+
+Rollout checks:
+
+1. Direct inbound SIP calls preserve full From and To identities.
+2. PSTN-originated SIP calls preserve the addresses supplied in From and To.
+3. Request-URI changes affect routing only.
+4. Existing-dialog requests do not mutate call identity.
+5. Transfer-created dialogs resolve independent identities.
+6. Outbound calls preserve existing application-selected values.
+7. The authentication UI saves only the canonical key.
+8. Non-SIP providers remain unchanged.
+
+## Rollback
+
+No data rollback is required.
+
+Rollback consists of reverting the native SIP and UI implementation. Public APIs, SIP wire
+messages, and database schemas remain compatible.
+
+Restoring DID extraction or session-URI fallback is not an approved long-term behavior.
+
+## Alternatives Considered
+
+### Validate Numeric DID Values
+
+Rejected. SIP party identities can legitimately be non-numeric, especially for direct calls
+and transfer-created dialogs.
+
+### Use Only the URI User Component
+
+Rejected. It discards the scheme, host, and URI parameters that distinguish SIP identities.
+
+### Use Request-URI as the Assistant Identity
+
+Rejected. Request-URI is a routing target and may change independently of the logical To
+identity.
+
+### Recompute Identity from Session Local and Remote URIs
+
+Rejected. Session endpoints and routing state are not replacements for the dialog-forming
+From and To identities.
+
+### Mutate Identity During REFER or Re-INVITE
+
+Rejected. Existing dialogs retain their original identity snapshot. New dialogs resolve new
+snapshots.
+
+### Support `client.assistantPhone`
+
+Rejected. Only the canonical snake_case metadata contract is supported.
+
+### Update Non-SIP Providers
+
+Rejected for this RFC. Their existing resolution contracts remain unchanged.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Consumers assume metadata always contains digits | Authentication request may receive a SIP identity | Document opaque semantics and avoid validation in transport code. |
+| Renaming fields misses a conversion boundary | Identity is lost | Add core/infra parity tests and compile-time updates at every construction site. |
+| Routing fallback mutates To identity | Metadata no longer matches the request | Keep routing result separate and test identity immutability. |
+| Transfer code reuses an old call context | New leg receives stale identities | Require a new snapshot for each dialog-forming request and add transfer tests. |
+| Raw identities leak through observability | Sensitive SIP data exposure | Emit presence and origin enums only. |
+| Existing camelCase UI mappings remain invalid | Existing authentication configuration may not resolve | Require explicit configuration correction; add no hidden alias. |
+
+## Acceptance Criteria
+
+1. Native SIP captures RequestURI, FromIdentity, and ToIdentity as distinct values.
+2. FromIdentity is exactly the parsed `From` header address string.
+3. ToIdentity is exactly the parsed `To` header address string.
+4. No phone-number validation, normalization, or DID extraction is performed.
+5. RequestURI is used only for routing.
+6. Inbound maps FromIdentity to `client.phone` through `CallerNumber`.
+7. Inbound maps ToIdentity to `client.assistant_phone` through `FromNumber`.
+8. Existing-dialog requests do not modify the identity snapshot.
+9. New dialogs created by direct calls, REFER, transfer, or Replaces resolve independently.
+10. Reconstruction paths never derive identities from LocalURI or RemoteURI.
+11. Outbound behavior remains unchanged.
+12. Non-SIP provider implementations remain unchanged.
+13. The UI saves only `client.assistant_phone`.
+14. No `client.assistantPhone` alias is added.
+15. No database, protobuf, REST, SDK, provider webhook, or SIP wire-format migration is
+    introduced.
+16. Required backend and UI tests pass.
+17. Independent review reports no unresolved critical or major findings.
+18. Final RFC bytes receive exact-digest confirmation before implementation begins.
+
+## References
+
+- RFC 3261, *SIP: Session Initiation Protocol*.
+- RFC 3515, *The Session Initiation Protocol Refer Method*.
+- RFC 3891, *The Session Initiation Protocol Replaces Header*.
+- RFC 5589, *Session Initiation Protocol Call Control - Transfer*.
+- `api/assistant-api/sip/internal/core/inbound_call.go`
+- `api/assistant-api/sip/internal/core/server.go`
+- `api/assistant-api/sip/internal/core/pipeline.go`
+- `api/assistant-api/sip/infra/server_type.go`
+- `api/assistant-api/sip/infra/pipeline_type.go`
+- `api/assistant-api/sip/pipeline/session.go`
+- `api/assistant-api/sip/pipeline/runtime.go`
+- `api/assistant-api/sip/pipeline/transfer.go`
+- `api/assistant-api/internal/channel/telephony/internal/base/base.go`
+- `ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts`
+
+## Decision Log
+
+| Date | Decision | Rationale |
+| --- | --- | --- |
+| 2026-08-22 | Preserve complete parsed SIP header addresses. | SIP identities are not limited to telephone numbers. |
+| 2026-08-22 | Apply no number validation or normalization. | Direct, referred, and transferred calls may use arbitrary valid SIP identities. |
+| 2026-08-22 | Keep Request-URI routing-only. | Request routing and logical party identity are independent. |
+| 2026-08-22 | Snapshot From and To per dialog-forming request. | Existing dialogs remain stable while new transfer legs resolve independently. |
+| 2026-08-22 | Keep `CallContext` and metadata field names. | Avoid public and persistence migrations while correcting native SIP semantics. |
+| 2026-08-22 | Add no camelCase authentication alias. | The canonical metadata contract remains singular. |
+| 2026-08-22 | Make no non-SIP provider changes. | This RFC addresses native SIP only. |

--- a/rfcs/0003-native-sip-assistant-phone-resolution.md
+++ b/rfcs/0003-native-sip-assistant-phone-resolution.md
@@ -1,6 +1,6 @@
 # RFC 0003: Native SIP Party Identity Resolution
 
-- Status: Draft
+- Status: Accepted
 - Date: 2026-08-22
 - Owners: Assistant API Native SIP, Assistant Authentication
 - Reviewers: SIP, Telephony, UI, Security, and SRE owners

--- a/rfcs/0003-native-sip-assistant-phone-resolution.md
+++ b/rfcs/0003-native-sip-assistant-phone-resolution.md
@@ -34,9 +34,9 @@ This contract applies equally when the dialog-forming request represents a direc
 call created after `REFER`, or a replacement/transfer INVITE. Each new SIP dialog resolves its
 own parties from its own dialog-forming request.
 
-This RFC changes only native SIP identity handling and the assistant-authentication UI key.
-Other telephony providers, public APIs, protobuf contracts, and database schemas are
-unchanged.
+This RFC changes only native SIP identity handling and assistant-authentication UI keys.
+Other telephony providers, public APIs, protobuf contracts, and database schemas remain
+compatible. Existing exported Go symbols receive deprecated adapters for at least one release.
 
 ## Status of This Memo
 
@@ -232,7 +232,7 @@ The semantic source of each field is fixed:
 | `fromIdentity` | `request.From().Address.String()` |
 | `toIdentity` | `request.To().Address.String()` |
 
-Equivalent exported boundary fields MUST use these names:
+Canonical exported boundary fields MUST use these names:
 
 ```go
 RequestURI   string
@@ -240,8 +240,30 @@ FromIdentity string
 ToIdentity   string
 ```
 
-New code MUST NOT introduce `FromURI` or `ToURI` fields for these values. Existing ambiguous
-fields MUST be renamed within the native SIP boundary as part of this change.
+New internal code MUST use the canonical fields. Existing exported `FromURI` and `ToURI`
+fields MUST remain as deprecated compatibility aliases for at least one released version.
+Boundary adapters MUST populate them from `FromIdentity` and `ToIdentity`; routing and metadata
+code MUST ignore the deprecated aliases. Their later removal requires a separately approved
+breaking-change RFC.
+
+The exported `ExtractDIDFromURI` function MUST remain as a deprecated compatibility wrapper for
+downstream Go consumers. Native SIP implementation code MUST NOT call it.
+
+Existing exported callback signatures MUST remain available. New identity-aware callbacks MUST
+accept a value object rather than adjacent positional strings:
+
+```go
+type SIPRequestIdentity struct {
+    RequestURI   string
+    FromIdentity string
+    ToIdentity   string
+}
+```
+
+The existing callbacks receive the canonical From and To values through their historical two
+string parameters. Native SIP application wiring MUST use the identity-aware callbacks so it
+also receives RequestURI. Removing the deprecated callbacks requires a separately approved
+breaking-change RFC.
 
 ### Direction-Aware Call Context Mapping
 
@@ -285,10 +307,14 @@ The only supported assistant authentication source is:
 client.assistant_phone
 ```
 
-The authentication UI MUST save `assistant_phone` as the client variable name.
+The authentication UI MUST save canonical snake_case client variable names, including
+`assistant_phone` and `provider_call_id`.
 
-The implementation MUST NOT add a `client.assistantPhone` compatibility alias. Existing
-incorrect configurations must be corrected by their owners.
+The runtime MUST NOT add `client.assistantPhone` or `client.providerCallId` metadata aliases.
+When the authentication UI loads or saves an existing configuration, it MUST normalize
+`assistantPhone` to `assistant_phone` and `providerCallId` to `provider_call_id`. If both legacy
+and canonical keys are present, the canonical key wins. The saved configuration MUST contain
+only canonical keys.
 
 ## Inbound Call Protocol
 
@@ -487,20 +513,20 @@ Replacement INVITE arrives
 | Service or component | Impact | Required update |
 | --- | --- | --- |
 | `assistant-api`: SIP core | Required | Capture distinct RequestURI, FromIdentity, and ToIdentity values from the dialog-forming request. |
-| `assistant-api`: SIP infra | Required | Preserve all three values across core/infra conversions. |
+| `assistant-api`: SIP infra | Required | Preserve all three values across core/infra conversions and retain deprecated exported adapters for one release. |
 | `assistant-api`: SIP middleware | Required | Route using RequestURI and preserve FromIdentity and ToIdentity unchanged. |
 | `assistant-api`: SIP pipeline | Required | Map identities by direction and remove DID extraction or session-URI fallback. |
 | `assistant-api`: SIP transfer | Verification required | Keep existing-leg identities immutable and resolve every new leg independently. |
 | `assistant-api`: telephony metadata | Verification required | Continue emitting values only from call context. |
-| `assistant-api`: authentication | Verification required | Read only canonical `client.assistant_phone`; add no alias. |
-| `ui`: authentication configuration | Required | Save `assistant_phone` instead of `assistantPhone`. |
+| `assistant-api`: authentication | Verification required | Read only canonical snake_case metadata keys; add no runtime aliases. |
+| `ui`: authentication configuration | Required | Save canonical `assistant_phone` and `provider_call_id`; normalize legacy camelCase keys when editing existing configurations. |
 | Non-SIP telephony providers | No implementation change | Preserve current behavior; do not modify provider adapters. |
 | `web-api` | No impact | No route, schema, or authentication contract change. |
 | `integration-api` | No impact | No caller or model-provider change. |
 | `endpoint-api` | No impact | No endpoint runtime contract change. |
 | `document-api` | No impact | No document contract change. |
 | Database and migrations | No impact | Continue using existing conversation metadata storage. |
-| Public protobuf, REST, and SDK contracts | No impact | Preserve all wire fields and names. |
+| Public Go, protobuf, REST, and SDK contracts | Compatibility update | Preserve existing exported Go fields, functions, and callbacks through deprecated adapters; preserve all wire fields and names. |
 
 ### Required File Boundaries
 
@@ -529,7 +555,7 @@ reconfirmed.
 
 ## External and Wire Compatibility
 
-This RFC introduces no SIP wire-format change and no public API change.
+This RFC introduces no SIP wire-format change and no immediate public API removal.
 
 - Incoming SIP headers are consumed as already received.
 - Outgoing SIP construction remains unchanged.
@@ -538,6 +564,10 @@ This RFC introduces no SIP wire-format change and no public API change.
 - REST routes and JSON response shapes remain unchanged.
 - No SDK regeneration is required.
 - No non-SIP provider payload changes are required.
+- Existing `SIPRequestContext.FromURI`, `SIPRequestContext.ToURI`, `ExtractDIDFromURI`, and
+  two-string server callbacks remain callable but are deprecated.
+- Identity-aware server callbacks use `SIPRequestIdentity` so RequestURI, FromIdentity, and
+  ToIdentity cannot be swapped accidentally.
 
 The intentional behavior change is internal representation:
 
@@ -605,6 +635,10 @@ No label or attribute introduced by this RFC may contain an unbounded identity s
 2. Populate them from `request.Recipient`, `request.From().Address`, and
    `request.To().Address` respectively.
 3. Add equivalent exported fields to core/infra request context types.
+4. Populate deprecated exported `FromURI` and `ToURI` aliases at compatibility boundaries only.
+5. Retain `ExtractDIDFromURI` as a deprecated exported wrapper with no native SIP callers.
+6. Preserve existing server callback signatures and add identity-aware callback variants using
+   `SIPRequestIdentity`.
 
 ### Phase 2: Separate Routing
 
@@ -638,8 +672,11 @@ No label or attribute introduced by this RFC may contain an unbounded identity s
 ### Phase 6: Authentication UI
 
 1. Save `assistant_phone` instead of `assistantPhone`.
-2. Add UI regression tests.
-3. Add no runtime compatibility alias.
+2. Save `provider_call_id` instead of `providerCallId`.
+3. Normalize both legacy camelCase keys while loading and before saving existing configurations.
+4. Prefer canonical values and remove legacy keys when both forms exist.
+5. Add UI form-submission and update-path regression tests.
+6. Add no runtime compatibility aliases.
 
 ## Testing and Verification
 
@@ -692,9 +729,13 @@ Required cases:
 
 Required cases:
 
-- Assistant Phone saves `assistant_phone`;
-- the label remains unchanged; and
-- no new configuration saves `assistantPhone`.
+- all client option values match canonical runtime metadata keys;
+- Assistant Phone saves `assistant_phone` through the form submission path;
+- Provider Call ID saves `provider_call_id` through the form submission path;
+- existing `assistantPhone` and `providerCallId` values normalize during the update path;
+- canonical values win if both legacy and canonical forms exist;
+- labels remain unchanged; and
+- no saved configuration contains `assistantPhone` or `providerCallId`.
 
 ### Required Commands
 
@@ -718,7 +759,9 @@ git diff --check
 
 ## Rollout
 
-The implementation is code-only and requires no cross-service migration ordering.
+The implementation is code-only and requires no cross-service migration ordering. Existing
+authentication configurations are migrated opportunistically when loaded and saved through the
+UI; runtime metadata remains canonical-only.
 
 Rollout checks:
 
@@ -766,9 +809,11 @@ From and To identities.
 Rejected. Existing dialogs retain their original identity snapshot. New dialogs resolve new
 snapshots.
 
-### Support `client.assistantPhone`
+### Support Runtime CamelCase Metadata Aliases
 
-Rejected. Only the canonical snake_case metadata contract is supported.
+Rejected. Only the canonical snake_case runtime metadata contract is supported. Compatibility
+is provided by normalizing legacy UI configuration keys during load/save, not by emitting or
+reading duplicate runtime metadata.
 
 ### Update Non-SIP Providers
 
@@ -783,7 +828,8 @@ Rejected for this RFC. Their existing resolution contracts remain unchanged.
 | Routing fallback mutates To identity | Metadata no longer matches the request | Keep routing result separate and test identity immutability. |
 | Transfer code reuses an old call context | New leg receives stale identities | Require a new snapshot for each dialog-forming request and add transfer tests. |
 | Raw identities leak through observability | Sensitive SIP data exposure | Emit presence and origin enums only. |
-| Existing camelCase UI mappings remain invalid | Existing authentication configuration may not resolve | Require explicit configuration correction; add no hidden alias. |
+| Existing camelCase UI mappings remain invalid | Existing authentication configuration may not resolve | Normalize legacy keys on UI load/save, prefer canonical values, and add no runtime alias. |
+| Deprecated exported SIP symbols remain in use | Removal could later break downstream Go consumers | Mark adapters deprecated, keep them for at least one release, and require a separate breaking-change RFC before removal. |
 
 ## Acceptance Criteria
 
@@ -799,13 +845,18 @@ Rejected for this RFC. Their existing resolution contracts remain unchanged.
 10. Reconstruction paths never derive identities from LocalURI or RemoteURI.
 11. Outbound behavior remains unchanged.
 12. Non-SIP provider implementations remain unchanged.
-13. The UI saves only `client.assistant_phone`.
-14. No `client.assistantPhone` alias is added.
-15. No database, protobuf, REST, SDK, provider webhook, or SIP wire-format migration is
+13. The UI saves canonical `client.assistant_phone` and `client.provider_call_id` references.
+14. Existing `assistantPhone` and `providerCallId` configuration keys normalize on UI load/save,
+    with canonical keys taking precedence.
+15. No camelCase runtime metadata alias is added.
+16. Existing exported SIP fields, functions, and callbacks remain available through deprecated
+    adapters for at least one release.
+17. New identity-aware callbacks use `SIPRequestIdentity` rather than positional identity strings.
+18. No database, protobuf, REST, SDK, provider webhook, or SIP wire-format migration is
     introduced.
-16. Required backend and UI tests pass.
-17. Independent review reports no unresolved critical or major findings.
-18. Final RFC bytes receive exact-digest confirmation before implementation begins.
+19. Required backend and UI tests pass.
+20. Independent review reports no unresolved critical or major findings.
+21. Final RFC bytes receive exact-digest confirmation before implementation begins.
 
 ## References
 
@@ -833,5 +884,6 @@ Rejected for this RFC. Their existing resolution contracts remain unchanged.
 | 2026-08-22 | Keep Request-URI routing-only. | Request routing and logical party identity are independent. |
 | 2026-08-22 | Snapshot From and To per dialog-forming request. | Existing dialogs remain stable while new transfer legs resolve independently. |
 | 2026-08-22 | Keep `CallContext` and metadata field names. | Avoid public and persistence migrations while correcting native SIP semantics. |
-| 2026-08-22 | Add no camelCase authentication alias. | The canonical metadata contract remains singular. |
+| 2026-08-22 | Normalize legacy UI authentication keys without runtime aliases. | Existing configurations become valid when edited while runtime metadata remains singular. |
+| 2026-08-22 | Retain deprecated exported SIP adapters for at least one release. | Preserve downstream Go compatibility while moving internal code to explicit identity contracts. |
 | 2026-08-22 | Make no non-SIP provider changes. | This RFC addresses native SIP only. |

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
@@ -330,17 +330,10 @@ jest.mock('@/app/components/carbon/url-table-cell', () => ({
 }));
 
 describe('CreateAssistantAuthenticationPage', () => {
-  it('uses the canonical assistant phone authentication key', () => {
-    expect(
-      AUTH_KEY_OPTIONS_BY_TYPE.client.find(
-        option => option.name === 'Assistant Phone',
-      ),
-    ).toEqual({ value: 'assistant_phone', name: 'Assistant Phone' });
-    expect(
-      AUTH_KEY_OPTIONS_BY_TYPE.client.some(
-        option => option.value === 'assistantPhone',
-      ),
-    ).toBe(false);
+  it('uses canonical client metadata keys', () => {
+    expect(AUTH_KEY_OPTIONS_BY_TYPE.client.map(option => option.value)).toEqual(
+      ['phone', 'assistant_phone', 'direction', 'channel', 'provider_call_id'],
+    );
   });
 
   const makeOption = (key: string, value: string) => ({
@@ -348,7 +341,11 @@ describe('CreateAssistantAuthenticationPage', () => {
     getValue: () => value,
   });
 
-  const getSuccessLoadResponse = (failBehavior = 'BLOCK', enabled = true) => ({
+  const getSuccessLoadResponse = (
+    failBehavior = 'BLOCK',
+    enabled = true,
+    body = '{"assistant.id":"assistantId","client.phone":"clientPhone"}',
+  ) => ({
     getSuccess: () => true,
     getDataList: () => [
       {
@@ -361,10 +358,7 @@ describe('CreateAssistantAuthenticationPage', () => {
           makeOption('http_method', 'POST'),
           makeOption('http_url', 'https://auth.example.com/loaded'),
           makeOption('http_headers', '{}'),
-          makeOption(
-            'http_body',
-            '{"assistant.id":"assistantId","client.phone":"clientPhone"}',
-          ),
+          makeOption('http_body', body),
           makeOption('fail_behavior', failBehavior),
           makeOption('timeout_ms', '5000'),
           makeOption(
@@ -443,6 +437,91 @@ describe('CreateAssistantAuthenticationPage', () => {
 
     expect(screen.getByText(/Mapping \(\d+\)/)).toBeInTheDocument();
     expect(lastField).toHaveValue('assistantPrompt');
+  });
+
+  it('submits canonical assistant and provider call identifiers', async () => {
+    render(<CreateAssistantAuthenticationPage />);
+    await waitUntilReady();
+
+    fireEvent.change(screen.getByTestId('assistant-auth-endpoint'), {
+      target: { value: 'https://auth.example.com/resolve' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add parameter' }));
+    fireEvent.change(screen.getByTestId('param-type-2'), {
+      target: { value: 'client' },
+    });
+    fireEvent.change(screen.getByTestId('param-key-2'), {
+      target: { value: 'assistant_phone' },
+    });
+    fireEvent.change(screen.getByTestId('param-val-2'), {
+      target: { value: 'assistantPhoneValue' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add parameter' }));
+    fireEvent.change(screen.getByTestId('param-type-3'), {
+      target: { value: 'client' },
+    });
+    fireEvent.change(screen.getByTestId('param-key-3'), {
+      target: { value: 'provider_call_id' },
+    });
+    fireEvent.change(screen.getByTestId('param-val-3'), {
+      target: { value: 'providerCallIdValue' },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save authentication' }),
+    );
+
+    await waitFor(() =>
+      expect(CreateAssistantConfiguration).toHaveBeenCalledTimes(1),
+    );
+    const request = (CreateAssistantConfiguration as jest.Mock).mock
+      .calls[0][1] as {
+      optionsList: Array<{ getKey: () => string; getValue: () => string }>;
+    };
+    const bodyOption = request.optionsList.find(
+      option => option.getKey() === 'http_body',
+    );
+    expect(JSON.parse(bodyOption?.getValue() || '{}')).toMatchObject({
+      'client.assistant_phone': 'assistantPhoneValue',
+      'client.provider_call_id': 'providerCallIdValue',
+    });
+  });
+
+  it('normalizes legacy client keys when updating an existing configuration', async () => {
+    (GetAllAssistantConfiguration as jest.Mock).mockResolvedValueOnce(
+      getSuccessLoadResponse(
+        'BLOCK',
+        true,
+        JSON.stringify({
+          'client.assistantPhone': 'legacyAssistant',
+          'client.assistant_phone': 'canonicalAssistant',
+          'client.providerCallId': 'legacyProviderCallId',
+        }),
+      ),
+    );
+
+    render(<UpdateAssistantAuthenticationPage />);
+    await waitUntilReady();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save authentication' }),
+    );
+
+    await waitFor(() =>
+      expect(UpdateAssistantConfiguration).toHaveBeenCalledTimes(1),
+    );
+    const request = (UpdateAssistantConfiguration as jest.Mock).mock
+      .calls[0][1] as {
+      optionsList: Array<{ getKey: () => string; getValue: () => string }>;
+    };
+    const bodyOption = request.optionsList.find(
+      option => option.getKey() === 'http_body',
+    );
+    expect(JSON.parse(bodyOption?.getValue() || '{}')).toEqual({
+      'client.assistant_phone': 'canonicalAssistant',
+      'client.provider_call_id': 'legacyProviderCallId',
+    });
   });
 
   it('creates authentication when valid', async () => {

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx
@@ -13,6 +13,7 @@ import {
   CreateAssistantAuthenticationPage,
   UpdateAssistantAuthenticationPage,
 } from '../index';
+import { AUTH_KEY_OPTIONS_BY_TYPE } from '../shared';
 import {
   CreateAssistantConfiguration,
   DeleteAssistantConfiguration,
@@ -329,6 +330,19 @@ jest.mock('@/app/components/carbon/url-table-cell', () => ({
 }));
 
 describe('CreateAssistantAuthenticationPage', () => {
+  it('uses the canonical assistant phone authentication key', () => {
+    expect(
+      AUTH_KEY_OPTIONS_BY_TYPE.client.find(
+        option => option.name === 'Assistant Phone',
+      ),
+    ).toEqual({ value: 'assistant_phone', name: 'Assistant Phone' });
+    expect(
+      AUTH_KEY_OPTIONS_BY_TYPE.client.some(
+        option => option.value === 'assistantPhone',
+      ),
+    ).toBe(false);
+  });
+
   const makeOption = (key: string, value: string) => ({
     getKey: () => key,
     getValue: () => value,

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/authentication-form.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/authentication-form.tsx
@@ -55,6 +55,7 @@ import {
   FailBehavior,
   fromApiFailBehavior,
   HttpMethod,
+  normalizeAuthenticationBody,
   toApiFailBehavior,
   toOptionMap,
 } from './shared';
@@ -151,7 +152,7 @@ const AuthenticationFormBase: FC<SharedAuthenticationFormProps> = ({
           setHeaders(optionMap[AUTH_OPTION_HEADERS]);
         }
         if (optionMap[AUTH_OPTION_BODY]) {
-          setBody(optionMap[AUTH_OPTION_BODY]);
+          setBody(normalizeAuthenticationBody(optionMap[AUTH_OPTION_BODY]));
         }
         if (optionMap[AUTH_OPTION_FAIL_BEHAVIOR]) {
           setFailBehavior(
@@ -296,7 +297,10 @@ const AuthenticationFormBase: FC<SharedAuthenticationFormProps> = ({
     addOption(AUTH_OPTION_METHOD, method);
     addOption(AUTH_OPTION_ENDPOINT, endpoint.trim());
     addOption(AUTH_OPTION_HEADERS, headers || DEFAULT_HEADERS);
-    addOption(AUTH_OPTION_BODY, body || DEFAULT_BODY);
+    addOption(
+      AUTH_OPTION_BODY,
+      normalizeAuthenticationBody(body || DEFAULT_BODY),
+    );
     addOption(AUTH_OPTION_FAIL_BEHAVIOR, toApiFailBehavior(failBehavior));
     addOption(AUTH_OPTION_TIMEOUT_MS, String(timeout));
     addOption(AUTH_OPTION_CONDITION, JSON.stringify(sourceConditions));

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts
@@ -45,8 +45,8 @@ export const AUTH_KEY_OPTIONS_BY_TYPE = {
     { value: 'phone', name: 'Phone' },
     { value: 'assistant_phone', name: 'Assistant Phone' },
     { value: 'direction', name: 'Direction' },
-    { value: 'provider', name: 'Provider' },
-    { value: 'providerCallId', name: 'Provider Call ID' },
+    { value: 'channel', name: 'Channel' },
+    { value: 'provider_call_id', name: 'Provider Call ID' },
   ],
   conversation: [
     { value: 'messages', name: 'Messages' },
@@ -68,6 +68,35 @@ export const fromApiFailBehavior = (value?: string): FailBehavior => {
 
 export const toApiFailBehavior = (value: FailBehavior): string =>
   value === 'do_nothing' ? FAIL_BEHAVIOR_DO_NOTHING : FAIL_BEHAVIOR_BLOCK;
+
+const LEGACY_CLIENT_KEYS: Record<string, string> = {
+  'client.assistantPhone': 'client.assistant_phone',
+  'client.providerCallId': 'client.provider_call_id',
+};
+
+export const normalizeAuthenticationBody = (value: string): string => {
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return value;
+    }
+
+    const normalized = { ...(parsed as Record<string, unknown>) };
+    Object.entries(LEGACY_CLIENT_KEYS).forEach(([legacyKey, canonicalKey]) => {
+      if (!(canonicalKey in normalized) && legacyKey in normalized) {
+        normalized[canonicalKey] = normalized[legacyKey];
+      }
+      delete normalized[legacyKey];
+    });
+    return JSON.stringify(normalized);
+  } catch {
+    return value;
+  }
+};
 
 export const toOptionMap = (options: Metadata[] = []) =>
   options.reduce(

--- a/ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts
@@ -43,7 +43,7 @@ export const AUTH_KEY_OPTIONS_BY_TYPE = {
   ],
   client: [
     { value: 'phone', name: 'Phone' },
-    { value: 'assistantPhone', name: 'Assistant Phone' },
+    { value: 'assistant_phone', name: 'Assistant Phone' },
     { value: 'direction', name: 'Direction' },
     { value: 'provider', name: 'Provider' },
     { value: 'providerCallId', name: 'Provider Call ID' },


### PR DESCRIPTION
## Summary

Implements accepted RFC 0003 for deterministic native SIP party identity resolution.

- Uses Request-URI only for assistant routing.
- Captures parsed `From` and `To` header addresses as opaque party identities.
- Maps inbound `FromIdentity` to `CallContext.CallerNumber` and `ToIdentity` to `CallContext.FromNumber`.
- Preserves the existing outbound call context as authoritative, with direction-aware defensive reconstruction.
- Removes legacy SIP DID extraction from identity propagation.
- Changes the authentication UI option from `assistantPhone` to canonical `assistant_phone`.
- Does not add phone-number validation, normalization, or a legacy camelCase alias.

## Approved Plan

- Accepted RFC: `rfcs/0003-native-sip-assistant-phone-resolution.md`
- Confirmed SHA-256: `270956bec44694abe0514c27dd8e651a15fc4f74835a8201735d8a2be222d5c7`
- Confirmation: explicitly approved by the requester before implementation.
- In scope: native SIP identity capture, routing separation, propagation, call-context mapping, transfer-safe identity behavior, and the canonical authentication UI key.
- Out of scope: non-SIP provider changes, database/protobuf migrations, public API changes, and unrelated SIP media or registration behavior.
- Rollback: revert implementation commit `9c07734b`; no migration or data rollback is required.

## Implementation

- Added distinct `RequestURI`, `FromIdentity`, and `ToIdentity` fields across native SIP request and session-established boundaries.
- Routed only from `RequestURI`; `FromIdentity` and `ToIdentity` are not routing fallbacks.
- Preserved parsed SIP address strings without DID extraction or normalization.
- Kept established call-context identity as the metadata source of truth.
- Added focused tests for capture, callback propagation, infra conversion, routing separation, direction-aware reconstruction, and UI key selection.

## Verification

Passed:

- `go test ./api/assistant-api/sip/internal/core/...`
- `go test ./api/assistant-api/sip/infra/...`
- `go test ./api/assistant-api/sip/middleware/...`
- `go test ./api/assistant-api/sip/pipeline/...`
- `go test ./api/assistant-api/sip/...`
- `go test ./api/assistant-api/internal/channel/telephony/internal/base/...`
- `yarn --cwd ui test --watchAll=false --runTestsByPath src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx`
- `yarn --cwd ui checkTs` — 175 current diagnostics match the 175-entry baseline; no new diagnostics.
- Targeted ESLint and Prettier checks for the changed UI files.
- `git diff --check`
- Pre-push Go vet and CI binary build.

Commit-hook note:

- The changed-package security hook was skipped for the implementation commit because it reports six pre-existing findings in unrelated SIP files and an unrelated RNNoise typecheck environment failure. Targeted tests and the pre-push vet/build checks passed.
- The generic telephony integration scope validator targets provider directories and flags the approved native `api/assistant-api/sip/**` boundary plus the approved UI key files; no files outside the RFC-approved scope were changed.

## Independent Code Review

- Reviewer: Pending
- Decision: Pending
- Critical findings: Pending
- Major findings: Pending
- The PR remains draft until an independent reviewer approves the complete diff.

## Checklist

- [x] Exact RFC bytes accepted before implementation.
- [x] Confirmed RFC digest preserved after implementation.
- [x] Implementation stays within approved scope.
- [x] Backend and UI regression tests added.
- [x] Required validation commands passed.
- [ ] Independent code reviewer approved the complete diff.
- [ ] Critical and major review findings are resolved.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates SIP routing identity from caller and callee identities, then propagates those values through inbound handling, session setup, call-context reconstruction, and runtime initialization.

- Routes inbound calls exclusively from the Request-URI.
- Preserves parsed From and To addresses as opaque party identities.
- Reconstructs missing call context according to call direction while retaining existing outbound context.
- Migrates the authentication UI option to `assistant_phone` and normalizes legacy configurations when edited.
- Adds focused backend, integration, pipeline, transfer, and UI regression tests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking defects identified.

The changed paths consistently separate routing from party identity, preserve authoritative outbound context, reconstruct missing context according to direction, and normalize the renamed UI key on both read and write.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/assistant-api/sip/internal/core/inbound_call.go | Captures Request-URI and parsed From/To addresses independently and preserves the initial dialog identities through callbacks. |
| api/assistant-api/sip/middleware/route_middleware.go | Restricts assistant routing to the Request-URI and removes From/To identity fallback behavior. |
| api/assistant-api/sip/pipeline/session.go | Maps inbound and outbound SIP identities into CallContext fields according to direction while preserving authoritative outbound context. |
| api/assistant-api/sip/pipeline/runtime.go | Carries the session identity stage into runtime preparation and defensively reconstructs missing call context. |
| api/assistant-api/sip/sip.go | Propagates the explicit SIP identity triple across application-ready and session-established boundaries. |
| ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts | Defines the canonical assistant-phone key and normalizes legacy camelCase authentication body entries. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Peer as SIP Peer
    participant Core as SIP Core
    participant Route as Route Middleware
    participant Engine as SIP Engine
    participant Pipeline as Call Pipeline
    participant Context as CallContext Store

    Peer->>Core: INVITE(Request-URI, From, To)
    Core->>Core: Capture RequestURI, FromIdentity, ToIdentity
    Core->>Route: SIPRequestContext
    Route->>Route: Resolve assistant from RequestURI only
    Route-->>Core: Assistant, auth, SIP config
    Core->>Engine: Session established + identity triple
    Engine->>Pipeline: SessionEstablishedPipeline
    Pipeline->>Context: Preserve or reconstruct context by direction
    Context-->>Pipeline: CallerNumber and FromNumber
    Pipeline->>Pipeline: Prepare and start call runtime
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve SIP API compatibility"](https://github.com/rapidaai/voice-ai/commit/98db92ef6a7d07547abd927c2b9bed704db80df0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55869606)</sub>

<!-- /greptile_comment -->