### PR TITLE
refactor: simplify SIP request and session ownership

### DIFF
--- a/api/assistant-api/sip/infra/common_type.go
+++ b/api/assistant-api/sip/infra/common_type.go
@@ -473,9 +473,3 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 	config := configFromCore(coreConfig)
 	return &config, nil
 }
-
-// ExtractDIDFromURI is retained for downstream compatibility.
-// Deprecated: native SIP identity handling preserves parsed SIP addresses.
-func ExtractDIDFromURI(uri string) string {
-	return internal_core.ExtractDIDFromURI(uri)
-}

--- a/api/assistant-api/sip/infra/facade_test.go
+++ b/api/assistant-api/sip/infra/facade_test.go
@@ -35,18 +35,18 @@ func TestDefaultSDPConfigUsesCurrentCoreShape(t *testing.T) {
 }
 
 func TestSessionFacadeConvertsPhaseAndCodec(t *testing.T) {
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config: &Config{
+	session, err := NewSession(context.Background(),
+		WithSessionConfig(&Config{
 			Server:            "sip.example.com",
 			Port:              5060,
 			Transport:         TransportUDP,
 			RTPPortRangeStart: 30000,
 			RTPPortRangeEnd:   30100,
-		},
-		Direction: CallDirectionInbound,
-		CallID:    "facade-call",
-		Codec:     &CodecPCMA,
-	})
+		}),
+		WithSessionDirection(CallDirectionInbound),
+		WithSessionCallID("facade-call"),
+		WithSessionCodec(&CodecPCMA),
+	)
 	if err != nil {
 		t.Fatalf("expected session facade to create core-backed session: %v", err)
 	}

--- a/api/assistant-api/sip/infra/pipeline_type.go
+++ b/api/assistant-api/sip/infra/pipeline_type.go
@@ -24,9 +24,12 @@ type SessionEstablishedPipeline struct {
 	AssistantID     uint64
 	Auth            *types.Authentication
 	RequestURI      string
-	FromIdentity    string
-	ToIdentity      string
-	ConversationID  uint64
+	CallAddress     CallAddress
+	// Deprecated: derived from CallAddress.From. Do not write.
+	FromIdentity string
+	// Deprecated: derived from CallAddress.To. Do not write.
+	ToIdentity     string
+	ConversationID uint64
 }
 
 func (p SessionEstablishedPipeline) CallID() string { return p.ID }

--- a/api/assistant-api/sip/infra/server.go
+++ b/api/assistant-api/sip/infra/server.go
@@ -46,10 +46,11 @@ func (s *Server) SetMiddlewares(middlewares []Middleware) {
 				Method:          ctx.Method,
 				CallID:          ctx.CallID,
 				RequestURI:      ctx.RequestURI,
-				FromIdentity:    ctx.FromIdentity,
-				ToIdentity:      ctx.ToIdentity,
-				FromURI:         ctx.FromIdentity,
-				ToURI:           ctx.ToIdentity,
+				FromIdentity:    ctx.CallAddress.FromURI,
+				ToIdentity:      ctx.CallAddress.ToURI,
+				FromURI:         ctx.CallAddress.FromURI,
+				ToURI:           ctx.CallAddress.ToURI,
+				CallAddress:     ctx.CallAddress,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,
@@ -114,8 +115,8 @@ func (s *Server) SetOnApplicationReady(fn func(session *Session, fromURI, toURI 
 		s.inner.SetOnApplicationReady(nil)
 		return
 	}
-	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
-		return fn(wrapSession(session), fromIdentity, toIdentity)
+	s.inner.SetOnApplicationReady(func(session *internal_core.Session, _ string, callAddress internal_core.CallAddress) error {
+		return fn(wrapSession(session), callAddress.FromURI, callAddress.ToURI)
 	})
 }
 
@@ -125,11 +126,12 @@ func (s *Server) SetOnApplicationReadyIdentity(fn func(session *Session, identit
 		s.inner.SetOnApplicationReady(nil)
 		return
 	}
-	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+	s.inner.SetOnApplicationReady(func(session *internal_core.Session, requestURI string, callAddress internal_core.CallAddress) error {
 		return fn(wrapSession(session), SIPRequestIdentity{
 			RequestURI:   requestURI,
-			FromIdentity: fromIdentity,
-			ToIdentity:   toIdentity,
+			CallAddress:  callAddress,
+			FromIdentity: callAddress.FromURI,
+			ToIdentity:   callAddress.ToURI,
 		})
 	})
 }
@@ -151,8 +153,8 @@ func (s *Server) SetOnInvite(fn func(session *Session, fromURI, toURI string) er
 		s.inner.SetOnInvite(nil)
 		return
 	}
-	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
-		return fn(wrapSession(session), fromIdentity, toIdentity)
+	s.inner.SetOnInvite(func(session *internal_core.Session, _ string, callAddress internal_core.CallAddress) error {
+		return fn(wrapSession(session), callAddress.FromURI, callAddress.ToURI)
 	})
 }
 
@@ -162,11 +164,12 @@ func (s *Server) SetOnInviteIdentity(fn func(session *Session, identity SIPReque
 		s.inner.SetOnInvite(nil)
 		return
 	}
-	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI, fromIdentity, toIdentity string) error {
+	s.inner.SetOnInvite(func(session *internal_core.Session, requestURI string, callAddress internal_core.CallAddress) error {
 		return fn(wrapSession(session), SIPRequestIdentity{
 			RequestURI:   requestURI,
-			FromIdentity: fromIdentity,
-			ToIdentity:   toIdentity,
+			CallAddress:  callAddress,
+			FromIdentity: callAddress.FromURI,
+			ToIdentity:   callAddress.ToURI,
 		})
 	})
 }

--- a/api/assistant-api/sip/infra/server_type.go
+++ b/api/assistant-api/sip/infra/server_type.go
@@ -24,15 +24,20 @@ const (
 	ServerStateStopped
 )
 
+type CallAddress = internal_core.CallAddress
+
 type SIPRequestContext struct {
-	Method       string
-	CallID       string
-	RequestURI   string
+	Method      string
+	CallID      string
+	RequestURI  string
+	CallAddress CallAddress
+	// Deprecated: derived from CallAddress.FromURI. Do not write.
 	FromIdentity string
-	ToIdentity   string
-	// Deprecated: use FromIdentity.
+	// Deprecated: derived from CallAddress.ToURI. Do not write.
+	ToIdentity string
+	// Deprecated: derived from CallAddress.FromURI. Do not write.
 	FromURI string
-	// Deprecated: use ToIdentity.
+	// Deprecated: derived from CallAddress.ToURI. Do not write.
 	ToURI           string
 	APIKey          string
 	AssistantID     string
@@ -44,9 +49,12 @@ type SIPRequestContext struct {
 }
 
 type SIPRequestIdentity struct {
-	RequestURI   string
+	RequestURI  string
+	CallAddress CallAddress
+	// Deprecated: derived from CallAddress.FromURI. Do not write.
 	FromIdentity string
-	ToIdentity   string
+	// Deprecated: derived from CallAddress.ToURI. Do not write.
+	ToIdentity string
 }
 
 type Middleware func(ctx *SIPRequestContext) error
@@ -144,10 +152,11 @@ func (c *ServerConfig) toCore() *internal_core.ServerConfig {
 				Method:          ctx.Method,
 				CallID:          ctx.CallID,
 				RequestURI:      ctx.RequestURI,
-				FromIdentity:    ctx.FromIdentity,
-				ToIdentity:      ctx.ToIdentity,
-				FromURI:         ctx.FromIdentity,
-				ToURI:           ctx.ToIdentity,
+				FromIdentity:    ctx.CallAddress.FromURI,
+				ToIdentity:      ctx.CallAddress.ToURI,
+				FromURI:         ctx.CallAddress.FromURI,
+				ToURI:           ctx.CallAddress.ToURI,
+				CallAddress:     ctx.CallAddress,
 				SDPInfo:         sdpInfoFromCore(ctx.SDPInfo),
 				APIKey:          ctx.APIKey,
 				AssistantID:     ctx.AssistantID,

--- a/api/assistant-api/sip/infra/session.go
+++ b/api/assistant-api/sip/infra/session.go
@@ -16,8 +16,8 @@ import (
 	"github.com/rapidaai/protos"
 )
 
-func NewSession(ctx context.Context, cfg *SessionConfig) (*Session, error) {
-	inner, err := internal_core.NewSession(ctx, cfg.toCore())
+func NewSession(ctx context.Context, opts ...SessionOption) (*Session, error) {
+	inner, err := internal_core.NewSession(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/assistant-api/sip/infra/session_type.go
+++ b/api/assistant-api/sip/infra/session_type.go
@@ -9,40 +9,46 @@ package sip_infra
 import (
 	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_core "github.com/rapidaai/api/assistant-api/sip/internal/core"
-	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
 	"github.com/rapidaai/protos"
 )
 
-type SessionConfig struct {
-	Config          *Config
-	Direction       CallDirection
-	CallID          string
-	Codec           *Codec
-	Logger          commons.Logger
-	Auth            *types.Authentication
-	Assistant       *internal_assistant_entity.Assistant
-	ConversationID  uint64
-	ContextID       string
-	VaultCredential *protos.VaultCredential
+type SessionOption = internal_core.SessionOption
+
+func WithSessionConfig(config *Config) SessionOption {
+	return internal_core.WithSessionConfig(config.toCore())
 }
 
-func (cfg *SessionConfig) toCore() *internal_core.SessionConfig {
-	if cfg == nil {
-		return nil
-	}
-	return &internal_core.SessionConfig{
-		Config:          cfg.Config.toCore(),
-		Direction:       cfg.Direction.toCore(),
-		CallID:          cfg.CallID,
-		Codec:           cfg.Codec.toCore(),
-		Logger:          cfg.Logger,
-		Auth:            cfg.Auth,
-		Assistant:       cfg.Assistant,
-		ConversationID:  cfg.ConversationID,
-		ContextID:       cfg.ContextID,
-		VaultCredential: cfg.VaultCredential,
-	}
+func WithSessionDirection(direction CallDirection) SessionOption {
+	return internal_core.WithSessionDirection(direction.toCore())
+}
+
+func WithSessionCallID(callID string) SessionOption {
+	return internal_core.WithSessionCallID(callID)
+}
+
+func WithSessionCodec(codec *Codec) SessionOption {
+	return internal_core.WithSessionCodec(codec.toCore())
+}
+
+func WithSessionAuth(auth *types.Authentication) SessionOption {
+	return internal_core.WithSessionAuth(auth)
+}
+
+func WithSessionAssistant(assistant *internal_assistant_entity.Assistant) SessionOption {
+	return internal_core.WithSessionAssistant(assistant)
+}
+
+func WithSessionConversationID(conversationID uint64) SessionOption {
+	return internal_core.WithSessionConversationID(conversationID)
+}
+
+func WithSessionContextID(contextID string) SessionOption {
+	return internal_core.WithSessionContextID(contextID)
+}
+
+func WithSessionVaultCredential(vaultCredential *protos.VaultCredential) SessionOption {
+	return internal_core.WithSessionVaultCredential(vaultCredential)
 }
 
 type Session struct {

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -290,8 +290,6 @@ func TestDeprecatedSIPCompatibilitySurface(t *testing.T) {
 	var _ func(*Server, func(*Session, string, string) error) = (*Server).SetOnInvite
 	var _ func(*Server, func(*Session, SIPRequestIdentity) error) = (*Server).SetOnApplicationReadyIdentity
 	var _ func(*Server, func(*Session, SIPRequestIdentity) error) = (*Server).SetOnInviteIdentity
-
-	assert.Equal(t, "+15551234567", ExtractDIDFromURI("sip:15551234567@example.com"))
 }
 
 func TestSIPRequestContextMiddleware(t *testing.T) {

--- a/api/assistant-api/sip/infra/type_facade_test.go
+++ b/api/assistant-api/sip/infra/type_facade_test.go
@@ -263,19 +263,25 @@ func TestServerConfigMiddlewareConversionPreservesSIPIdentities(t *testing.T) {
 	require.Len(t, serverConfig.Middlewares, 1)
 
 	coreContext := &internal_core.SIPRequestContext{
-		RequestURI:   "sip:agent-42@sip.rapida.ai",
-		FromIdentity: "sip:alice@example.com;user=phone",
-		ToIdentity:   "sips:support@example.net",
+		RequestURI: "sip:agent-42@sip.rapida.ai",
+		CallAddress: internal_core.CallAddress{
+			From:    "+14155550100",
+			To:      "agent-42",
+			FromURI: "sip:+14155550100@carrier.example.com",
+			ToURI:   "sip:agent-42@sip.rapida.ai",
+			Headers: map[string]string{"x-original-called-number": "+14155550200"},
+		},
 	}
 	err := serverConfig.Middlewares[0](coreContext)
 
 	require.NoError(t, err)
 	require.NotNil(t, received)
 	assert.Equal(t, "sip:agent-42@sip.rapida.ai", received.RequestURI)
-	assert.Equal(t, "sip:alice@example.com;user=phone", received.FromIdentity)
-	assert.Equal(t, "sips:support@example.net", received.ToIdentity)
-	assert.Equal(t, "sip:alice@example.com;user=phone", received.FromURI)
-	assert.Equal(t, "sips:support@example.net", received.ToURI)
+	assert.Equal(t, coreContext.CallAddress.FromURI, received.FromIdentity)
+	assert.Equal(t, coreContext.CallAddress.ToURI, received.ToIdentity)
+	assert.Equal(t, coreContext.CallAddress.FromURI, received.FromURI)
+	assert.Equal(t, coreContext.CallAddress.ToURI, received.ToURI)
+	assert.Equal(t, coreContext.CallAddress, received.CallAddress)
 	assert.Equal(t, "42", coreContext.AssistantID)
 }
 
@@ -290,9 +296,13 @@ func TestDeprecatedSIPCompatibilitySurface(t *testing.T) {
 
 func TestSIPRequestContextMiddleware(t *testing.T) {
 	requestContext := &SIPRequestContext{
-		RequestURI:   "sip:agent-42@sip.rapida.ai",
-		FromIdentity: "sip:alice@example.com",
-		ToIdentity:   "sip:support@example.net",
+		RequestURI: "sip:agent-42@sip.rapida.ai",
+		CallAddress: CallAddress{
+			From:    "alice",
+			To:      "support",
+			FromURI: "sip:alice@example.com",
+			ToURI:   "sip:support@example.net",
+		},
 	}
 
 	var order []string
@@ -321,8 +331,8 @@ func TestSIPRequestContextMiddleware(t *testing.T) {
 		t.Fatalf("unexpected middleware context: %#v", requestContext)
 	}
 	if requestContext.RequestURI != "sip:agent-42@sip.rapida.ai" ||
-		requestContext.FromIdentity != "sip:alice@example.com" ||
-		requestContext.ToIdentity != "sip:support@example.net" {
+		requestContext.CallAddress.FromURI != "sip:alice@example.com" ||
+		requestContext.CallAddress.ToURI != "sip:support@example.net" {
 		t.Fatalf("middleware changed SIP identities: %#v", requestContext)
 	}
 	expectedOrder := []string{"first", "second", "final"}

--- a/api/assistant-api/sip/internal/core/bridge_test.go
+++ b/api/assistant-api/sip/internal/core/bridge_test.go
@@ -68,12 +68,11 @@ func bridgeTestConfig() *Config {
 // newBridgeTestSession creates a session with an in-memory RTP handler attached.
 func newBridgeTestSession(t *testing.T, direction CallDirection, codec *Codec) (*Session, *RTPHandler) {
 	t.Helper()
-	s, err := NewSession(context.Background(), &SessionConfig{
-		Config:    bridgeTestConfig(),
-		Direction: direction,
-		Codec:     codec,
-		Logger:    bridgeTestLogger(),
-	})
+	s, err := NewSession(context.Background(),
+		WithSessionConfig(bridgeTestConfig()),
+		WithSessionDirection(direction),
+		WithSessionCodec(codec),
+	)
 	require.NoError(t, err)
 	s.SetState(CallStateConnected)
 	rtp := newTestRTPHandler()

--- a/api/assistant-api/sip/internal/core/inbound_call.go
+++ b/api/assistant-api/sip/internal/core/inbound_call.go
@@ -85,15 +85,15 @@ func newInboundSession(
 	setupPhase InboundSetupPhase,
 	setupTimings InboundSetupTimings,
 ) (*Session, *inboundFailure) {
-	session, err := NewSession(ctx, &SessionConfig{
-		Config:          resolvedConfig.config,
-		Direction:       CallDirectionInbound,
-		CallID:          identity.callID,
-		Codec:           mediaOffer.negotiatedCodec,
-		Auth:            resolvedConfig.auth,
-		Assistant:       resolvedConfig.assistant,
-		VaultCredential: resolvedConfig.vaultCredential,
-	})
+	session, err := NewSession(ctx,
+		WithSessionConfig(resolvedConfig.config),
+		WithSessionDirection(CallDirectionInbound),
+		WithSessionCallID(identity.callID),
+		WithSessionCodec(mediaOffer.negotiatedCodec),
+		WithSessionAuth(resolvedConfig.auth),
+		WithSessionAssistant(resolvedConfig.assistant),
+		WithSessionVaultCredential(resolvedConfig.vaultCredential),
+	)
 	if err != nil {
 		sessionErr := fmt.Errorf("failed to create inbound session: %w", err)
 		failure := newInboundSessionFailure(sessionErr)

--- a/api/assistant-api/sip/internal/core/inbound_call.go
+++ b/api/assistant-api/sip/internal/core/inbound_call.go
@@ -18,11 +18,10 @@ import (
 )
 
 type inboundInviteIdentity struct {
-	callID       string
-	fromTag      string
-	requestURI   string
-	fromIdentity string
-	toIdentity   string
+	callID      string
+	fromTag     string
+	requestURI  string
+	callAddress CallAddress
 }
 
 // Inbound owns the lifecycle for a single inbound SIP INVITE.
@@ -66,13 +65,13 @@ func inboundInviteIdentityFromRequest(request *sip.Request) (inboundInviteIdenti
 	if !ok || fromTag == "" {
 		return inboundInviteIdentity{}, false
 	}
+	callAddress := NewCallAddress(request)
 
 	return inboundInviteIdentity{
-		callID:       request.CallID().Value(),
-		fromTag:      fromTag,
-		requestURI:   request.Recipient.String(),
-		fromIdentity: request.From().Address.String(),
-		toIdentity:   request.To().Address.String(),
+		callID:      request.CallID().Value(),
+		fromTag:     fromTag,
+		requestURI:  request.Recipient.String(),
+		callAddress: callAddress,
 	}, true
 }
 
@@ -328,8 +327,7 @@ func (inboundCall *Inbound) callInboundApplicationReadyHandler() error {
 	return applicationReadyHandler(
 		inboundCall.session,
 		inboundCall.identity.requestURI,
-		inboundCall.identity.fromIdentity,
-		inboundCall.identity.toIdentity,
+		inboundCall.identity.callAddress,
 	)
 }
 
@@ -438,8 +436,7 @@ func (inboundCall *Inbound) callInboundInviteHandler() error {
 	return inviteHandler(
 		inboundCall.session,
 		inboundCall.identity.requestURI,
-		inboundCall.identity.fromIdentity,
-		inboundCall.identity.toIdentity,
+		inboundCall.identity.callAddress,
 	)
 }
 

--- a/api/assistant-api/sip/internal/core/inbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/inbound_call_test.go
@@ -1173,15 +1173,15 @@ func loadInboundMediaOffer(t *testing.T, inboundCall *Inbound) {
 
 func createInboundSessionForTest(t *testing.T, inboundCall *Inbound) {
 	t.Helper()
-	session, err := NewSession(inboundCall.server.ctx, &SessionConfig{
-		Config:          inboundCall.resolvedConfig.config,
-		Direction:       CallDirectionInbound,
-		CallID:          inboundCall.identity.callID,
-		Codec:           inboundCall.mediaOffer.negotiatedCodec,
-		Auth:            inboundCall.resolvedConfig.auth,
-		Assistant:       inboundCall.resolvedConfig.assistant,
-		VaultCredential: inboundCall.resolvedConfig.vaultCredential,
-	})
+	session, err := NewSession(inboundCall.server.ctx,
+		WithSessionConfig(inboundCall.resolvedConfig.config),
+		WithSessionDirection(CallDirectionInbound),
+		WithSessionCallID(inboundCall.identity.callID),
+		WithSessionCodec(inboundCall.mediaOffer.negotiatedCodec),
+		WithSessionAuth(inboundCall.resolvedConfig.auth),
+		WithSessionAssistant(inboundCall.resolvedConfig.assistant),
+		WithSessionVaultCredential(inboundCall.resolvedConfig.vaultCredential),
+	)
 	require.NoError(t, err)
 	inboundCall.session = session
 }

--- a/api/assistant-api/sip/internal/core/inbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/inbound_call_test.go
@@ -87,8 +87,32 @@ func TestInboundInviteIdentityFromRequestPreservesRoutingAndPartyIdentities(t *t
 
 	require.True(t, ok)
 	assert.Equal(t, request.Recipient.String(), identity.requestURI)
-	assert.Equal(t, request.From().Address.String(), identity.fromIdentity)
-	assert.Equal(t, request.To().Address.String(), identity.toIdentity)
+	assert.Equal(t, "alice", identity.callAddress.From)
+	assert.Equal(t, "support", identity.callAddress.To)
+	assert.Equal(t, request.From().Address.String(), identity.callAddress.FromURI)
+	assert.Equal(t, request.To().Address.String(), identity.callAddress.ToURI)
+}
+
+func TestNewCallAddressCapturesHeadersWithoutCredentials(t *testing.T) {
+	request := newInboundInviteRequest("identity-headers")
+	request.AppendHeader(sip.NewHeader("X-Original-Called-Number", "+14155550200"))
+	request.AppendHeader(sip.NewHeader("X-Original-Called-Number", "+14155550300"))
+	request.AppendHeader(sip.NewHeader("Authorization", "secret"))
+	request.AppendHeader(sip.NewHeader("Proxy-Authorization", "proxy-secret"))
+
+	address := NewCallAddress(request)
+
+	assert.Equal(t, request.From().Address.User, address.From)
+	assert.Equal(t, request.To().Address.User, address.To)
+	assert.Equal(t, request.From().Address.String(), address.FromURI)
+	assert.Equal(t, request.To().Address.String(), address.ToURI)
+	assert.Equal(t, "+14155550200,+14155550300", address.Headers["x-original-called-number"])
+	assert.NotContains(t, address.Headers, "authorization")
+	assert.NotContains(t, address.Headers, "proxy-authorization")
+}
+
+func TestNewCallAddressHandlesNilRequest(t *testing.T) {
+	assert.Equal(t, CallAddress{}, NewCallAddress(nil))
 }
 
 func TestInboundCall_ConfigRejectDoesNotCreateSession(t *testing.T) {
@@ -452,23 +476,20 @@ func TestInboundCall_ApplicationReadyBeforeAnswerAndMediaStart(t *testing.T) {
 	transaction := newActiveAckableTestServerTx()
 	request := newInboundInviteRequest("inbound-ready-before-answer")
 	expectedRequestURI := request.Recipient.String()
-	expectedFromIdentity := request.From().Address.String()
-	expectedToIdentity := request.To().Address.String()
-	server.SetOnApplicationReady(func(session *Session, requestURI, fromIdentity, toIdentity string) error {
+	expectedCallAddress := NewCallAddress(request)
+	server.SetOnApplicationReady(func(session *Session, requestURI string, callAddress CallAddress) error {
 		phaseOrder = append(phaseOrder, "application_ready")
 		assert.Equal(t, 180, transaction.lastStatus())
 		assert.Equal(t, InboundSetupPhaseMediaAllocated, session.GetInboundSetupPhase())
 		assert.Equal(t, expectedRequestURI, requestURI)
-		assert.Equal(t, expectedFromIdentity, fromIdentity)
-		assert.Equal(t, expectedToIdentity, toIdentity)
+		assert.Equal(t, expectedCallAddress, callAddress)
 		return nil
 	})
-	server.SetOnInvite(func(session *Session, requestURI, fromIdentity, toIdentity string) error {
+	server.SetOnInvite(func(session *Session, requestURI string, callAddress CallAddress) error {
 		phaseOrder = append(phaseOrder, "call_start")
 		assert.Equal(t, InboundSetupPhaseMediaFlowing, session.GetInboundSetupPhase())
 		assert.Equal(t, expectedRequestURI, requestURI)
-		assert.Equal(t, expectedFromIdentity, fromIdentity)
-		assert.Equal(t, expectedToIdentity, toIdentity)
+		assert.Equal(t, expectedCallAddress, callAddress)
 		return nil
 	})
 	transaction.PushACK(newACKRequest("inbound-ready-before-answer"))
@@ -493,10 +514,10 @@ func TestInboundCall_ReInviteDoesNotReplaceInitialPartyIdentities(t *testing.T) 
 	callbackCount := 0
 	var capturedFromIdentity string
 	var capturedToIdentity string
-	server.SetOnInvite(func(_ *Session, _, fromIdentity, toIdentity string) error {
+	server.SetOnInvite(func(_ *Session, _ string, callAddress CallAddress) error {
 		callbackCount++
-		capturedFromIdentity = fromIdentity
-		capturedToIdentity = toIdentity
+		capturedFromIdentity = callAddress.FromURI
+		capturedToIdentity = callAddress.ToURI
 		return nil
 	})
 
@@ -536,11 +557,11 @@ func TestInboundCall_InviteWithReplacesUsesNewDialogPartyIdentities(t *testing.T
 	var capturedRequestURI string
 	var capturedFromIdentity string
 	var capturedToIdentity string
-	server.SetOnInvite(func(_ *Session, requestURI, fromIdentity, toIdentity string) error {
+	server.SetOnInvite(func(_ *Session, requestURI string, callAddress CallAddress) error {
 		callbackCount++
 		capturedRequestURI = requestURI
-		capturedFromIdentity = fromIdentity
-		capturedToIdentity = toIdentity
+		capturedFromIdentity = callAddress.FromURI
+		capturedToIdentity = callAddress.ToURI
 		return nil
 	})
 
@@ -574,10 +595,10 @@ func TestInboundCall_REFERDoesNotReplaceInitialPartyIdentities(t *testing.T) {
 	callbackCount := 0
 	var capturedFromIdentity string
 	var capturedToIdentity string
-	server.SetOnInvite(func(_ *Session, _, fromIdentity, toIdentity string) error {
+	server.SetOnInvite(func(_ *Session, _ string, callAddress CallAddress) error {
 		callbackCount++
-		capturedFromIdentity = fromIdentity
-		capturedToIdentity = toIdentity
+		capturedFromIdentity = callAddress.FromURI
+		capturedToIdentity = callAddress.ToURI
 		return nil
 	})
 
@@ -662,7 +683,7 @@ func TestInboundCall_RetransmitsRingingUntilAnswer(t *testing.T) {
 		return nil
 	}})
 	applicationReady := make(chan struct{})
-	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _ string, _ CallAddress) error {
 		<-applicationReady
 		return nil
 	})
@@ -700,7 +721,7 @@ func TestInboundCall_WaitsForApplicationReadyBeforeAnswer(t *testing.T) {
 		return nil
 	}})
 	applicationReady := make(chan struct{})
-	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _ string, _ CallAddress) error {
 		<-applicationReady
 		return nil
 	})
@@ -778,7 +799,7 @@ func TestInboundCall_AnswersAfterApplicationReadyWithoutAssistantAudio(t *testin
 		return nil
 	}})
 	applicationReadyCalled := false
-	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _ string, _ CallAddress) error {
 		applicationReadyCalled = true
 		return nil
 	})
@@ -853,10 +874,10 @@ func TestInboundCall_ApplicationReadinessFailureRejectsBeforeAnswer(t *testing.T
 		ctx.Config = bridgeTestConfig()
 		return nil
 	}})
-	server.SetOnApplicationReady(func(_ *Session, _, _, _ string) error {
+	server.SetOnApplicationReady(func(_ *Session, _ string, _ CallAddress) error {
 		return errors.New("assistant not ready")
 	})
-	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
+	server.SetOnInvite(func(_ *Session, _ string, _ CallAddress) error {
 		t.Fatal("onInvite should not run when application readiness fails")
 		return nil
 	})
@@ -883,14 +904,14 @@ func TestInboundCall_ACKTimeoutCleansPreparedApplication(t *testing.T) {
 	}})
 	cleanupCount := 0
 	var capturedSession *Session
-	server.SetOnApplicationReady(func(session *Session, _, _, _ string) error {
+	server.SetOnApplicationReady(func(session *Session, _ string, _ CallAddress) error {
 		capturedSession = session
 		return nil
 	})
 	server.SetOnApplicationCleanup(func(_ *Session) {
 		cleanupCount++
 	})
-	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
+	server.SetOnInvite(func(_ *Session, _ string, _ CallAddress) error {
 		t.Fatal("onInvite should not run when ACK timeout fails")
 		return nil
 	})
@@ -1129,11 +1150,10 @@ func loadInboundIdentity(t *testing.T, inboundCall *Inbound) {
 	require.NotNil(t, inboundCall.request.From())
 	require.NotNil(t, inboundCall.request.To())
 	inboundCall.identity = inboundInviteIdentity{
-		callID:       inboundCall.request.CallID().Value(),
-		fromTag:      "fromtag",
-		requestURI:   inboundCall.request.Recipient.String(),
-		fromIdentity: inboundCall.request.From().Address.String(),
-		toIdentity:   inboundCall.request.To().Address.String(),
+		callID:      inboundCall.request.CallID().Value(),
+		fromTag:     "fromtag",
+		requestURI:  inboundCall.request.Recipient.String(),
+		callAddress: NewCallAddress(inboundCall.request),
 	}
 	inboundCall.inviteKey = inboundInviteKey{callID: inboundCall.identity.callID, fromTag: inboundCall.identity.fromTag}
 }

--- a/api/assistant-api/sip/internal/core/inbound_config.go
+++ b/api/assistant-api/sip/internal/core/inbound_config.go
@@ -47,12 +47,11 @@ func NewInboundConfig(server *Server, identity inboundInviteIdentity, mediaOffer
 	}
 
 	requestContext := &SIPRequestContext{
-		Method:       "INVITE",
-		CallID:       identity.callID,
-		RequestURI:   identity.requestURI,
-		FromIdentity: identity.fromIdentity,
-		ToIdentity:   identity.toIdentity,
-		SDPInfo:      mediaOffer.sdpInfo,
+		Method:      "INVITE",
+		CallID:      identity.callID,
+		RequestURI:  identity.requestURI,
+		CallAddress: identity.callAddress,
+		SDPInfo:     mediaOffer.sdpInfo,
 	}
 	for _, middleware := range middlewares {
 		if err := middleware(requestContext); err != nil {

--- a/api/assistant-api/sip/internal/core/inbound_rejected_invite.go
+++ b/api/assistant-api/sip/internal/core/inbound_rejected_invite.go
@@ -72,14 +72,14 @@ func (s *Server) recordRejectedInboundInvite(request *sip.Request, response *sip
 	if s.rejectedInvites == nil {
 		s.rejectedInvites = make(map[inboundInviteKey]inboundRejectedInvite)
 	}
-	if len(s.rejectedInvites) >= maxInboundRejectedInvites {
+	if len(s.rejectedInvites) >= MaxInboundRejectedInvites {
 		s.pruneRejectedInboundInvitesLocked(now)
 	}
 	s.rejectedInvites[key] = inboundRejectedInvite{
 		statusCode:     response.StatusCode,
 		reason:         response.Reason,
 		includeContact: response.Contact() != nil,
-		expiresAt:      now.Add(inboundRejectedInviteTTL),
+		expiresAt:      now.Add(InboundRejectedInviteTTL),
 	}
 	s.mu.Unlock()
 }
@@ -90,12 +90,12 @@ func (s *Server) pruneRejectedInboundInvitesLocked(now time.Time) {
 			delete(s.rejectedInvites, key)
 		}
 	}
-	if len(s.rejectedInvites) < maxInboundRejectedInvites {
+	if len(s.rejectedInvites) < MaxInboundRejectedInvites {
 		return
 	}
 	for key := range s.rejectedInvites {
 		delete(s.rejectedInvites, key)
-		if len(s.rejectedInvites) < maxInboundRejectedInvites {
+		if len(s.rejectedInvites) < MaxInboundRejectedInvites {
 			return
 		}
 	}

--- a/api/assistant-api/sip/internal/core/outbound_call.go
+++ b/api/assistant-api/sip/internal/core/outbound_call.go
@@ -304,11 +304,16 @@ func (outboundCall *Outbound) callOutboundInviteHandler(answerTime time.Time) er
 	if inviteRequest == nil {
 		return fmt.Errorf("outbound INVITE request is unavailable")
 	}
+	callAddress := NewCallAddress(inviteRequest)
+	callAddress.From = outboundCall.request.Identity.FromUser
+	callAddress.To = outboundCall.request.Identity.ToUser
+	if callAddress.ToURI == "" {
+		callAddress.ToURI = inviteRequest.Recipient.String()
+	}
 	if err := inviteHandler(
 		outboundCall.session,
 		inviteRequest.Recipient.String(),
-		outboundCall.request.Identity.FromUser,
-		outboundCall.request.Identity.ToUser,
+		callAddress,
 	); err != nil {
 		return err
 	}

--- a/api/assistant-api/sip/internal/core/outbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/outbound_call_test.go
@@ -56,11 +56,11 @@ func TestOutboundCallInviteHandlerUsesAuthoritativeRequestIdentity(t *testing.T)
 		},
 	}
 
-	server.SetOnInvite(func(callbackSession *Session, requestURI, fromIdentity, toIdentity string) error {
+	server.SetOnInvite(func(callbackSession *Session, requestURI string, callAddress CallAddress) error {
 		assert.Same(t, session, callbackSession)
 		assert.Equal(t, inviteRequest.Recipient.String(), requestURI)
-		assert.Equal(t, "assistant-line", fromIdentity)
-		assert.Equal(t, "customer-alias", toIdentity)
+		assert.Equal(t, "assistant-line", callAddress.From)
+		assert.Equal(t, "customer-alias", callAddress.To)
 		return nil
 	})
 	outboundCall := NewOutbound(server, session, dialog, nil, request)
@@ -74,7 +74,7 @@ func TestOutboundCallInviteHandlerUsesAuthoritativeRequestIdentity(t *testing.T)
 
 func TestOutboundCallInviteHandlerRejectsMissingInviteRequest(t *testing.T) {
 	server := &Server{logger: bridgeTestLogger()}
-	server.SetOnInvite(func(_ *Session, _, _, _ string) error {
+	server.SetOnInvite(func(_ *Session, _ string, _ CallAddress) error {
 		t.Fatal("onInvite must not run without the outbound INVITE request")
 		return nil
 	})

--- a/api/assistant-api/sip/internal/core/outbound_call_test.go
+++ b/api/assistant-api/sip/internal/core/outbound_call_test.go
@@ -22,6 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newOutboundSessionForTest(t *testing.T, config *Config, callID string) *Session {
+	t.Helper()
+	session, err := NewSession(context.Background(),
+		WithSessionConfig(config),
+		WithSessionDirection(CallDirectionOutbound),
+		WithSessionCallID(callID),
+	)
+	require.NoError(t, err)
+	return session
+}
+
 func TestNewOutboundCall_OwnsLifecycleDependencies(t *testing.T) {
 	server := &Server{}
 	session := &Session{}
@@ -199,13 +210,7 @@ func TestOutboundCall_PreAnswerLifecycleCancelSendsSIPCancel(t *testing.T) {
 	}
 	cfg := testOutboundConfig()
 	cfg.InviteTimeout = time.Minute
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    dialogSession.InviteRequest.CallID().Value(),
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, dialogSession.InviteRequest.CallID().Value())
 	session.SetDialogClientSession(dialogSession)
 	server.registerSession(session, session.GetCallID())
 
@@ -276,13 +281,7 @@ func TestOutboundCall_RingingTimeoutSendsLifecycleCancel(t *testing.T) {
 	}
 	cfg := testOutboundConfig()
 	cfg.InviteTimeout = 20 * time.Millisecond
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    dialogSession.InviteRequest.CallID().Value(),
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, dialogSession.InviteRequest.CallID().Value())
 	session.SetDialogClientSession(dialogSession)
 	server.registerSession(session, session.GetCallID())
 
@@ -356,13 +355,7 @@ func TestOutboundCall_RemoteBusyReportsFailure(t *testing.T) {
 	}
 	cfg := testOutboundConfig()
 	cfg.InviteTimeout = time.Minute
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    dialogSession.InviteRequest.CallID().Value(),
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, dialogSession.InviteRequest.CallID().Value())
 	session.SetDialogClientSession(dialogSession)
 	server.registerSession(session, session.GetCallID())
 
@@ -426,13 +419,7 @@ func TestOutboundCall_AnsweredSDPFailureSendsBYENotCancel(t *testing.T) {
 	}
 	cfg := testOutboundConfig()
 	cfg.InviteTimeout = time.Minute
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    dialogSession.InviteRequest.CallID().Value(),
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, dialogSession.InviteRequest.CallID().Value())
 	session.SetDialogClientSession(dialogSession)
 	session.SetRTPHandler(newTestRTPHandler())
 	server.registerSession(session, session.GetCallID())
@@ -489,13 +476,7 @@ func TestOutboundCall_ApplicationFailureRecordsFailure(t *testing.T) {
 		lifecycles: make(map[string]*CallLifecycle),
 	}
 	cfg := testOutboundConfig()
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    "call-application-failure",
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, "call-application-failure")
 	session.SetState(CallStateConnected)
 	session.SetOutboundDialogPhase(OutboundDialogPhaseConfirmed)
 	server.registerSession(session, session.GetCallID())
@@ -535,13 +516,7 @@ func TestOutboundCall_MediaTimeoutWithoutReceivedRTPFails(t *testing.T) {
 		lifecycles: make(map[string]*CallLifecycle),
 	}
 	cfg := testOutboundConfig()
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    "call-media-timeout-no-rtp",
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, "call-media-timeout-no-rtp")
 	session.SetState(CallStateConnected)
 	session.SetOutboundDialogPhase(OutboundDialogPhaseConfirmed)
 	session.SetRTPHandler(&RTPHandler{})
@@ -571,13 +546,7 @@ func TestOutboundCall_MediaTimeoutAfterReceivedRTPEndsCompleted(t *testing.T) {
 		lifecycles: make(map[string]*CallLifecycle),
 	}
 	cfg := testOutboundConfig()
-	session, err := NewSession(context.Background(), &SessionConfig{
-		Config:    cfg,
-		Direction: CallDirectionOutbound,
-		CallID:    "call-media-timeout-established",
-		Logger:    server.logger,
-	})
-	require.NoError(t, err)
+	session := newOutboundSessionForTest(t, cfg, "call-media-timeout-established")
 	session.SetState(CallStateConnected)
 	session.SetOutboundDialogPhase(OutboundDialogPhaseConfirmed)
 	rtpHandler := &RTPHandler{}

--- a/api/assistant-api/sip/internal/core/pipeline.go
+++ b/api/assistant-api/sip/internal/core/pipeline.go
@@ -35,8 +35,7 @@ type SessionEstablishedPipeline struct {
 	AssistantID     uint64
 	Auth            *types.Authentication
 	RequestURI      string
-	FromIdentity    string
-	ToIdentity      string
+	CallAddress     CallAddress
 	ConversationID  uint64 // Non-zero for outbound (already created by channel pipeline)
 }
 

--- a/api/assistant-api/sip/internal/core/server.go
+++ b/api/assistant-api/sip/internal/core/server.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +36,51 @@ const (
 	maxInboundRejectedInvites = 1024
 )
 
+// CallAddress contains the SIP parties and non-credential headers received with a call.
+// From and To are URI users. Header names are lowercase and repeated values preserve arrival order.
+type CallAddress struct {
+	From    string
+	To      string
+	FromURI string
+	ToURI   string
+	Headers map[string]string
+}
+
+// NewCallAddress reads the parties and non-credential headers from a SIP request.
+func NewCallAddress(request *sip.Request) CallAddress {
+	if request == nil {
+		return CallAddress{}
+	}
+
+	address := CallAddress{Headers: make(map[string]string)}
+	if from := request.From(); from != nil {
+		address.From = strings.TrimSpace(from.Address.User)
+		address.FromURI = from.Address.String()
+	}
+	if to := request.To(); to != nil {
+		address.To = strings.TrimSpace(to.Address.User)
+		address.ToURI = to.Address.String()
+	}
+
+	for _, header := range request.Headers() {
+		if header == nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(header.Name()))
+		if name == "" || name == "authorization" || name == "proxy-authorization" {
+			continue
+		}
+		value := strings.TrimSpace(header.Value())
+		if previous := address.Headers[name]; previous != "" {
+			address.Headers[name] = previous + "," + value
+		} else {
+			address.Headers[name] = value
+		}
+	}
+
+	return address
+}
+
 // SIPRequestContext contains information about an incoming SIP request.
 // Used by the middleware chain to resolve config for every SIP request.
 //
@@ -43,12 +89,11 @@ const (
 //	RouteMiddleware → resolves assistant route, sets Auth and Assistant
 //	VaultMiddleware → fetches SIP config from vault, sets VaultCredential
 type SIPRequestContext struct {
-	Method       string // SIP method (INVITE, REGISTER, BYE, etc.)
-	CallID       string
-	RequestURI   string
-	FromIdentity string
-	ToIdentity   string
-	SDPInfo      *SDPMediaInfo
+	Method      string // SIP method (INVITE, REGISTER, BYE, etc.)
+	CallID      string
+	RequestURI  string
+	CallAddress CallAddress
+	SDPInfo     *SDPMediaInfo
 
 	// Route/auth fields resolved by middleware.
 	APIKey      string
@@ -117,9 +162,9 @@ type Server struct {
 	middlewares []Middleware
 
 	// Event callbacks
-	onApplicationReady   func(session *Session, requestURI, fromIdentity, toIdentity string) error
+	onApplicationReady   func(session *Session, requestURI string, callAddress CallAddress) error
 	onApplicationCleanup func(session *Session)
-	onInvite             func(session *Session, requestURI, fromIdentity, toIdentity string) error
+	onInvite             func(session *Session, requestURI string, callAddress CallAddress) error
 	onBye                func(session *Session) error
 	onCancel             func(session *Session) error
 	onError              func(session *Session, err error)
@@ -471,7 +516,7 @@ func (s *Server) SessionCount() int {
 	return len(s.sessions)
 }
 
-func (s *Server) SetOnApplicationReady(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
+func (s *Server) SetOnApplicationReady(fn func(session *Session, requestURI string, callAddress CallAddress) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onApplicationReady = fn
@@ -484,7 +529,7 @@ func (s *Server) SetOnApplicationCleanup(fn func(session *Session)) {
 }
 
 // SetOnInvite sets the callback for answered INVITE requests.
-func (s *Server) SetOnInvite(fn func(session *Session, requestURI, fromIdentity, toIdentity string) error) {
+func (s *Server) SetOnInvite(fn func(session *Session, requestURI string, callAddress CallAddress) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onInvite = fn

--- a/api/assistant-api/sip/internal/core/server.go
+++ b/api/assistant-api/sip/internal/core/server.go
@@ -10,109 +10,15 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
-	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	internal_outbound "github.com/rapidaai/api/assistant-api/sip/internal/outbound"
 	"github.com/rapidaai/pkg/commons"
-	"github.com/rapidaai/pkg/types"
-	"github.com/rapidaai/protos"
 )
-
-// ServerState represents the state of the SIP server
-type ServerState int32
-
-const (
-	ServerStateCreated ServerState = iota
-	ServerStateRunning
-	ServerStateStopped
-
-	inboundRejectedInviteTTL  = time.Minute
-	maxInboundRejectedInvites = 1024
-)
-
-// CallAddress contains the SIP parties and non-credential headers received with a call.
-// From and To are URI users. Header names are lowercase and repeated values preserve arrival order.
-type CallAddress struct {
-	From    string
-	To      string
-	FromURI string
-	ToURI   string
-	Headers map[string]string
-}
-
-// NewCallAddress reads the parties and non-credential headers from a SIP request.
-func NewCallAddress(request *sip.Request) CallAddress {
-	if request == nil {
-		return CallAddress{}
-	}
-
-	address := CallAddress{Headers: make(map[string]string)}
-	if from := request.From(); from != nil {
-		address.From = strings.TrimSpace(from.Address.User)
-		address.FromURI = from.Address.String()
-	}
-	if to := request.To(); to != nil {
-		address.To = strings.TrimSpace(to.Address.User)
-		address.ToURI = to.Address.String()
-	}
-
-	for _, header := range request.Headers() {
-		if header == nil {
-			continue
-		}
-		name := strings.ToLower(strings.TrimSpace(header.Name()))
-		if name == "" || name == "authorization" || name == "proxy-authorization" {
-			continue
-		}
-		value := strings.TrimSpace(header.Value())
-		if previous := address.Headers[name]; previous != "" {
-			address.Headers[name] = previous + "," + value
-		} else {
-			address.Headers[name] = value
-		}
-	}
-
-	return address
-}
-
-// SIPRequestContext contains information about an incoming SIP request.
-// Used by the middleware chain to resolve config for every SIP request.
-//
-// Middleware enriches this context as it flows through the chain:
-//
-//	RouteMiddleware → resolves assistant route, sets Auth and Assistant
-//	VaultMiddleware → fetches SIP config from vault, sets VaultCredential
-type SIPRequestContext struct {
-	Method      string // SIP method (INVITE, REGISTER, BYE, etc.)
-	CallID      string
-	RequestURI  string
-	CallAddress CallAddress
-	SDPInfo     *SDPMediaInfo
-
-	// Route/auth fields resolved by middleware.
-	APIKey      string
-	AssistantID string
-
-	Auth            *types.Authentication
-	Assistant       *internal_assistant_entity.Assistant
-	VaultCredential *protos.VaultCredential
-	Config          *Config
-}
-
-// Middleware processes a SIP request context and mutates it in place.
-// Returning nil continues to the next middleware by index. Returning an error
-// stops execution.
-//
-// Example chain for INVITE:
-//
-//	RouteMiddleware → VaultMiddleware
-type Middleware func(ctx *SIPRequestContext) error
 
 // Server wraps sipgo for handling SIP signaling.
 type Server struct {

--- a/api/assistant-api/sip/internal/core/server_commands_test.go
+++ b/api/assistant-api/sip/internal/core/server_commands_test.go
@@ -234,13 +234,12 @@ func validInboundOfferSDP() string {
 
 func newTestSession(t *testing.T, callID string, dir CallDirection) *Session {
 	t.Helper()
-	s, err := NewSession(context.Background(), &SessionConfig{
-		Config:    bridgeTestConfig(),
-		Direction: dir,
-		CallID:    callID,
-		Codec:     &CodecPCMU,
-		Logger:    bridgeTestLogger(),
-	})
+	s, err := NewSession(context.Background(),
+		WithSessionConfig(bridgeTestConfig()),
+		WithSessionDirection(dir),
+		WithSessionCallID(callID),
+		WithSessionCodec(&CodecPCMU),
+	)
 	require.NoError(t, err)
 	return s
 }

--- a/api/assistant-api/sip/internal/core/server_dialog.go
+++ b/api/assistant-api/sip/internal/core/server_dialog.go
@@ -31,7 +31,7 @@ func (s *Server) handleBye(req *sip.Request, tx sip.ServerTransaction) {
 		return
 	}
 
-	disconnectMetadata := parseSIPDisconnectMetadata(req)
+	disconnectMetadata := NewSIPReason(req).DisconnectMetadata()
 	session.SetDisconnectMetadata(disconnectMetadata)
 
 	if session.GetInfo().Direction == CallDirectionOutbound {

--- a/api/assistant-api/sip/internal/core/server_outbound.go
+++ b/api/assistant-api/sip/internal/core/server_outbound.go
@@ -127,18 +127,17 @@ func (s *Server) applyOutboundLegMetadata(session *Session, opts outboundCallLeg
 }
 
 func (s *Server) createAndRegisterOutboundSession(ctx context.Context, cfg *Config, callID string, opts MakeCallOptions) (*Session, error) {
-	session, err := NewSession(ctx, &SessionConfig{
-		Config:          cfg,
-		Direction:       CallDirectionOutbound,
-		CallID:          callID,
-		Codec:           &CodecPCMU,
-		Logger:          s.logger,
-		Auth:            opts.Auth,
-		Assistant:       opts.Assistant,
-		ConversationID:  opts.ConversationID,
-		ContextID:       opts.ContextID,
-		VaultCredential: opts.VaultCredential,
-	})
+	session, err := NewSession(ctx,
+		WithSessionConfig(cfg),
+		WithSessionDirection(CallDirectionOutbound),
+		WithSessionCallID(callID),
+		WithSessionCodec(&CodecPCMU),
+		WithSessionAuth(opts.Auth),
+		WithSessionAssistant(opts.Assistant),
+		WithSessionConversationID(opts.ConversationID),
+		WithSessionContextID(opts.ContextID),
+		WithSessionVaultCredential(opts.VaultCredential),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create outbound session: %w", err)
 	}

--- a/api/assistant-api/sip/internal/core/session.go
+++ b/api/assistant-api/sip/internal/core/session.go
@@ -17,35 +17,13 @@ import (
 	"github.com/emiago/sipgo"
 	"github.com/google/uuid"
 	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
-	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
 	"github.com/rapidaai/protos"
 )
 
-// Session channel buffer sizes
-const (
-	eventBufferSize = 50
-	errorBufferSize = 10
-)
-
-// SessionConfig holds configuration for creating a session
-type SessionConfig struct {
-	Config          *Config
-	Direction       CallDirection
-	CallID          string // Optional: if empty, a new UUID will be generated
-	Codec           *Codec
-	Logger          commons.Logger
-	Auth            *types.Authentication                // Authentication principal
-	Assistant       *internal_assistant_entity.Assistant // Assistant entity
-	ConversationID  uint64                               // Conversation ID (outbound: set by channel pipeline)
-	ContextID       string                               // Call context ID (outbound: set by channel pipeline)
-	VaultCredential *protos.VaultCredential              // Vault-resolved SIP provider credential
-}
-
 // Session manages a single SIP call session
 type Session struct {
-	mu     sync.RWMutex
-	logger commons.Logger
+	mu sync.RWMutex
 
 	info   SessionInfo
 	config *Config
@@ -112,60 +90,91 @@ type Session struct {
 	onEnded func(session *Session)
 }
 
-// NewSession creates a new SIP session
-func NewSession(ctx context.Context, cfg *SessionConfig) (*Session, error) {
-	if cfg.Config == nil {
-		return nil, fmt.Errorf("%w: config is required", ErrInvalidConfig)
-	}
-	// Outbound identity/auth is validated before the INVITE is built.
-	if cfg.Direction == CallDirectionOutbound {
-		if err := cfg.Config.Validate(); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := cfg.Config.ValidateRTP(); err != nil {
-			return nil, err
-		}
-	}
+type SessionOption func(*Session)
 
+func WithSessionConfig(config *Config) SessionOption {
+	return func(session *Session) { session.config = config }
+}
+
+func WithSessionDirection(direction CallDirection) SessionOption {
+	return func(session *Session) { session.info.Direction = direction }
+}
+
+func WithSessionCallID(callID string) SessionOption {
+	return func(session *Session) { session.info.CallID = callID }
+}
+
+func WithSessionCodec(codec *Codec) SessionOption {
+	return func(session *Session) {
+		if codec == nil {
+			return
+		}
+		session.negotiatedCodec = codec
+		session.info.Codec = codec.Name
+		session.info.SampleRate = int(codec.ClockRate)
+	}
+}
+
+func WithSessionAuth(auth *types.Authentication) SessionOption {
+	return func(session *Session) { session.auth = auth }
+}
+
+func WithSessionAssistant(assistant *internal_assistant_entity.Assistant) SessionOption {
+	return func(session *Session) { session.assistant = assistant }
+}
+
+func WithSessionConversationID(conversationID uint64) SessionOption {
+	return func(session *Session) { session.conversationID = conversationID }
+}
+
+func WithSessionContextID(contextID string) SessionOption {
+	return func(session *Session) { session.contextID = contextID }
+}
+
+func WithSessionVaultCredential(vaultCredential *protos.VaultCredential) SessionOption {
+	return func(session *Session) { session.vaultCredential = vaultCredential }
+}
+
+// NewSession creates a new SIP session.
+func NewSession(ctx context.Context, opts ...SessionOption) (*Session, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
-
-	callID := cfg.CallID
-	if callID == "" {
-		callID = uuid.New().String()
-	}
-
-	codec := cfg.Codec
-	if codec == nil {
-		codec = &CodecPCMU
-	}
-
 	session := &Session{
-		logger: cfg.Logger,
 		info: SessionInfo{
-			CallID:     callID,
+			CallID:     uuid.New().String(),
 			LocalTag:   uuid.New().String()[:8],
 			State:      CallStateInitializing,
-			Direction:  cfg.Direction,
 			StartTime:  time.Now(),
-			Codec:      codec.Name,
-			SampleRate: int(codec.ClockRate),
+			Codec:      CodecPCMU.Name,
+			SampleRate: int(CodecPCMU.ClockRate),
 		},
-		config:           cfg.Config,
 		ctx:              sessionCtx,
 		cancel:           cancel,
-		eventChan:        make(chan Event, eventBufferSize),
-		errorChan:        make(chan error, errorBufferSize),
-		negotiatedCodec:  codec,
-		auth:             cfg.Auth,
-		assistant:        cfg.Assistant,
-		conversationID:   cfg.ConversationID,
-		contextID:        cfg.ContextID,
-		vaultCredential:  cfg.VaultCredential,
+		eventChan:        make(chan Event, SessionEventBufferSize),
+		errorChan:        make(chan error, SessionErrorBufferSize),
+		negotiatedCodec:  &CodecPCMU,
 		byeReceived:      make(chan struct{}),
 		initialACKSignal: make(chan struct{}),
 	}
-	if cfg.Direction == CallDirectionOutbound {
+	for _, opt := range opts {
+		if opt != nil {
+			opt(session)
+		}
+	}
+	if session.config == nil {
+		cancel()
+		return nil, fmt.Errorf("%w: config is required", ErrInvalidConfig)
+	}
+	// Outbound identity/auth is validated before the INVITE is built.
+	if session.info.Direction == CallDirectionOutbound {
+		if err := session.config.Validate(); err != nil {
+			cancel()
+			return nil, err
+		}
+	} else if err := session.config.ValidateRTP(); err != nil {
+		cancel()
+		return nil, err
+	}
+	if session.info.Direction == CallDirectionOutbound {
 		session.outboundDialogPhase = OutboundDialogPhaseInviting
 	}
 
@@ -197,12 +206,6 @@ func (s *Session) SetState(state CallState) {
 
 	// Validate state transitions
 	if !s.isValidTransition(previousState, state) {
-		if s.logger != nil {
-			s.logger.Warnw("Invalid state transition",
-				"call_id", s.info.CallID,
-				"from", previousState,
-				"to", state)
-		}
 		return
 	}
 
@@ -229,12 +232,6 @@ func (s *Session) SetState(state CallState) {
 		s.emitEvent(EventTypeRinging, nil)
 	}
 
-	if s.logger != nil {
-		s.logger.Debugw("Session state changed",
-			"call_id", s.info.CallID,
-			"from", previousState,
-			"to", state)
-	}
 }
 
 // isValidTransition checks if a state transition is valid
@@ -448,13 +445,10 @@ func (s *Session) SetRTPHandler(handler *RTPHandler) {
 		return
 	}
 	s.rtpHandler = handler
-	callID := s.info.CallID
 	s.mu.Unlock()
 
 	if previous != nil {
-		if err := previous.Stop(); err != nil && s.logger != nil {
-			s.logger.Warnw("Error stopping replaced RTP handler", "error", err, "call_id", callID)
-		}
+		_ = previous.Stop()
 	}
 }
 
@@ -769,9 +763,7 @@ func (s *Session) End() {
 	s.rtpHandler = nil
 	s.mu.Unlock()
 	if rtpHandler != nil {
-		if err := rtpHandler.Stop(); err != nil && s.logger != nil {
-			s.logger.Warnw("Error stopping RTP handler", "error", err, "call_id", s.info.CallID)
-		}
+		_ = rtpHandler.Stop()
 	}
 
 	// Cancel context — unblocks anything waiting on session.Context()
@@ -782,12 +774,6 @@ func (s *Session) End() {
 	s.mu.RUnlock()
 	if !terminal {
 		s.SetState(CallStateEnded)
-	}
-
-	if s.logger != nil {
-		s.logger.Info("Session ended",
-			"call_id", s.info.CallID,
-			"duration", s.info.GetDuration())
 	}
 
 	s.mu.RLock()

--- a/api/assistant-api/sip/internal/core/session_race_test.go
+++ b/api/assistant-api/sip/internal/core/session_race_test.go
@@ -28,10 +28,10 @@ func testSessionConfig() *Config {
 
 func newInboundTestSession(t *testing.T) *Session {
 	t.Helper()
-	s, err := NewSession(context.Background(), &SessionConfig{
-		Config:    testSessionConfig(),
-		Direction: CallDirectionInbound,
-	})
+	s, err := NewSession(context.Background(),
+		WithSessionConfig(testSessionConfig()),
+		WithSessionDirection(CallDirectionInbound),
+	)
 	require.NoError(t, err)
 	return s
 }

--- a/api/assistant-api/sip/internal/core/session_test.go
+++ b/api/assistant-api/sip/internal/core/session_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSessionAppliesOptions(t *testing.T) {
+	config := testSessionConfig()
+
+	session, err := NewSession(context.Background(),
+		WithSessionConfig(config),
+		WithSessionDirection(CallDirectionOutbound),
+		WithSessionCallID("call-123"),
+		WithSessionCodec(&CodecPCMA),
+		WithSessionConversationID(42),
+		WithSessionContextID("context-123"),
+	)
+
+	require.NoError(t, err)
+	assert.Same(t, config, session.GetConfig())
+	assert.Equal(t, "call-123", session.GetCallID())
+	assert.Equal(t, CallDirectionOutbound, session.GetInfo().Direction)
+	assert.Equal(t, CodecPCMA.Name, session.GetNegotiatedCodec().Name)
+	assert.Equal(t, uint64(42), session.GetConversationID())
+	assert.Equal(t, "context-123", session.GetContextID())
+	assert.Equal(t, OutboundDialogPhaseInviting, session.GetOutboundDialogPhase())
+}
+
+func TestNewSessionRequiresConfig(t *testing.T) {
+	session, err := NewSession(context.Background())
+
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Nil(t, session)
+}

--- a/api/assistant-api/sip/internal/core/sip_reason.go
+++ b/api/assistant-api/sip/internal/core/sip_reason.go
@@ -13,144 +13,115 @@ import (
 	"github.com/emiago/sipgo/sip"
 )
 
-func parseSIPDisconnectMetadata(request *sip.Request) DisconnectMetadata {
-	metadata := DisconnectMetadata{Reason: DisconnectReasonRemoteHangup}
+// SIPReason contains the parsed reason reported by a SIP peer.
+type SIPReason struct {
+	Protocol string
+	Cause    int
+	Text     string
+	Raw      string
+}
+
+func NewSIPReason(request *sip.Request) SIPReason {
 	if request == nil {
-		return metadata
+		return SIPReason{}
 	}
 
 	for _, header := range request.GetHeaders("Reason") {
-		candidate := parseSIPReasonHeader(header.Value())
-		if candidate.Reason == "" {
+		reason := SIPReason{Raw: strings.TrimSpace(header.Value())}
+		if reason.Raw == "" {
 			continue
 		}
-		return candidate
-	}
-	return metadata
-}
 
-func parseSIPReasonHeader(headerValue string) DisconnectMetadata {
-	metadata := DisconnectMetadata{
-		Reason: DisconnectReasonRemoteHangup,
-		Raw:    strings.TrimSpace(headerValue),
-	}
-	parts := splitReasonHeaderParts(headerValue)
-	if len(parts) == 0 {
-		return metadata
-	}
-
-	protocol := strings.ToUpper(strings.TrimSpace(parts[0]))
-	for _, part := range parts[1:] {
-		key, value, ok := strings.Cut(part, "=")
-		if !ok {
-			continue
-		}
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "cause":
-			cause, err := strconv.Atoi(strings.TrimSpace(value))
-			if err == nil {
-				metadata.ProviderStatusCode = cause
+		parts := make([]string, 0, 3)
+		var part strings.Builder
+		inQuotes := false
+		for _, char := range reason.Raw {
+			switch char {
+			case '"':
+				inQuotes = !inQuotes
+				part.WriteRune(char)
+			case ';':
+				if inQuotes {
+					part.WriteRune(char)
+					continue
+				}
+				if value := strings.TrimSpace(part.String()); value != "" {
+					parts = append(parts, value)
+				}
+				part.Reset()
+			default:
+				part.WriteRune(char)
 			}
-		case "text":
-			metadata.Text = strings.Trim(unquoteReasonValue(value), " ")
 		}
-	}
-	metadata.Reason = classifyDisconnectReason(protocol, metadata.ProviderStatusCode)
-	return metadata
-}
+		if value := strings.TrimSpace(part.String()); value != "" {
+			parts = append(parts, value)
+		}
+		if len(parts) == 0 {
+			continue
+		}
 
-func splitReasonHeaderParts(headerValue string) []string {
-	parts := make([]string, 0, 3)
-	var builder strings.Builder
-	inQuotes := false
-	for _, char := range headerValue {
-		switch char {
-		case '"':
-			inQuotes = !inQuotes
-			builder.WriteRune(char)
-		case ';':
-			if inQuotes {
-				builder.WriteRune(char)
+		reason.Protocol = strings.ToLower(strings.TrimSpace(parts[0]))
+		for _, parameter := range parts[1:] {
+			key, value, ok := strings.Cut(parameter, "=")
+			if !ok {
 				continue
 			}
-			parts = appendReasonPart(parts, builder.String())
-			builder.Reset()
-		default:
-			builder.WriteRune(char)
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "cause":
+				reason.Cause, _ = strconv.Atoi(strings.TrimSpace(value))
+			case "text":
+				value = strings.TrimSpace(value)
+				if unquoted, err := strconv.Unquote(value); err == nil {
+					reason.Text = unquoted
+				} else {
+					reason.Text = value
+				}
+			}
+		}
+		return reason
+	}
+	return SIPReason{}
+}
+
+func (reason SIPReason) DisconnectMetadata() DisconnectMetadata {
+	metadata := DisconnectMetadata{
+		Reason:             DisconnectReasonRemoteHangup,
+		Text:               reason.Text,
+		Raw:                reason.Raw,
+		ProviderStatusCode: reason.Cause,
+	}
+	switch reason.Protocol {
+	case "q.850":
+		switch reason.Cause {
+		case 16, 31:
+			metadata.Reason = DisconnectReasonNormalClearing
+		case 17:
+			metadata.Reason = DisconnectReasonBusy
+		case 18, 19:
+			metadata.Reason = DisconnectReasonNoAnswer
+		case 21:
+			metadata.Reason = DisconnectReasonRejected
+		case 34, 38, 41, 42, 47:
+			metadata.Reason = DisconnectReasonNetworkFailure
+		}
+	case "sip":
+		switch reason.Cause {
+		case 200:
+			metadata.Reason = DisconnectReasonNormalClearing
+		case 408, 480:
+			metadata.Reason = DisconnectReasonNoAnswer
+		case 486, 600:
+			metadata.Reason = DisconnectReasonBusy
+		case 487:
+			metadata.Reason = DisconnectReasonCancelled
+		case 403, 603:
+			metadata.Reason = DisconnectReasonRejected
+		case 500, 502, 503, 504:
+			metadata.Reason = DisconnectReasonNetworkFailure
 		}
 	}
-	parts = appendReasonPart(parts, builder.String())
-	return parts
-}
-
-func appendReasonPart(parts []string, part string) []string {
-	trimmedPart := strings.TrimSpace(part)
-	if trimmedPart == "" {
-		return parts
+	if metadata.Reason == DisconnectReasonRemoteHangup && reason.Cause > 0 {
+		metadata.Reason = DisconnectReasonRemoteError
 	}
-	return append(parts, trimmedPart)
-}
-
-func unquoteReasonValue(value string) string {
-	value = strings.TrimSpace(value)
-	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
-		return value
-	}
-	return strings.ReplaceAll(value[1:len(value)-1], `\"`, `"`)
-}
-
-func classifyDisconnectReason(protocol string, cause int) string {
-	switch protocol {
-	case "Q.850":
-		return classifyQ850DisconnectReason(cause)
-	case "SIP":
-		return classifySIPDisconnectReason(cause)
-	default:
-		if cause > 0 {
-			return DisconnectReasonRemoteError
-		}
-		return DisconnectReasonRemoteHangup
-	}
-}
-
-func classifyQ850DisconnectReason(cause int) string {
-	switch cause {
-	case 16, 31:
-		return DisconnectReasonNormalClearing
-	case 17:
-		return DisconnectReasonBusy
-	case 18, 19:
-		return DisconnectReasonNoAnswer
-	case 21:
-		return DisconnectReasonRejected
-	case 34, 38, 41, 42, 47:
-		return DisconnectReasonNetworkFailure
-	default:
-		if cause > 0 {
-			return DisconnectReasonRemoteError
-		}
-		return DisconnectReasonRemoteHangup
-	}
-}
-
-func classifySIPDisconnectReason(cause int) string {
-	switch cause {
-	case 200:
-		return DisconnectReasonNormalClearing
-	case 408, 480:
-		return DisconnectReasonNoAnswer
-	case 486, 600:
-		return DisconnectReasonBusy
-	case 487:
-		return DisconnectReasonCancelled
-	case 403, 603:
-		return DisconnectReasonRejected
-	case 500, 502, 503, 504:
-		return DisconnectReasonNetworkFailure
-	default:
-		if cause >= 400 {
-			return DisconnectReasonRemoteError
-		}
-		return DisconnectReasonRemoteHangup
-	}
+	return metadata
 }

--- a/api/assistant-api/sip/internal/core/sip_reason_test.go
+++ b/api/assistant-api/sip/internal/core/sip_reason_test.go
@@ -9,34 +9,41 @@ package core
 import (
 	"testing"
 
+	"github.com/emiago/sipgo/sip"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseSIPReasonHeader_Q850NormalClearing(t *testing.T) {
-	metadata := parseSIPReasonHeader(`Q.850;cause=16;text="Normal call clearing"`)
+func requestWithReason(value string) *sip.Request {
+	request := sip.NewRequest(sip.BYE, sip.Uri{Host: "example.com"})
+	request.AppendHeader(sip.NewHeader("Reason", value))
+	return request
+}
+
+func TestSIPReason_Q850NormalClearing(t *testing.T) {
+	metadata := NewSIPReason(requestWithReason(`Q.850;cause=16;text="Normal call clearing"`)).DisconnectMetadata()
 
 	assert.Equal(t, DisconnectReasonNormalClearing, metadata.Reason)
 	assert.Equal(t, 16, metadata.ProviderStatusCode)
 	assert.Equal(t, "Normal call clearing", metadata.Text)
 }
 
-func TestParseSIPReasonHeader_SIPBusy(t *testing.T) {
-	metadata := parseSIPReasonHeader(`SIP;cause=486;text="Busy Here"`)
+func TestSIPReason_SIPBusy(t *testing.T) {
+	metadata := NewSIPReason(requestWithReason(`SIP;cause=486;text="Busy Here"`)).DisconnectMetadata()
 
 	assert.Equal(t, DisconnectReasonBusy, metadata.Reason)
 	assert.Equal(t, 486, metadata.ProviderStatusCode)
 	assert.Equal(t, "Busy Here", metadata.Text)
 }
 
-func TestParseSIPReasonHeader_QuotedTextWithSemicolon(t *testing.T) {
-	metadata := parseSIPReasonHeader(`Q.850;cause=41;text="Temporary failure; upstream"`)
+func TestSIPReason_QuotedTextWithSemicolon(t *testing.T) {
+	metadata := NewSIPReason(requestWithReason(`Q.850;cause=41;text="Temporary failure; upstream"`)).DisconnectMetadata()
 
 	assert.Equal(t, DisconnectReasonNetworkFailure, metadata.Reason)
 	assert.Equal(t, "Temporary failure; upstream", metadata.Text)
 }
 
-func TestParseSIPDisconnectMetadata_DefaultsToRemoteHangup(t *testing.T) {
-	metadata := parseSIPDisconnectMetadata(nil)
+func TestSIPReason_DefaultsToRemoteHangup(t *testing.T) {
+	metadata := NewSIPReason(nil).DisconnectMetadata()
 
 	assert.Equal(t, DisconnectReasonRemoteHangup, metadata.Reason)
 	assert.Zero(t, metadata.ProviderStatusCode)

--- a/api/assistant-api/sip/internal/core/types.go
+++ b/api/assistant-api/sip/internal/core/types.go
@@ -7,14 +7,15 @@
 package core
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/emiago/sipgo/sip"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
+	"github.com/rapidaai/pkg/types"
+	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/protos"
 )
 
@@ -37,6 +38,98 @@ var (
 	ErrInboundAnswerPolicyTimeout = errors.New("inbound answer policy timeout")
 	ErrBridgeLifecycleRejected    = errors.New("bridge lifecycle transition rejected")
 )
+
+// ServerState represents the state of the SIP server.
+type ServerState int32
+
+const (
+	ServerStateCreated ServerState = iota
+	ServerStateRunning
+	ServerStateStopped
+
+	InboundRejectedInviteTTL  = time.Minute
+	MaxInboundRejectedInvites = 1024
+	SessionEventBufferSize    = 50
+	SessionErrorBufferSize    = 10
+)
+
+// CallAddress contains the SIP parties and non-credential headers received with a call.
+// From and To are URI users. Header names are lowercase and repeated values preserve arrival order.
+type CallAddress struct {
+	From    string
+	To      string
+	FromURI string
+	ToURI   string
+	Headers map[string]string
+}
+
+// NewCallAddress reads the parties and non-credential headers from a SIP request.
+func NewCallAddress(request *sip.Request) CallAddress {
+	if request == nil {
+		return CallAddress{}
+	}
+
+	address := CallAddress{Headers: make(map[string]string)}
+	if from := request.From(); from != nil {
+		address.From = strings.TrimSpace(from.Address.User)
+		address.FromURI = from.Address.String()
+	}
+	if to := request.To(); to != nil {
+		address.To = strings.TrimSpace(to.Address.User)
+		address.ToURI = to.Address.String()
+	}
+
+	for _, header := range request.Headers() {
+		if header == nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(header.Name()))
+		if name == "" || name == "authorization" || name == "proxy-authorization" {
+			continue
+		}
+		value := strings.TrimSpace(header.Value())
+		if previous := address.Headers[name]; previous != "" {
+			address.Headers[name] = previous + "," + value
+		} else {
+			address.Headers[name] = value
+		}
+	}
+
+	return address
+}
+
+// SIPRequestContext contains information about an incoming SIP request.
+// Used by the middleware chain to resolve config for every SIP request.
+//
+// Middleware enriches this context as it flows through the chain:
+//
+//	RouteMiddleware → resolves assistant route, sets Auth and Assistant
+//	VaultMiddleware → fetches SIP config from vault, sets VaultCredential
+type SIPRequestContext struct {
+	Method      string // SIP method (INVITE, REGISTER, BYE, etc.)
+	CallID      string
+	RequestURI  string
+	CallAddress CallAddress
+	SDPInfo     *SDPMediaInfo
+
+	// Route/auth fields resolved by middleware.
+	APIKey      string
+	AssistantID string
+
+	Auth            *types.Authentication
+	Assistant       *internal_assistant_entity.Assistant
+	VaultCredential *protos.VaultCredential
+	Config          *Config
+}
+
+// Middleware processes a SIP request context and mutates it in place.
+// Returning nil continues to the next middleware by index. Returning an error
+// stops execution.
+//
+// Example chain for INVITE:
+//
+//	RouteMiddleware → VaultMiddleware
+type Middleware func(ctx *SIPRequestContext) error
 
 // SIPError adds operation and call context to SIP failures.
 type SIPError struct {
@@ -497,126 +590,62 @@ func ParseConfigFromVault(vaultCredential *protos.VaultCredential) (*Config, err
 		return nil, fmt.Errorf("vault credential is required")
 	}
 
-	credMap := vaultCredential.GetValue().AsMap()
+	options := utils.Option(vaultCredential.GetValue().AsMap())
 	cfg := &Config{}
 
-	if sipURI, ok := stringValue(credMap, "sip_uri"); ok {
-		cfg.Server, cfg.Port = parseHostPort(sipURI, cfg.Port)
-	}
+	for _, key := range []string{"sip_uri", "host", "host_port"} {
+		value, err := options.GetString(key)
+		if err != nil || strings.TrimSpace(value) == "" {
+			continue
+		}
 
-	if host, ok := stringValue(credMap, "host"); ok {
-		cfg.Server, cfg.Port = parseHostPort(host, cfg.Port)
+		raw := strings.TrimSpace(value)
+		if !strings.HasPrefix(raw, "sip:") && !strings.HasPrefix(raw, "sips:") {
+			raw = "sip:" + raw
+		}
+		var uri sip.Uri
+		if err := sip.ParseUri(raw, &uri); err == nil && uri.Host != "" {
+			cfg.Server = uri.Host
+			if uri.Port > 0 && uri.Port <= 65535 {
+				cfg.Port = uri.Port
+			}
+		}
 	}
-	if host, ok := stringValue(credMap, "host_port"); ok {
-		cfg.Server, cfg.Port = parseHostPort(host, cfg.Port)
-	}
-	if server, ok := stringValue(credMap, "sip_server"); ok {
-		cfg.Server = server
+	if server, err := options.GetString("sip_server"); err == nil && strings.TrimSpace(server) != "" {
+		cfg.Server = strings.TrimSpace(server)
 	}
 	if cfg.Port <= 0 {
-		cfg.Port = parsePortValue(credMap["sip_port"])
+		if port, err := options.GetUint32("sip_port"); err == nil && port > 0 && port <= 65535 {
+			cfg.Port = int(port)
+		}
 	}
-	if username, ok := stringValue(credMap, "user"); ok {
-		cfg.Username = username
+	if username, err := options.GetString("user"); err == nil && strings.TrimSpace(username) != "" {
+		cfg.Username = strings.TrimSpace(username)
 	}
-	if username, ok := stringValue(credMap, "sip_username"); ok {
-		cfg.Username = username
+	if username, err := options.GetString("sip_username"); err == nil && strings.TrimSpace(username) != "" {
+		cfg.Username = strings.TrimSpace(username)
 	}
-	if password, ok := stringValue(credMap, "password"); ok {
-		cfg.Password = password
+	if password, err := options.GetString("password"); err == nil && strings.TrimSpace(password) != "" {
+		cfg.Password = strings.TrimSpace(password)
 	}
-	if password, ok := stringValue(credMap, "sip_password"); ok {
-		cfg.Password = password
+	if password, err := options.GetString("sip_password"); err == nil && strings.TrimSpace(password) != "" {
+		cfg.Password = strings.TrimSpace(password)
 	}
-	if realm, ok := stringValue(credMap, "sip_realm"); ok {
-		cfg.Realm = realm
+	if realm, err := options.GetString("sip_realm"); err == nil && strings.TrimSpace(realm) != "" {
+		cfg.Realm = strings.TrimSpace(realm)
 	}
-	if domain, ok := stringValue(credMap, "sip_domain"); ok {
-		cfg.Domain = domain
+	if domain, err := options.GetString("sip_domain"); err == nil && strings.TrimSpace(domain) != "" {
+		cfg.Domain = strings.TrimSpace(domain)
 	}
-	if callerID, ok := stringValue(credMap, "sip_caller_id"); ok {
-		cfg.CallerID = callerID
+	if callerID, err := options.GetString("sip_caller_id"); err == nil && strings.TrimSpace(callerID) != "" {
+		cfg.CallerID = strings.TrimSpace(callerID)
 	}
-	if headers := parseHeadersValue(credMap["headers"]); len(headers) > 0 {
+	if headers, err := options.GetStringMap("headers"); err == nil && len(headers) > 0 {
 		cfg.CustomHeaders = headers
 	}
-	if headers := parseHeadersValue(credMap["sip_headers"]); len(headers) > 0 {
+	if headers, err := options.GetStringMap("sip_headers"); err == nil && len(headers) > 0 {
 		cfg.CustomHeaders = headers
 	}
 
 	return cfg, nil
-}
-
-func stringValue(values map[string]interface{}, key string) (string, bool) {
-	value, ok := values[key].(string)
-	if !ok {
-		return "", false
-	}
-	value = strings.TrimSpace(value)
-	return value, value != ""
-}
-
-func parseHostPort(value string, currentPort int) (string, int) {
-	raw := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(value), "sips:"), "sip:")
-	host, portStr, err := net.SplitHostPort(raw)
-	if err != nil {
-		return raw, currentPort
-	}
-	if port, err := strconv.Atoi(portStr); err == nil && port > 0 && port <= 65535 {
-		return host, port
-	}
-	return host, currentPort
-}
-
-func parsePortValue(v any) int {
-	switch p := v.(type) {
-	case float64:
-		if int(p) > 0 && int(p) <= 65535 {
-			return int(p)
-		}
-	case string:
-		if port, err := strconv.Atoi(p); err == nil && port > 0 && port <= 65535 {
-			return port
-		}
-	}
-	return 0
-}
-
-func parseHeadersValue(value any) map[string]string {
-	switch headers := value.(type) {
-	case map[string]interface{}:
-		parsed := make(map[string]string, len(headers))
-		for name, value := range headers {
-			if stringValue, ok := value.(string); ok {
-				parsed[name] = stringValue
-			}
-		}
-		if len(parsed) > 0 {
-			return parsed
-		}
-	case string:
-		if strings.TrimSpace(headers) == "" {
-			return nil
-		}
-		parsed := make(map[string]string)
-		if err := json.Unmarshal([]byte(headers), &parsed); err == nil && len(parsed) > 0 {
-			return parsed
-		}
-	}
-	return nil
-}
-
-// ExtractDIDFromURI is retained for compatibility with the public SIP facade.
-// Deprecated: native SIP identity handling preserves parsed SIP addresses.
-func ExtractDIDFromURI(uri string) string {
-	raw := strings.TrimPrefix(strings.TrimPrefix(uri, "sip:"), "sips:")
-	user, _, _ := strings.Cut(raw, "@")
-	user, _, _ = strings.Cut(user, ";")
-	if user == "" || strings.Contains(user, ":") {
-		return ""
-	}
-	if len(user) > 5 && user[0] != '+' {
-		user = "+" + user
-	}
-	return user
 }

--- a/api/assistant-api/sip/pipeline/dispatcher_race_test.go
+++ b/api/assistant-api/sip/pipeline/dispatcher_race_test.go
@@ -30,15 +30,15 @@ func newPipelineTestLogger(t *testing.T) commons.Logger {
 
 func newPipelineTestSession(t *testing.T) *sip_infra.Session {
 	t.Helper()
-	s, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config: &sip_infra.Config{
+	s, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(&sip_infra.Config{
 			Server:            "127.0.0.1",
 			Port:              5060,
 			RTPPortRangeStart: 10000,
 			RTPPortRangeEnd:   10020,
-		},
-		Direction: sip_infra.CallDirectionInbound,
-	})
+		}),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionInbound),
+	)
 	require.NoError(t, err)
 	return s
 }

--- a/api/assistant-api/sip/pipeline/runtime.go
+++ b/api/assistant-api/sip/pipeline/runtime.go
@@ -85,8 +85,8 @@ func (d *Dispatcher) prepareSIPCallRuntime(ctx context.Context, stage sip_infra.
 		session,
 		setup,
 		string(stage.Direction),
-		stage.FromIdentity,
-		stage.ToIdentity,
+		stage.CallAddress.From,
+		stage.CallAddress.To,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve SIP call context: %w", err)

--- a/api/assistant-api/sip/pipeline/session.go
+++ b/api/assistant-api/sip/pipeline/session.go
@@ -30,9 +30,9 @@ func (d *Dispatcher) createConversation(ctx context.Context, stage sip_infra.Ses
 		dirEnum = type_enums.DIRECTION_OUTBOUND
 	}
 
-	conversationIdentifier := stage.FromIdentity
+	conversationIdentifier := stage.CallAddress.From
 	if stage.Direction == sip_infra.CallDirectionOutbound {
-		conversationIdentifier = stage.ToIdentity
+		conversationIdentifier = stage.CallAddress.To
 	}
 
 	assistant := stage.Session.GetAssistant()
@@ -69,7 +69,7 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 	if stage.Direction == sip_infra.CallDirectionOutbound {
 		contextID := stage.Session.GetContextID()
 		if contextID == "" {
-			return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, "", stage.FromIdentity, stage.ToIdentity)
+			return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, "", stage.CallAddress.From, stage.CallAddress.To)
 		}
 		if claimed, err := d.callContextStore.Claim(ctx, contextID); err == nil {
 			return claimed, nil
@@ -77,7 +77,7 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 		if loaded, err := d.callContextStore.Get(ctx, contextID); err == nil {
 			return loaded, nil
 		}
-		return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, contextID, stage.FromIdentity, stage.ToIdentity)
+		return reconstructCallContext(stage.Auth, stage.AssistantID, conversationID, dirStr, callID, contextID, stage.CallAddress.From, stage.CallAddress.To)
 	}
 
 	callContext := &callcontext.CallContext{
@@ -85,8 +85,8 @@ func (d *Dispatcher) ensureCallContext(ctx context.Context, stage sip_infra.Sess
 		ConversationID: conversationID,
 		Direction:      dirStr,
 		Provider:       "sip",
-		CallerNumber:   stage.FromIdentity,
-		FromNumber:     stage.ToIdentity,
+		CallerNumber:   stage.CallAddress.From,
+		FromNumber:     stage.CallAddress.To,
 		ChannelUUID:    callID,
 	}
 	if err := callContext.SetAuthentication(stage.Auth); err != nil {

--- a/api/assistant-api/sip/pipeline/session_test.go
+++ b/api/assistant-api/sip/pipeline/session_test.go
@@ -65,13 +65,15 @@ func TestEnsureCallContextOutboundFallbackPreservesResolvedRequestIdentities(t *
 	dispatcher := &Dispatcher{}
 
 	call, err := dispatcher.ensureCallContext(context.Background(), sip_infra.SessionEstablishedPipeline{
-		ID:           "call-outbound",
-		Session:      session,
-		Direction:    sip_infra.CallDirectionOutbound,
-		AssistantID:  42,
-		Auth:         auth,
-		FromIdentity: "assistant-line",
-		ToIdentity:   "customer-alias",
+		ID:          "call-outbound",
+		Session:     session,
+		Direction:   sip_infra.CallDirectionOutbound,
+		AssistantID: 42,
+		Auth:        auth,
+		CallAddress: sip_infra.CallAddress{
+			From: "assistant-line",
+			To:   "customer-alias",
+		},
 	}, 84)
 
 	require.NoError(t, err)

--- a/api/assistant-api/sip/pipeline/session_test.go
+++ b/api/assistant-api/sip/pipeline/session_test.go
@@ -49,18 +49,18 @@ func TestReconstructCallContextInboundPreservesSIPIdentities(t *testing.T) {
 
 func TestEnsureCallContextOutboundFallbackPreservesResolvedRequestIdentities(t *testing.T) {
 	auth := newIdentityTestAuthentication()
-	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config: &sip_infra.Config{
+	session, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(&sip_infra.Config{
 			Server:            "sip.example.com",
 			Port:              5060,
 			Transport:         sip_infra.TransportUDP,
 			RTPPortRangeStart: 10000,
 			RTPPortRangeEnd:   10020,
-		},
-		Direction: sip_infra.CallDirectionOutbound,
-		CallID:    "call-outbound",
-		Auth:      auth,
-	})
+		}),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionOutbound),
+		sip_infra.WithSessionCallID("call-outbound"),
+		sip_infra.WithSessionAuth(auth),
+	)
 	require.NoError(t, err)
 	dispatcher := &Dispatcher{}
 

--- a/api/assistant-api/sip/pipeline/transfer_test.go
+++ b/api/assistant-api/sip/pipeline/transfer_test.go
@@ -124,20 +124,20 @@ func newTransferTestConfig() *sip_infra.Config {
 
 func newTransferTestSession(t *testing.T) *sip_infra.Session {
 	t.Helper()
-	s, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config:    newTransferTestConfig(),
-		Direction: sip_infra.CallDirectionInbound,
-	})
+	s, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(newTransferTestConfig()),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionInbound),
+	)
 	require.NoError(t, err)
 	return s
 }
 
 func newTransferTestOutboundSession(t *testing.T) *sip_infra.Session {
 	t.Helper()
-	s, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config:    newTransferTestConfig(),
-		Direction: sip_infra.CallDirectionOutbound,
-	})
+	s, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(newTransferTestConfig()),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionOutbound),
+	)
 	require.NoError(t, err)
 	return s
 }

--- a/api/assistant-api/sip/sip.go
+++ b/api/assistant-api/sip/sip.go
@@ -293,8 +293,7 @@ func (m *SIPEngine) sessionEstablishedStage(session *sip_infra.Session, identity
 		AssistantID:     assistant.Id,
 		Auth:            auth,
 		RequestURI:      identity.RequestURI,
-		FromIdentity:    identity.FromIdentity,
-		ToIdentity:      identity.ToIdentity,
+		CallAddress:     identity.CallAddress,
 		ConversationID:  session.GetConversationID(),
 	}, nil
 }

--- a/api/assistant-api/sip/sip_test.go
+++ b/api/assistant-api/sip/sip_test.go
@@ -29,18 +29,18 @@ func TestSIPEngineUsesConfiguredServiceID(t *testing.T) {
 
 func TestSessionEstablishedStagePreservesCallAddress(t *testing.T) {
 	auth := &types.Authentication{}
-	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config: &sip_infra.Config{
+	session, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(&sip_infra.Config{
 			Server:            "127.0.0.1",
 			Port:              5060,
 			RTPPortRangeStart: 10000,
 			RTPPortRangeEnd:   10020,
-		},
-		Direction: sip_infra.CallDirectionInbound,
-		CallID:    "call-address",
-		Auth:      auth,
-		Assistant: &internal_assistant_entity.Assistant{},
-	})
+		}),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionInbound),
+		sip_infra.WithSessionCallID("call-address"),
+		sip_infra.WithSessionAuth(auth),
+		sip_infra.WithSessionAssistant(&internal_assistant_entity.Assistant{}),
+	)
 	require.NoError(t, err)
 	address := sip_infra.CallAddress{
 		From:    "+14155550100",
@@ -166,17 +166,17 @@ func (s *sipCallStatusTestStore) UpdateCallStatus(_ context.Context, contextID s
 
 func newSIPCallStatusTestSession(t *testing.T, contextID string) *sip_infra.Session {
 	t.Helper()
-	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
-		Config: &sip_infra.Config{
+	session, err := sip_infra.NewSession(context.Background(),
+		sip_infra.WithSessionConfig(&sip_infra.Config{
 			Server:            "127.0.0.1",
 			Port:              5060,
 			RTPPortRangeStart: 10000,
 			RTPPortRangeEnd:   10020,
-		},
-		Direction: sip_infra.CallDirectionOutbound,
-		CallID:    "sip-call-id",
-		ContextID: contextID,
-	})
+		}),
+		sip_infra.WithSessionDirection(sip_infra.CallDirectionOutbound),
+		sip_infra.WithSessionCallID("sip-call-id"),
+		sip_infra.WithSessionContextID(contextID),
+	)
 	require.NoError(t, err)
 	return session
 }

--- a/api/assistant-api/sip/sip_test.go
+++ b/api/assistant-api/sip/sip_test.go
@@ -13,9 +13,11 @@ import (
 
 	assistant_config "github.com/rapidaai/api/assistant-api/config"
 	callcontext "github.com/rapidaai/api/assistant-api/internal/callcontext"
+	internal_assistant_entity "github.com/rapidaai/api/assistant-api/internal/entity/assistants"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	app_config "github.com/rapidaai/config"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +25,40 @@ import (
 func TestSIPEngineUsesConfiguredServiceID(t *testing.T) {
 	engine := &SIPEngine{cfg: &assistant_config.AssistantConfig{AppConfig: app_config.AppConfig{ServiceID: 9007}}}
 	assert.Equal(t, uint64(9007), engine.cfg.ServiceID)
+}
+
+func TestSessionEstablishedStagePreservesCallAddress(t *testing.T) {
+	auth := &types.Authentication{}
+	session, err := sip_infra.NewSession(context.Background(), &sip_infra.SessionConfig{
+		Config: &sip_infra.Config{
+			Server:            "127.0.0.1",
+			Port:              5060,
+			RTPPortRangeStart: 10000,
+			RTPPortRangeEnd:   10020,
+		},
+		Direction: sip_infra.CallDirectionInbound,
+		CallID:    "call-address",
+		Auth:      auth,
+		Assistant: &internal_assistant_entity.Assistant{},
+	})
+	require.NoError(t, err)
+	address := sip_infra.CallAddress{
+		From:    "+14155550100",
+		To:      "agent-42",
+		FromURI: "sip:+14155550100@carrier.example.com",
+		ToURI:   "sip:agent-42@sip.rapida.ai",
+		Headers: map[string]string{"x-original-called-number": "+14155550200"},
+	}
+
+	stage, err := (&SIPEngine{}).sessionEstablishedStage(session, sip_infra.SIPRequestIdentity{
+		RequestURI:  "sip:agent-42@sip.rapida.ai",
+		CallAddress: address,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, address, stage.CallAddress)
+	assert.Empty(t, stage.FromIdentity)
+	assert.Empty(t, stage.ToIdentity)
 }
 
 func TestPersistRemoteByeCallStatus_UpdatesCompletedDisconnectMetadata(t *testing.T) {

--- a/rfcs/0010-sip-call-address-authentication.md
+++ b/rfcs/0010-sip-call-address-authentication.md
@@ -1,0 +1,213 @@
+# RFC 0010: Telephony Call Address in Assistant Authentication
+
+- Status: Draft
+- Owner: Assistant API Telephony and Authentication
+- Created: 2026-08-24
+- Updated: 2026-08-24
+- Reviewers: Telephony, Authentication, UI, Security
+
+## Summary
+
+Replace telephony-owned `client.*` metadata and authentication sources with one provider-neutral
+`telephony.*` contract. Every provider publishes actual call-direction From and To phone values.
+Native SIP additionally publishes full party URIs. SIP headers remain internal to `CallAddress`.
+
+This is an intentional breaking change. Removed telephony `client.*` keys have no runtime aliases.
+
+## Context
+
+All telephony streamers create a `ConversationInitialization` through the shared base streamer, and
+assistant authentication resolves its metadata through the default variable registry. Today that
+path publishes role-based keys such as `client.phone` and `client.assistant_phone`. Those names do
+not represent wire-level From and To consistently across inbound and outbound calls.
+
+Provider webhooks and outbound APIs already supply From and To values. Native SIP has the richer
+`CallAddress` snapshot with parsed users, full URIs, and filtered headers. Authentication should
+use one namespace while retaining provider-specific optional detail.
+
+## Goals
+
+- Publish `telephony.from_phone` and `telephony.to_phone` for every provider when available.
+- Publish provider, direction, call ID, context ID, codec, and sample rate under `telephony.*`.
+- Publish `telephony.from_uri` and `telephony.to_uri` for native SIP.
+- Remove telephony fields from the authentication UI's `client` source.
+- Remove runtime compatibility aliases for the replaced telephony `client.*` keys.
+- Keep genuine client-device metadata such as timezone and user agent under `client.*`.
+
+## Non-Goals
+
+- Converting phone values to E.164.
+- Resolving an agent SIP URI through an external DID lookup.
+- Fabricating URI or header values for non-SIP providers.
+- Changing authentication HTTP execution semantics.
+- Changing protobuf definitions or database schemas.
+
+## Scope and Ownership
+
+### Allowed Paths
+
+- `rfcs/0010-sip-call-address-authentication.md` and JSON artifacts
+- `api/assistant-api/internal/type/telephony.go`
+- `api/assistant-api/internal/channel/telephony/**`
+- `api/assistant-api/sip/pipeline/runtime.go`
+- `api/assistant-api/internal/observability/conversation.go`
+- `api/assistant-api/internal/services/assistant/conversaction.impl.service.go`
+- `api/assistant-api/internal/variable/namespace/registry.go`
+- focused tests in the changed backend packages
+- `ui/src/app/pages/assistant/actions/configure-assistant-authentication/**`
+- `ui/src/app/pages/assistant/view/conversations/**`
+- `ui/src/utils/prompt-reserved-variables.ts`
+
+### Out-of-Scope Paths
+
+- `protos/**`
+- database migrations
+- `api/assistant-api/internal/authentication/http/**`
+- STT, TTS, VAD, EOS, and LLM implementations
+
+## Proposed Design
+
+The canonical runtime keys are:
+
+| Runtime source | Availability |
+| --- | --- |
+| `telephony.from_phone` | Every provider when supplied |
+| `telephony.to_phone` | Every provider when supplied |
+| `telephony.direction` | Every provider |
+| `telephony.provider` | Every provider |
+| `telephony.provider_call_id` | When supplied |
+| `telephony.context_id` | When supplied |
+| `telephony.codec` | When known |
+| `telephony.sample_rate` | When known |
+| `telephony.from_uri` | Native SIP |
+| `telephony.to_uri` | Native SIP |
+
+`CallInfo` gains explicit `FromPhone` and `ToPhone` fields owned by each provider. Providers fill
+them directly from webhook values or outbound arguments. Authentication never reconstructs wire
+direction from the role-based `CallerNumber` and `FromNumber` fields.
+
+For persisted call context data, From and To are assigned as follows:
+
+- inbound: From is the caller number and To is the assistant/provider number
+- outbound: From is the assistant/provider number and To is the called number
+
+Native SIP uses its immutable `CallAddress` directly instead of re-deriving party values. The SIP
+streamer adds URI fields to the base initialization metadata. Headers are not projected into
+authentication metadata.
+
+The default variable registry registers `telephony` over the `telephony.` metadata prefix. The
+authentication executor remains unchanged because `registry.Apply` already maps runtime sources
+to configured outgoing JSON keys.
+
+The authentication UI replaces its telephony-oriented `Client` choices with a `Telephony` group.
+The default body becomes:
+
+```json
+{
+  "assistant.id": "assistantId",
+  "telephony.from_phone": "fromPhone",
+  "telephony.to_phone": "toPhone"
+}
+```
+
+## Provider Mapping
+
+- Exotel inbound: `CallFrom` to From and `CallTo` to To.
+- Twilio inbound: `From` to From and `To` to To.
+- Other inbound providers map their existing caller and destination fields when present.
+- Every outbound provider maps its existing `fromPhone` and `toPhone` arguments directly.
+- Native SIP maps phone and URI fields from `CallAddress`.
+- Missing provider values are omitted, not replaced with empty strings or role guesses.
+
+## Contracts and Compatibility
+
+- `client.phone`, `client.assistant_phone`, `client.direction`, `client.channel`,
+  `client.provider_call_id`, `client.context_id`, `client.codec`, and `client.sample_rate` are
+  removed from telephony production, resolution, UI selection, prompt suggestions, and display.
+- Existing saved mappings using those keys stop resolving until changed to `telephony.*`.
+- No legacy aliases or dual writes are added.
+- Non-telephony `client.*` metadata remains supported.
+
+## Failure and Recovery
+
+- Missing optional fields are omitted by existing registry behavior.
+- A provider that lacks a reliable destination does not invent `telephony.to_phone`.
+- SIP URI metadata conversion failure does not block media startup.
+- Existing authentication timeout and failure handling remain unchanged.
+
+## Security and Privacy
+
+- SIP headers are not exposed to assistant authentication.
+- Raw addresses are not added to metric labels or logs.
+- Provider signaling values are claims, not proof of caller ownership.
+
+## Observability
+
+Rename telephony metadata constants and emitted keys to `telephony.*`. Update backend conversation
+query translation, conversation display, and search fields to use the new keys. Do not dual write
+old values.
+
+## Data and Migration
+
+No schema migration. Previously persisted conversations retain old metadata keys and are
+intentionally unsupported by the new telephony filters and channel display. Saved authentication
+mappings and prompts are not rewritten automatically; removed telephony `client.*` sources resolve
+absent until manually edited.
+
+## Rollout
+
+Deploy backend and UI together. Validate inbound and outbound calls for native SIP and at least one
+webhook provider. Stop rollout if From and To are reversed, credential headers appear, or a
+non-telephony `client.*` variable regresses.
+
+## Rollback
+
+Revert the backend and UI change together. New `telephony.*` mappings created during rollout will
+not resolve after rollback.
+
+## Alternatives Considered
+
+- Keep `client.*` aliases: rejected by product direction because there must be one contract.
+- Use `sip.*` for every field: rejected because From and To are available across providers.
+- Use `client.sip.*`: rejected because signaling direction is not client identity.
+- Change protobufs: rejected because initialization metadata already carries the values.
+
+## Testing and Verification
+
+- Provider tests cover explicit From/To capture for Exotel, Twilio, Telnyx, Vonage, Vobiz,
+  Asterisk, and native SIP where each direction is supported.
+- Base streamer tests cover explicit From/To projection and omitted values.
+- Native SIP tests cover phone and URI projection while proving headers are not exposed.
+- Registry and authentication dispatch tests cover `telephony.*` mapping.
+- Provider tests cover existing Exotel and Twilio inbound mappings and outbound direction.
+- UI tests cover the Telephony group, removed telephony Client choices, default mapping, and saved JSON.
+- Conversation UI tests cover `telephony.provider` display and search fields.
+- Run focused Go and UI tests, `git diff --check`, and `make agent-finalize CHANGED_FILES="..."`.
+
+## Acceptance Criteria
+
+- [ ] All telephony providers use the shared `telephony.*` initialization path.
+- [ ] From and To retain wire direction for inbound and outbound calls.
+- [ ] Native SIP authentication can map phone and URI values, but not SIP headers.
+- [ ] Removed telephony `client.*` keys are neither emitted nor selectable.
+- [ ] Genuine non-telephony `client.*` metadata remains resolvable.
+- [ ] Existing HTTP authentication execution remains unchanged.
+- [ ] Required tests and repository finalization pass.
+
+## Open Questions
+
+None.
+
+## Challenge Resolution
+
+Pending independent challenge.
+
+## Artifact Index
+
+- `jsons/plan.json`: implementation plan, draft
+
+## Decision Log
+
+| Date | Decision | Owner | Evidence |
+| --- | --- | --- | --- |
+| 2026-08-24 | Replace telephony `client.*` with `telephony.*` without aliases | Product | User direction |

--- a/rfcs/0010-sip-call-address-authentication/jsons/challenge-02.json
+++ b/rfcs/0010-sip-call-address-authentication/jsons/challenge-02.json
@@ -1,0 +1,81 @@
+{
+  "status": "changes_requested",
+  "decision": "not_approved",
+  "reviewed_at": "2026-08-24",
+  "reviewer": "independent plan challenger",
+  "rfc_file": "rfcs/0010-sip-call-address-authentication.md",
+  "rfc_sha256": "d9890e085a9497980c2a5c53dcb5bb69c2242fd64ebddcb9298e347ec0de586d",
+  "plan_file": "rfcs/0010-sip-call-address-authentication/jsons/plan.json",
+  "plan_sha256": "16c242a582a31195094f4e05202a0eee0d53da653447bd336db2cd1f0ad93eb0",
+  "critical_findings": [],
+  "major_findings": [
+    {
+      "id": "major-1-provider-contract-matrix",
+      "summary": "The provider mapping and test matrix are still not explicit enough to prove the FromPhone and ToPhone contract for every provider and supported direction.",
+      "details": "The RFC now defines independent CallInfo FromPhone and ToPhone fields and correct wire-direction semantics, resolving the shared-contract portion of the prior finding. However, the provider section names only Exotel and Twilio inbound mappings, groups Asterisk, Telnyx, Vobiz, and Vonage as other providers, and groups every outbound implementation under one statement. The test section similarly uses where each direction is supported without recording which directions are supported or the exact source fields and expected omissions. Current provider implementations differ materially in inbound field names and outbound CallInfo population, so this leaves implementation and verification decisions implicit.",
+      "paths": [
+        "rfcs/0010-sip-call-address-authentication.md",
+        "rfcs/0010-sip-call-address-authentication/jsons/plan.json",
+        "api/assistant-api/internal/channel/telephony/internal/asterisk/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/telnyx/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/twilio/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/vobiz/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/vonage/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/sip/telephony.go"
+      ],
+      "required_resolution": "Add a provider-by-provider matrix covering inbound and outbound support, the exact source for FromPhone and ToPhone, omission behavior, and the exact provider test case required for each supported direction."
+    },
+    {
+      "id": "major-2-backend-query-verification",
+      "summary": "Backend conversation query translation is now in production scope but has no corresponding allowed test path or explicit verification case.",
+      "details": "The RFC correctly adds conversaction.impl.service.go and defines new filters as intentionally unsupported for historical client.* metadata. The plan does not allow a test file in api/assistant-api/internal/services/assistant, does not require a test that proves each telephony.* query key selects the matching metadata key, and provides no focused service test command. This violates the repository requirement that changed backend behavior include package-level test coverage and leaves the previously missed query behavior unverifiable.",
+      "paths": [
+        "rfcs/0010-sip-call-address-authentication/jsons/plan.json",
+        "api/assistant-api/internal/services/assistant/conversaction.impl.service.go",
+        "api/assistant-api/internal/services/assistant"
+      ],
+      "required_resolution": "Allow a focused assistant-service test file, specify success and unsupported-historical-key cases for the new telephony query translation, and add the exact package test command."
+    },
+    {
+      "id": "major-3-breaking-consumer-inventory",
+      "summary": "The breaking-change inventory remains incomplete and the allowed paths cannot update all tests and generated examples that encode the removed keys.",
+      "details": "The RFC identifies runtime metadata, authentication UI, prompt suggestions, conversation display, and filters, but does not enumerate all concrete consumers. Repository search also finds prompt-editor and configuration tests outside the allowed UI paths, plus the Postman collection generator and generated collections containing the old default authentication body. The plan's broad assertion that no telephony-owned client.* key remains cannot be satisfied without distinguishing historical migration fixtures from active consumers and including every active source and required test path.",
+      "paths": [
+        "rfcs/0010-sip-call-address-authentication.md",
+        "rfcs/0010-sip-call-address-authentication/jsons/plan.json",
+        "ui/src/app/components/prompt-editor/suggestions.test.ts",
+        "ui/src/app/components/configuration/config-prompt/index.test.tsx",
+        "openapi/scripts/generate_assistant_postman_collection.py",
+        "openapi/postman/assistant-api/assistant-api.postman_collection.json",
+        "openapi/postman/assistant-api/assistant-api.smoke.postman_collection.json"
+      ],
+      "required_resolution": "Add an explicit active-consumer inventory, classify historical fixtures that intentionally retain client.* text, include all affected source and test paths, and refresh generated API examples through their generator if the old authentication default is part of this contract."
+    },
+    {
+      "id": "major-4-unaccepted-review-bytes",
+      "summary": "The challenged RFC and plan are still marked Draft, so these exact bytes cannot receive governed approval.",
+      "details": "The repository process requires the final challenged RFC bytes to contain the sole metadata status line Status: Accepted before approval. The RFC has Status: Draft, the plan has status draft, and the challenge-resolution section is pending. Approval of these bytes would bypass the exact-digest gate contract.",
+      "paths": [
+        "rfcs/0010-sip-call-address-authentication.md",
+        "rfcs/0010-sip-call-address-authentication/jsons/plan.json",
+        "DEVELOPMENT_PROCESS.md"
+      ],
+      "required_resolution": "Resolve the content findings, mark the final RFC and plan accepted as required by the governed workflow, update the challenge-resolution and artifact index, then submit the exact revised bytes for challenge."
+    }
+  ],
+  "resolved_prior_findings": [
+    {
+      "id": "major-1-address-contract",
+      "resolution": "The RFC now explicitly adds CallInfo FromPhone and ToPhone, assigns wire-direction semantics, forbids role-based reconstruction, and defines omission behavior. Provider-by-provider completeness remains separately blocked."
+    },
+    {
+      "id": "major-2-incomplete-consumer-scope",
+      "resolution": "The backend conversation query implementation is now an allowed production path and historical client.* records are explicitly unsupported by new filters. Test scope remains separately blocked."
+    },
+    {
+      "id": "major-3-sip-header-exposure",
+      "resolution": "SIP headers are removed from authentication metadata and the native SIP contract is limited to phone and URI fields."
+    }
+  ]
+}

--- a/rfcs/0010-sip-call-address-authentication/jsons/challenge.json
+++ b/rfcs/0010-sip-call-address-authentication/jsons/challenge.json
@@ -1,0 +1,85 @@
+{
+  "status": "changes_requested",
+  "decision": "not_approved",
+  "reviewed_at": "2026-08-24",
+  "critical_findings": [],
+  "major_findings": [
+    {
+      "id": "major-1-address-contract",
+      "summary": "The shared telephony model does not currently represent wire-level From and To as independent values.",
+      "details": "CallInfo exposes role-based CallerNumber and an overloaded FromNumber. Its comments define CallerNumber as the client for both directions and FromNumber only as the outbound origin, while inbound providers also use FromNumber for the destination or assistant number. The RFC requires actual telephony.from_phone and telephony.to_phone across every provider, but does not define the model change and provider-by-provider source mapping needed to preserve wire direction without role inference.",
+      "paths": [
+        "api/assistant-api/internal/type/telephony.go",
+        "api/assistant-api/internal/channel/telephony/inbound.go",
+        "api/assistant-api/internal/channel/telephony/outbound.go",
+        "api/assistant-api/internal/channel/telephony/internal/base/base.go",
+        "api/assistant-api/internal/channel/telephony/internal/asterisk/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/exotel/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/telnyx/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/twilio/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/vobiz/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/vonage/telephony.go",
+        "api/assistant-api/internal/channel/telephony/internal/sip/telephony.go"
+      ],
+      "required_resolution": "Define explicit FromPhone and ToPhone ownership in the shared call contract, inventory each inbound and outbound provider mapping, and specify behavior when a provider does not supply one side. CallAddress remains authoritative for native SIP."
+    },
+    {
+      "id": "major-2-incomplete-consumer-scope",
+      "summary": "The allowed implementation scope omits backend conversation filtering that is hard-coded to the removed client.* keys.",
+      "details": "The RFC includes conversation UI changes but excludes the service query implementation that resolves direction, channel, call ID, codec, sample rate, context ID, phone, and assistant phone filters. Updating only metadata production and UI selectors would leave conversation searches querying obsolete keys.",
+      "paths": [
+        "api/assistant-api/internal/services/assistant/conversaction.impl.service.go",
+        "ui/src/app/pages/assistant/view/conversations/session-query-search.tsx",
+        "ui/src/app/pages/assistant/view/conversations/session-list.helpers.ts",
+        "api/assistant-api/internal/observability/conversation.go"
+      ],
+      "required_resolution": "Add the conversation service implementation and focused tests to allowed scope, and define whether historical conversations containing client.* remain searchable or are intentionally unsupported."
+    },
+    {
+      "id": "major-3-sip-header-exposure",
+      "summary": "The proposed telephony.headers source is too broad for an authentication payload contract.",
+      "details": "Explicit UI mapping limits accidental transmission, but once selected the complete captured header map is sent to an external authentication endpoint. Excluding only Authorization and Proxy-Authorization does not address identity, routing, challenge, vendor, or custom headers that may contain credentials or personal data. The RFC has no allowlist, configurable selection, size limit, or logging and persistence constraints for this map.",
+      "paths": [
+        "api/assistant-api/sip/internal/core/inbound_call.go",
+        "api/assistant-api/internal/channel/telephony/internal/sip/streamer.go",
+        "api/assistant-api/internal/adapters/internal/dispatch_handler.go",
+        "api/assistant-api/internal/authentication/http/executor.go",
+        "ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts"
+      ],
+      "required_resolution": "Replace the unrestricted header map with an explicit safe allowlist or individually selected header sources, define case and repeated-header behavior, cap transmitted size, and add tests proving credential and identity-sensitive headers cannot be forwarded unintentionally."
+    },
+    {
+      "id": "major-4-breaking-consumer-inventory",
+      "summary": "Removing telephony-owned client.* keys affects more than authentication and the RFC does not fully specify those runtime compatibility consequences.",
+      "details": "The same keys are exposed as prompt variables, persisted conversation metadata, observability constants, display fields, and search filters. Existing assistant prompts and saved authentication mappings will silently resolve missing values. Declaring a breaking change is insufficient without an exhaustive consumer inventory, explicit release boundary, and tests proving genuine client.* metadata remains unaffected.",
+      "paths": [
+        "ui/src/utils/prompt-reserved-variables.ts",
+        "ui/src/app/components/prompt-editor/suggestions.test.ts",
+        "api/assistant-api/internal/observability/conversation.go",
+        "api/assistant-api/internal/services/assistant/conversaction.impl.service.go",
+        "api/assistant-api/internal/variable/namespace/registry.go",
+        "api/assistant-api/internal/adapters/internal/dispatch_handler.go",
+        "ui/src/app/pages/assistant/actions/configure-assistant-authentication/shared.ts"
+      ],
+      "required_resolution": "Document the complete removal inventory and release/migration behavior, update allowed paths and tests for every consumer, and state whether stored configurations and prompts are rejected, migrated, or intentionally allowed to resolve absent values."
+    }
+  ],
+  "minor_findings": [
+    {
+      "id": "minor-1-provider-name",
+      "summary": "The RFC uses telephony.provider while the removed contract uses client.channel; the semantic rename should be explicit in UI labels, filters, and observability constants."
+    },
+    {
+      "id": "minor-2-test-matrix",
+      "summary": "The test plan should name every provider and both directions where supported instead of relying on a shared base test to prove provider-specific From and To mappings."
+    }
+  ],
+  "required_before_rechallenge": [
+    "Revise the RFC and plan JSON to define an explicit provider-neutral FromPhone and ToPhone contract.",
+    "Add missing backend conversation query paths and tests to implementation scope.",
+    "Replace unrestricted SIP header forwarding with a least-privilege contract.",
+    "Complete the breaking-change consumer inventory and migration or release behavior.",
+    "Provide a provider-by-provider inbound and outbound verification matrix."
+  ],
+  "independence_note": "The dispatched independent challenger could not execute because its provider account reported an insufficient credit balance. This conservative non-approval was recorded rather than falsely approving an unchallenged governed change."
+}

--- a/rfcs/0010-sip-call-address-authentication/jsons/plan.json
+++ b/rfcs/0010-sip-call-address-authentication/jsons/plan.json
@@ -1,0 +1,74 @@
+{
+  "status": "draft",
+  "objective": "Replace telephony-owned client.* metadata and authentication sources with provider-neutral telephony.* fields, including SIP-only URI details.",
+  "acceptance_criteria": [
+    "All telephony providers publish telephony.from_phone and telephony.to_phone when their runtime supplies those values.",
+    "Native SIP publishes telephony.from_uri and telephony.to_uri from CallAddress without exposing SIP headers.",
+    "Telephony client.* keys are no longer emitted, resolved as aliases, or selectable in the authentication UI.",
+    "Non-telephony client.* metadata remains supported.",
+    "Authentication mappings resolve telephony.* sources to configured payload keys.",
+    "Required backend and UI tests plus make agent-finalize pass."
+  ],
+  "allowed_paths": [
+    "rfcs/0010-sip-call-address-authentication.md",
+    "rfcs/0010-sip-call-address-authentication/jsons/**",
+    "api/assistant-api/internal/type/telephony.go",
+    "api/assistant-api/internal/channel/telephony/**",
+    "api/assistant-api/sip/pipeline/runtime.go",
+    "api/assistant-api/internal/observability/conversation.go",
+    "api/assistant-api/internal/services/assistant/conversaction.impl.service.go",
+    "api/assistant-api/internal/variable/namespace/registry.go",
+    "api/assistant-api/internal/variable/**/*_test.go",
+    "api/assistant-api/internal/adapters/internal/*_test.go",
+    "ui/src/app/pages/assistant/actions/configure-assistant-authentication/**",
+    "ui/src/app/pages/assistant/view/conversations/**",
+    "ui/src/utils/prompt-reserved-variables.ts"
+  ],
+  "out_of_scope_paths": [
+    "protos/**",
+    "migrations/**",
+    "api/assistant-api/internal/authentication/http/**",
+    "api/assistant-api/internal/transformer/**",
+    "api/integration-api/**"
+  ],
+  "ownership": {
+    "provider CallInfo": "owns explicit provider-supplied FromPhone and ToPhone values",
+    "base telephony streamer": "owns common telephony initialization metadata",
+    "native SIP streamer": "adds authoritative CallAddress URI fields without exposing headers",
+    "variable registry": "owns telephony.* resolution",
+    "authentication UI": "owns source selection and persisted mapping presentation",
+    "conversation UI": "owns telephony metadata display and filters"
+  },
+  "principles": {
+    "single_source_of_truth": "Each provider supplies one party-address state; metadata is a transport projection.",
+    "breaking_change": "No client.* compatibility aliases or dual writes are retained for telephony fields.",
+    "least_privilege": "SIP headers remain internal and are not available to authentication.",
+    "scope": "Genuine client-device metadata remains under client.*."
+  },
+  "risks": [
+    "Existing saved authentication mappings using telephony client.* keys stop resolving.",
+    "Previously persisted conversations retain old keys and may not appear in new filters.",
+    "Provider-specific inbound payloads may omit a reliable destination number.",
+    "From and To can be reversed if role-based call context fields are interpreted incorrectly.",
+    "Existing prompts and saved mappings using removed telephony client.* keys resolve absent until manually updated."
+  ],
+  "required_tests": [
+    "Base initialization covers inbound and outbound telephony From and To.",
+    "Native SIP initialization includes URI values and excludes all headers.",
+    "The telephony namespace resolves scalar and map values.",
+    "Authentication dispatch maps telephony.* sources to payload keys.",
+    "UI selection, defaults, conversation display, and filters use telephony.*.",
+    "No telephony-owned client.* key remains in runtime, prompt suggestions, filters, or authentication UI paths."
+  ],
+  "required_commands": [
+    "go test ./api/assistant-api/internal/channel/telephony/...",
+    "go test ./api/assistant-api/internal/variable/...",
+    "go test ./api/assistant-api/internal/adapters/internal",
+    "go test ./api/assistant-api/internal/observability",
+    "go test ./api/assistant-api/sip/pipeline",
+    "cd ui && yarn test --watchAll=false --runInBand --runTestsByPath src/app/pages/assistant/actions/configure-assistant-authentication/__tests__/index.test.tsx",
+    "git diff --check",
+    "make agent-finalize CHANGED_FILES=\"comma-separated changed paths\""
+  ],
+  "rollback": "Revert backend and UI together. No schema rollback is required, but mappings created with telephony.* will not resolve on the reverted version."
+}


### PR DESCRIPTION
## Summary
- introduce one authoritative SIP `CallAddress` containing From, To, full URIs, and filtered headers
- carry `CallAddress` through inbound and outbound SIP lifecycle without duplicate identity state
- parse SIP disconnect details once through `NewSIPReason(request)` and let `SIPReason` own metadata mapping
- consolidate SIP server, request context, call address, and buffer constants in `types.go`
- replace `SessionConfig` with LiveKit-style functional session options that mutate the owned session
- remove logger ownership from `Session` and keep logging with server/call lifecycle owners
- remove the deprecated `ExtractDIDFromURI` facade and its tests
- add RFC 0010 and challenge evidence for the proposed breaking `telephony.*` authentication migration

## Current scope
This PR implements the SIP request and session ownership refactors. The `telephony.*` authentication/UI migration is documented but intentionally not implemented because RFC 0010 still has unresolved major challenge findings.

## Verification
- `go test ./api/assistant-api/sip/internal/core ./api/assistant-api/sip/infra ./api/assistant-api/sip/pipeline ./api/assistant-api/sip -count=1`
- `make agent-finalize CHANGED_FILES="..."`
- `git diff --check`

## Known environment issue
The commit-time `go-security-scan` typecheck cannot compile the existing RNNoise package because `RNNoise` and `NewRNNoise` are unavailable in this local build environment. Only that hook was skipped. Focused SIP tests, finalizer tests, `go vet` on CI-safe packages, and CI binary builds passed.

## RFC status
RFC 0010 remains Draft and is not approved. Do not merge the breaking authentication migration until its remaining provider mapping, backend filter, prompt/Postman inventory, and confirmation requirements are resolved.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates SIP party data into an authoritative `CallAddress`, moves session construction to functional options, and centralizes disconnect parsing and shared SIP types.
- Propagates parsed SIP users, full URIs, and filtered headers through inbound and outbound lifecycles.
- Removes duplicate session identity and logger ownership while updating pipeline and facade contracts.
- Adds draft RFC 0010 and challenge artifacts without implementing the proposed authentication migration.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The disconnect-reason regression should be fixed before merging because valid non-error SIP causes can be persisted as remote errors.

The refactor generally preserves SIP request and session ownership, but the new generic Reason fallback changes completed-call status for unmapped SIP causes; the remaining comment issue is non-blocking.

**Files Needing Attention:** api/assistant-api/sip/internal/core/sip_reason.go, api/assistant-api/sip/internal/core/session.go
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/assistant-api/sip/internal/core/types.go | Centralizes CallAddress, middleware types, constants, and vault parsing; supported port and header input shapes remain handled. |
| api/assistant-api/sip/internal/core/session.go | Replaces SessionConfig with functional options and removes logger ownership; one changed comment violates repository prose rules. |
| api/assistant-api/sip/internal/core/sip_reason.go | Encapsulates Reason parsing and metadata mapping but incorrectly classifies unmapped positive SIP causes as remote errors. |
| api/assistant-api/sip/internal/core/inbound_call.go | Captures one authoritative inbound CallAddress and carries it through middleware and callbacks. |
| api/assistant-api/sip/internal/core/outbound_call.go | Constructs outbound callback identity from the actual INVITE while preserving authoritative requested users. |
| api/assistant-api/sip/pipeline/session.go | Uses CallAddress user fields for conversation and call-context identities in accordance with the new contract. |
| api/assistant-api/sip/infra/server.go | Projects the core CallAddress through facade middleware and legacy callback compatibility fields. |
| rfcs/0010-sip-call-address-authentication.md | Documents the deferred authentication migration and explicitly leaves it unapproved and unimplemented. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Peer as SIP Peer
    participant Server as SIP Server
    participant Address as CallAddress
    participant Pipeline as Session Pipeline
    participant Store as Call Context Store
    Peer->>Server: INVITE with From, To, headers
    Server->>Address: NewCallAddress(request)
    Address-->>Server: users, full URIs, filtered headers
    Server->>Pipeline: SessionEstablishedPipeline
    Pipeline->>Store: conversation and call identity
    Peer->>Server: BYE with Reason header
    Server->>Server: NewSIPReason(request)
    Server->>Store: completed status and disconnect metadata
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
api/assistant-api/sip/internal/core/sip_reason.go:123-125
**Unmapped SIP causes become errors**

When a remote BYE contains an unmapped SIP cause below 400, the generic positive-cause fallback classifies it as `remote_error`, causing redirects and provisional causes to be persisted with an incorrect disconnect reason.

```suggestion
	if metadata.Reason == DisconnectReasonRemoteHangup &&
		reason.Cause > 0 &&
		(reason.Protocol != "sip" || reason.Cause >= 400) {
		metadata.Reason = DisconnectReasonRemoteError
	}
```

### Issue 2
api/assistant-api/sip/internal/core/session.go:769
**Prohibited em dash in comment**

This changed production comment uses an em dash, contrary to the repository's canonical prose convention, creating avoidable finalization cleanup.

```suggestion
	// Cancel context to unblock anything waiting on session.Context().
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: simplify SIP request and sessi..."](https://github.com/rapidaai/voice-ai/commit/71769218546f2c9a3048f0613cc04513827af20a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56352743)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rapidaai/voice-ai/blob/main/AGENTS.md))

<!-- /greptile_comment -->