### PR TITLE
fix: improve assistant table date UX

### DIFF
--- a/ui/src/app/pages/activities/conversation-activity-v2/utils.test.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/utils.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   createTraceFilter,
   dedupeTraceFilters,
+  formatDateTime,
   getDocumentComponent,
   getTraceFilterValues,
   matchesTraceFilters,
@@ -64,6 +65,32 @@ const observabilityRecord = (metric: any) =>
   }) as any;
 
 describe('conversation activity v2 telemetry utilities', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('formats trace occurrence dates with the shared table contract', () => {
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockReturnValue([
+        { type: 'weekday', value: 'Mon' },
+        { type: 'day', value: '24' },
+        { type: 'month', value: 'Aug' },
+        { type: 'year', value: '2026' },
+        { type: 'hour', value: '16' },
+        { type: 'minute', value: '24' },
+        { type: 'second', value: '11' },
+      ]);
+
+    expect(formatDateTime('2026-08-24T10:54:11.000Z')).toBe(
+      'Mon, 24 Aug 2026 16:24:11',
+    );
+  });
+
+  it('preserves invalid trace occurrence values', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+  });
+
   it('uses component latency metrics as waterfall durations', () => {
     const document = telemetryRecordToTimelineDocument(
       observabilityRecord(

--- a/ui/src/app/pages/activities/conversation-activity-v2/utils.ts
+++ b/ui/src/app/pages/activities/conversation-activity-v2/utils.ts
@@ -11,6 +11,7 @@ import type {
   ObservabilityMetricRecord,
   ObservabilityRecord,
 } from '@rapidaai/react';
+import { toHumanReadableDateTimeFromDate } from '@/utils/date';
 
 const MIN_VISIBLE_WIDTH_PCT = 0.75;
 
@@ -985,7 +986,7 @@ export const formatTime = (value: string): string => {
 export const formatDateTime = (value: string | number): string => {
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return String(value);
-  return date.toUTCString();
+  return toHumanReadableDateTimeFromDate(date);
 };
 
 export const sampleTimelineDocuments: TimelineDocument[] = [

--- a/ui/src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx
+++ b/ui/src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx
@@ -91,7 +91,11 @@ const makeAssistant = (overrides: Record<string, any> = {}) =>
     getWebplugindeployment: () => null,
     getPhonedeployment: () => null,
     getUpdateddate: () => makeTimestamp(400),
-    getCreatedactor: () => ({ getType: () => 'user', getId: () => '42', getDisplayname: () => 'Prashant' }),
+    getCreatedactor: () => ({
+      getType: () => 'user',
+      getId: () => '42',
+      getDisplayname: () => 'Prashant',
+    }),
     ...overrides,
   }) as any;
 
@@ -134,7 +138,8 @@ describe('assistant listing table UX', () => {
     expect(screen.queryByText('billing')).not.toBeInTheDocument();
     expect(screen.getByText('+1')).toBeInTheDocument();
     expect(screen.getByText('date:400')).toBeInTheDocument();
-    expect(screen.getByText('Prashant')).toBeInTheDocument();
+    expect(screen.queryByText('Prashant')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('cell')).toHaveLength(9);
   });
 
   it('keeps assistants without deployments actionable from the table row', () => {
@@ -156,7 +161,6 @@ describe('assistant listing table UX', () => {
     expect(screen.getByText('Not configured')).toBeInTheDocument();
     expect(screen.getByText('prompt')).toBeInTheDocument();
     expect(screen.getAllByText('-')).toHaveLength(3);
-    expect(screen.getByText('—')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Set up deployment' }));
     expect(mockGoToManageAssistant).toHaveBeenCalledWith('assistant-1');

--- a/ui/src/app/pages/assistant/listing/index.tsx
+++ b/ui/src/app/pages/assistant/listing/index.tsx
@@ -51,7 +51,6 @@ const assistantColumnClassName: Record<string, string> = {
   actions: 'w-28 min-w-28 whitespace-nowrap',
   tags: 'min-w-40 whitespace-nowrap',
   updated: 'min-w-36 whitespace-nowrap',
-  owner: 'min-w-32 whitespace-nowrap',
 };
 
 const assistantColumns = [
@@ -64,7 +63,6 @@ const assistantColumns = [
   { name: 'Actions', key: 'actions' },
   { name: 'Tags', key: 'tags' },
   { name: 'Updated', key: 'updated' },
-  { name: 'Owner', key: 'owner' },
 ];
 
 const assistantSkeletonCellWidth: Record<string, string> = {
@@ -77,7 +75,6 @@ const assistantSkeletonCellWidth: Record<string, string> = {
   actions: '96px',
   tags: '116px',
   updated: '128px',
-  owner: '84px',
 };
 
 const formatQuerySearchValue = (key: string, value: string): string =>
@@ -182,7 +179,7 @@ export function AssistantPage() {
         />
       ) : assistantAction.assistants &&
         assistantAction.assistants.length > 0 ? (
-        <div className="overflow-auto flex-1">
+        <div className="no-scrollbar overflow-auto flex-1">
           <Table>
             <TableHead>
               <TableRow>
@@ -266,7 +263,10 @@ function AssistantTableSkeleton({ rowCount }: { rowCount: number }) {
   const rows = Array.from({ length: rowCount }, (_, index) => index);
 
   return (
-    <div className="overflow-auto flex-1" aria-label="Loading assistants">
+    <div
+      className="no-scrollbar overflow-auto flex-1"
+      aria-label="Loading assistants"
+    >
       <Table>
         <TableHead>
           <TableRow>

--- a/ui/src/app/pages/assistant/listing/single-assistant.tsx
+++ b/ui/src/app/pages/assistant/listing/single-assistant.tsx
@@ -9,7 +9,6 @@ import { RecordStatusIndicator } from '@/app/components/carbon/record-status-ind
 import { IconOnlyButton } from '@/app/components/carbon/button';
 import { CopyButton } from '@/app/components/carbon/button/copy-button';
 import { VersionIndicator } from '@/app/components/indicators/version';
-import { auditActorLabel, createdAuditActor } from '@/utils/audit-actor';
 
 const SingleAssistant: FC<{ assistant: Assistant }> = ({ assistant }) => {
   const gn = useGlobalNavigation();
@@ -18,7 +17,6 @@ const SingleAssistant: FC<{ assistant: Assistant }> = ({ assistant }) => {
   const tags = assistant.getAssistanttag()?.getTagList() ?? [];
   const visibleTags = tags.slice(0, 2);
   const overflowTagCount = Math.max(tags.length - visibleTags.length, 0);
-  const owner = auditActorLabel(createdAuditActor(assistant));
   const hasDeployment = hasAssistantDeployment(assistant);
 
   return (
@@ -144,10 +142,6 @@ const SingleAssistant: FC<{ assistant: Assistant }> = ({ assistant }) => {
         {assistant.getUpdateddate()
           ? toHumanReadableDateTime(assistant.getUpdateddate()!)
           : '-'}
-      </TableCell>
-
-      <TableCell className="text-sm">
-        <span className="capitalize">{owner || '-'}</span>
       </TableCell>
     </TableRow>
   );

--- a/ui/src/utils/date.test.ts
+++ b/ui/src/utils/date.test.ts
@@ -1,0 +1,72 @@
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+import {
+  toHumanReadableDateTime,
+  toHumanReadableDateTimeFromDate,
+} from './date';
+
+describe('toHumanReadableDateTime', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('formats timestamps with the table date-time display contract', () => {
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockReturnValue([
+        { type: 'weekday', value: 'Mon' },
+        { type: 'literal', value: ', ' },
+        { type: 'day', value: '24' },
+        { type: 'literal', value: ' ' },
+        { type: 'month', value: 'Aug' },
+        { type: 'literal', value: ' ' },
+        { type: 'year', value: '2026' },
+        { type: 'literal', value: ', ' },
+        { type: 'hour', value: '16' },
+        { type: 'literal', value: ':' },
+        { type: 'minute', value: '24' },
+        { type: 'literal', value: ':' },
+        { type: 'second', value: '11' },
+      ]);
+    const timestamp = new Timestamp();
+    timestamp.setSeconds(1_725_000_000);
+
+    expect(toHumanReadableDateTime(timestamp)).toBe(
+      'Mon, 24 Aug 2026 16:24:11',
+    );
+  });
+
+  it('preserves fractional timestamp precision before formatting', () => {
+    let formattedTime = 0;
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockImplementation(date => {
+        formattedTime = (date as Date).getTime();
+        return [];
+      });
+    const timestamp = new Timestamp();
+    timestamp.setSeconds(1);
+    timestamp.setNanos(500_000_000);
+
+    toHumanReadableDateTime(timestamp);
+
+    expect(formattedTime).toBe(1_500);
+  });
+
+  it('uses the same display contract for Date values', () => {
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+      .mockReturnValue([
+        { type: 'weekday', value: 'Mon' },
+        { type: 'day', value: '24' },
+        { type: 'month', value: 'Aug' },
+        { type: 'year', value: '2026' },
+        { type: 'hour', value: '16' },
+        { type: 'minute', value: '24' },
+        { type: 'second', value: '11' },
+      ]);
+
+    expect(toHumanReadableDateTimeFromDate(new Date())).toBe(
+      'Mon, 24 Aug 2026 16:24:11',
+    );
+  });
+});

--- a/ui/src/utils/date.ts
+++ b/ui/src/utils/date.ts
@@ -76,7 +76,26 @@ export function toHumanReadableDateFromDate(date: Date): string {
 }
 
 export function toHumanReadableDateTime(timestamp: Timestamp): string {
-  return toDate(timestamp).toUTCString();
+  return toHumanReadableDateTimeFromDate(toDate(timestamp));
+}
+
+export function toHumanReadableDateTimeFromDate(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find(part => part.type === type)?.value ?? '';
+
+  return `${value('weekday')}, ${value('day')} ${value('month')} ${value(
+    'year',
+  )} ${value('hour')}:${value('minute')}:${value('second')}`;
 }
 
 export function toHumanReadableRelativeTime(timestamp: Timestamp): string {


### PR DESCRIPTION
## Summary
- hide the assistant listing scrollbar while preserving scrolling
- remove the unused Owner column from assistant rows and loading skeletons
- format shared table timestamps in the user's browser timezone as `Mon, 24 Aug 2026 16:24:11`
- apply the shared format to trace `Occurred at` values

## Testing
- `yarn test --watchAll=false --runTestsByPath src/utils/date.test.ts src/app/pages/activities/conversation-activity-v2/utils.test.ts src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx`
- `yarn checkTs`
- `make agent-finalize CHANGED_FILES="..."` ran the required provider suite: 22 suites and 401 tests passed, but the wrapper returned timeout code 124 after Jest completed


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves assistant-table presentation and standardizes shared timestamps in the user's browser timezone.
- Removes the unused Owner column from assistant rows, headers, and loading skeletons.
- Hides assistant-list scrollbars while preserving overflow scrolling.
- Adds a shared `Intl.DateTimeFormat`-based timestamp format and applies it to trace occurrence dates.
- Adds focused tests for assistant-table structure, invalid trace values, timestamp precision, and formatted output.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The table structure remains aligned after removing the Owner column, and valid and invalid trace timestamps are routed through the intended shared browser-timezone formatting behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ui/src/utils/date.ts | Adds the shared browser-timezone date-time formatter while retaining protobuf nanosecond-to-millisecond conversion. |
| ui/src/app/pages/activities/conversation-activity-v2/utils.ts | Routes valid trace occurrence timestamps through the shared formatter and preserves invalid input values. |
| ui/src/app/pages/assistant/listing/index.tsx | Removes Owner column metadata and applies hidden-scrollbar styling consistently to loaded and loading tables. |
| ui/src/app/pages/assistant/listing/single-assistant.tsx | Removes the Owner cell and its now-unused audit-actor derivation. |
| ui/src/utils/date.test.ts | Covers the shared output contract, Date input path, and preservation of fractional timestamp precision. |
| ui/src/app/pages/assistant/listing/__tests__/assistant-table-ux.test.tsx | Updates table assertions to verify that owner data and the corresponding cell are absent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: improve assistant table date UX"](https://github.com/rapidaai/voice-ai/commit/6cb7a90b5712a903fbe3e3c63f1029bc12e9d60b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56359093)</sub>

<!-- /greptile_comment -->