### PR TITLE
fix: dispatch STT audio before VAD

### DIFF
--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -137,50 +137,59 @@ func (h requestorDispatchHandler) HandleUserText(ctx context.Context, vl interna
 
 func (h requestorDispatchHandler) HandleUserAudio(ctx context.Context, vl internal_type.UserAudioReceivedPacket) {
 	if h.r.denoiserExecutor != nil {
-		h.r.OnPacket(ctx,
-			internal_type.DenoiseAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio},
-		)
+		h.r.OnPacket(ctx, internal_type.DenoiseAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
 		return
 	}
-	if h.r.vadExecutor != nil {
-		h.r.OnPacket(ctx,
-			internal_type.VadAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+
+	if h.r.speechToTextTransformer != nil {
+		h.r.OnPacket(ctx, internal_type.SpeechToTextAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
 	}
-	h.r.OnPacket(ctx,
-		internal_type.SpeechToTextAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio},
-		internal_type.EndOfSpeechAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio},
-	)
+
+	if h.r.vadExecutor != nil {
+		h.r.OnPacket(ctx, internal_type.VadAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	}
+
+	if h.r.endOfSpeechExecutor != nil {
+		h.r.OnPacket(ctx, internal_type.EndOfSpeechAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	}
+
 }
 
 func (h requestorDispatchHandler) HandleEndOfSpeechAudio(ctx context.Context, vl internal_type.EndOfSpeechAudioPacket) {
 	if h.r.endOfSpeechExecutor != nil {
-		_ = h.r.endOfSpeechExecutor.Execute(ctx, vl)
+		h.r.endOfSpeechExecutor.Execute(ctx, vl)
 	}
 }
 
 func (h requestorDispatchHandler) HandleSpeechToTextAudio(ctx context.Context, vl internal_type.SpeechToTextAudioPacket) {
 	if h.r.speechToTextTransformer != nil {
-		_ = h.r.speechToTextTransformer.Transform(ctx, vl)
+		h.r.speechToTextTransformer.Transform(ctx, vl)
 	}
 }
 
 func (h requestorDispatchHandler) HandleDenoise(ctx context.Context, vl internal_type.DenoiseAudioPacket) {
-	_ = h.r.denoiserExecutor.Execute(ctx, vl)
+	if h.r.denoiserExecutor != nil {
+		h.r.denoiserExecutor.Execute(ctx, vl)
+	}
 }
 
 func (h requestorDispatchHandler) HandleDenoisedAudio(ctx context.Context, vl internal_type.DenoisedAudioPacket) {
-	if h.r.vadExecutor != nil {
-		h.r.OnPacket(ctx,
-			internal_type.VadAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	if h.r.speechToTextTransformer != nil {
+		h.r.OnPacket(ctx, internal_type.SpeechToTextAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
 	}
-	h.r.OnPacket(ctx,
-		internal_type.SpeechToTextAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio},
-		internal_type.EndOfSpeechAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio},
-	)
+	if h.r.vadExecutor != nil {
+		h.r.OnPacket(ctx, internal_type.VadAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	}
+	if h.r.endOfSpeechExecutor != nil {
+		h.r.OnPacket(ctx, internal_type.EndOfSpeechAudioPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	}
 }
 
 func (h requestorDispatchHandler) HandleVadAudio(ctx context.Context, vl internal_type.VadAudioPacket) {
-	_ = h.r.vadExecutor.Execute(ctx, internal_type.UserAudioReceivedPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	if h.r.vadExecutor != nil {
+		h.r.vadExecutor.Execute(ctx, internal_type.UserAudioReceivedPacket{ContextID: vl.ContextID, Audio: vl.Audio})
+	}
+
 }
 func (h requestorDispatchHandler) HandleSpeechToText(ctx context.Context, p internal_type.SpeechToTextPacket) {
 	if !validator.NotBlank(p.Script) && !p.Interim {
@@ -403,7 +412,7 @@ func (h requestorDispatchHandler) HandleUserInput(ctx context.Context, p interna
 	)
 
 	if h.r.assistantExecutor != nil {
-		_ = h.r.messageLifecycle.AssistantGenerating(contextID)
+		h.r.messageLifecycle.AssistantGenerating(contextID)
 		utils.Go(ctx, func() {
 			if err := h.r.assistantExecutor.Execute(ctx, h.r, p); err != nil {
 				h.r.OnPacket(ctx, internal_type.LLMErrorPacket{ContextID: contextID, Error: err})
@@ -468,7 +477,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 		case internal_type.InterruptionEventStart:
 			if bargeInTrigger == internal_options.BargeInTriggerWord {
 				if h.r.endOfSpeechExecutor != nil {
-					_ = h.r.endOfSpeechExecutor.Execute(ctx, p)
+					h.r.endOfSpeechExecutor.Execute(ctx, p)
 				}
 				h.r.OnPacket(ctx, internal_type.SpeechToTextStartPacket{ContextID: p.ContextID})
 				return
@@ -477,7 +486,7 @@ func (h requestorDispatchHandler) HandleInterruptionDetected(ctx context.Context
 			messageState := h.r.messageLifecycle.State()
 			switch messageState {
 			case adapter_lifecycle.MessageStateUserIdle:
-				_ = h.r.messageLifecycle.UserSpeaking(p.ContextID)
+				h.r.messageLifecycle.UserSpeaking(p.ContextID)
 			case adapter_lifecycle.MessageStateUserListening,
 				adapter_lifecycle.MessageStateUserSpeaking,
 				adapter_lifecycle.MessageStateUserThinking:

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go
@@ -22,6 +22,28 @@ type blockingVADExecutor struct {
 	releaseCh chan struct{}
 }
 
+type noopDenoiserExecutor struct{}
+
+func (noopDenoiserExecutor) Name() string {
+	return "noop-denoiser"
+}
+
+func (noopDenoiserExecutor) Options() utils.Option {
+	return nil
+}
+
+func (noopDenoiserExecutor) Arguments() (map[string]string, error) {
+	return nil, nil
+}
+
+func (noopDenoiserExecutor) Execute(context.Context, internal_type.DenoiseAudioPacket) error {
+	return nil
+}
+
+func (noopDenoiserExecutor) Close(context.Context) error {
+	return nil
+}
+
 func (b *blockingVADExecutor) Name() string {
 	return "blocking-vad"
 }
@@ -153,4 +175,55 @@ func TestHandleVadAudio_ExecuteIsSynchronous(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("expected HandleVadAudio to return after Execute unblocks")
 	}
+}
+
+func TestHandleUserAudio_QueuesSpeechToTextBeforeVAD(t *testing.T) {
+	r := newDispatchHandlerVADTestRequestor(t)
+	r.speechToTextTransformer = noopSpeechToTextTransformer{}
+	r.vadExecutor = &blockingVADExecutor{}
+	r.endOfSpeechExecutor = &recordingEOSExecutor{}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserAudio(t.Context(), internal_type.UserAudioReceivedPacket{
+		ContextID: "ctx-user-audio",
+		Audio:     []byte{1, 2},
+	})
+
+	require.Equal(t, internal_type.PacketNameSpeechToTextAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+	require.Equal(t, internal_type.PacketNameVadAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+	require.Equal(t, internal_type.PacketNameEndOfSpeechAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+}
+
+func TestHandleDenoisedAudio_QueuesSpeechToTextBeforeVAD(t *testing.T) {
+	r := newDispatchHandlerVADTestRequestor(t)
+	r.speechToTextTransformer = noopSpeechToTextTransformer{}
+	r.vadExecutor = &blockingVADExecutor{}
+	r.endOfSpeechExecutor = &recordingEOSExecutor{}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleDenoisedAudio(t.Context(), internal_type.DenoisedAudioPacket{
+		ContextID: "ctx-denoised-audio",
+		Audio:     []byte{1, 2},
+	})
+
+	require.Equal(t, internal_type.PacketNameSpeechToTextAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+	require.Equal(t, internal_type.PacketNameVadAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+	require.Equal(t, internal_type.PacketNameEndOfSpeechAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+}
+
+func TestHandleUserAudio_WithDenoiserQueuesOnlyDenoise(t *testing.T) {
+	r := newDispatchHandlerVADTestRequestor(t)
+	r.denoiserExecutor = noopDenoiserExecutor{}
+	r.speechToTextTransformer = noopSpeechToTextTransformer{}
+	r.vadExecutor = &blockingVADExecutor{}
+	r.endOfSpeechExecutor = &recordingEOSExecutor{}
+	h := requestorDispatchHandler{r: r}
+
+	h.HandleUserAudio(t.Context(), internal_type.UserAudioReceivedPacket{
+		ContextID: "ctx-user-audio",
+		Audio:     []byte{1, 2},
+	})
+
+	require.Equal(t, internal_type.PacketNameDenoiseAudio, (<-r.channels.IngressChannel()).Pkt.PacketName())
+	require.Empty(t, r.channels.IngressChannel())
 }

--- a/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go
@@ -150,7 +150,9 @@ func TestInitializeBehavior_GreetingInterruptibleOption_ControlsAudioBlock(t *te
 		t.Run(testCase.name, func(t *testing.T) {
 			requestorChannels := adapter_channel.NewRequestorChannels()
 			requestor := &genericRequestor{
-				source: utils.Debugger,
+				source:                  utils.Debugger,
+				speechToTextTransformer: noopSpeechToTextTransformer{},
+				endOfSpeechExecutor:     &recordingEOSExecutor{},
 				assistant: &internal_assistant_entity.Assistant{
 					AssistantDebuggerDeployment: &internal_assistant_entity.AssistantDebuggerDeployment{
 						AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
@@ -274,8 +276,10 @@ func TestInitializeBehavior_NonInterruptibleGreeting_BlocksAudioAndAcceptsAfterT
 	streamer := &streamTestStreamer{}
 	requestorChannels := adapter_channel.NewRequestorChannels()
 	requestor := &genericRequestor{
-		source:   utils.Debugger,
-		streamer: streamer,
+		source:                  utils.Debugger,
+		streamer:                streamer,
+		speechToTextTransformer: noopSpeechToTextTransformer{},
+		endOfSpeechExecutor:     &recordingEOSExecutor{},
 		assistant: &internal_assistant_entity.Assistant{
 			AssistantDebuggerDeployment: &internal_assistant_entity.AssistantDebuggerDeployment{
 				AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{
@@ -333,8 +337,10 @@ func TestInitializeBehavior_NonInterruptibleGreeting_TextInputDoesNotKeepAudioBl
 	streamer := &streamTestStreamer{}
 	requestorChannels := adapter_channel.NewRequestorChannels()
 	requestor := &genericRequestor{
-		source:   utils.Debugger,
-		streamer: streamer,
+		source:                  utils.Debugger,
+		streamer:                streamer,
+		speechToTextTransformer: noopSpeechToTextTransformer{},
+		endOfSpeechExecutor:     &recordingEOSExecutor{},
 		assistant: &internal_assistant_entity.Assistant{
 			AssistantDebuggerDeployment: &internal_assistant_entity.AssistantDebuggerDeployment{
 				AssistantDeploymentBehavior: internal_assistant_entity.AssistantDeploymentBehavior{

--- a/api/assistant-api/internal/adapters/internal/dispatch_policy_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_policy_test.go
@@ -13,9 +13,11 @@ import (
 func newDispatchPolicyTestRequestor() *genericRequestor {
 	channels := adapter_channel.NewRequestorChannels()
 	return &genericRequestor{
-		channels:         channels,
-		dispatchRoute:    adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), channels),
-		sessionLifecycle: adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateReady),
+		channels:                channels,
+		dispatchRoute:           adapter_router.NewDispatchRoute(adapter_router.NewRoutePolicy(), channels),
+		sessionLifecycle:        adapter_lifecycle.NewSessionLifecycleWithState(adapter_lifecycle.StateReady),
+		speechToTextTransformer: noopSpeechToTextTransformer{},
+		endOfSpeechExecutor:     &recordingEOSExecutor{},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Dispatch configured speech-to-text audio before VAD and end-of-speech processing.
- Preserve denoising as the first stage when configured.
- Keep execution handlers safe when media components are unavailable.
- Update dispatcher, policy, and initialization-flow tests for configured components.

- Workflow tier: Standard

## Approved Plan

- Acceptance criteria: STT receives each audio chunk before VAD; denoised audio follows the same order; denoising does not duplicate downstream processing.
- In scope: assistant adapter audio dispatch ordering and related tests.
- Out of scope: VAD implementation, STT providers, denoiser implementations, and unrelated Node.js changes.
- Ownership: the requestor dispatcher owns routing; each configured media component owns execution of its packet.
- Rollback or disablement: revert commit `d741978b`.

## RFC Confirmation

- Accepted RFC: N/A
- RFC artifact directory: N/A
- Approved plan: N/A
- Confirmed SHA-256: N/A
- Orca confirmation gate / receipt: N/A

## Principles

- KISS / smallest complete solution: reorder existing packet routing without adding goroutines or queues.
- YAGNI / rejected speculation: did not make VAD packets asynchronous.
- Single source of truth and ownership: existing requestor handlers remain responsible for routing.
- Contracts and compatibility: packet types and external APIs are unchanged.
- Failure safety and cleanup: nil checks protect queued packets during component lifecycle changes.
- Security and least privilege: no permission or secret changes.
- Observability: existing media observability remains unchanged.

## Testing

- `env GOCACHE=/private/tmp/voice-ai-gocache go test ./internal/adapters/internal` from `api/assistant-api`: passed.
- `make agent-finalize CHANGED_FILES="api/assistant-api/internal/adapters/internal/dispatch_handler.go,api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go,api/assistant-api/internal/adapters/internal/dispatch_policy_test.go,api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go"`: passed.
- Push-time Go vet and CI-safe binary builds: passed.

## Independent Code Review

- Reviewer: pending
- Review report or Orca task: pending
- Decision: pending
- Critical findings: 0
- Major findings: 0
- Unresolved follow-ups: independent review required before merge.

## Checklist

- [x] The selected workflow tier matches `DEVELOPMENT_PROCESS.md`.
- [x] I kept the change focused.
- [x] I updated tests where needed.
- [x] Required validation commands passed.
- [ ] An independent code reviewer approved the complete diff.
- [x] Critical and major implementation findings are resolved.
- [x] Rollback and operational impact are documented where relevant.
- [x] I did not commit secrets or generated noise.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes assistant audio routing so configured STT processing is dispatched before VAD and end-of-speech processing, while retaining denoising as the first stage.
- Adds component-aware guards to audio execution and routing handlers.
- Applies the same STT-to-VAD-to-EOS order to raw and denoised audio.
- Extends dispatcher, policy, and initialization-flow tests for configured media components.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code defects identified.

The FIFO ingress dispatcher preserves the new STT-before-VAD order, denoised audio follows the same route, and optional-component guards do not introduce a demonstrated regression.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/adapters/internal/dispatch_handler.go | Reorders raw and denoised audio dispatch to STT, VAD, then EOS and guards optional component execution. |
| api/assistant-api/internal/adapters/internal/dispatch_handler_vad_test.go | Adds regression coverage for raw and denoised packet order and denoiser-only first-stage routing. |
| api/assistant-api/internal/adapters/internal/dispatch_init_flow_test.go | Configures STT and EOS test doubles so initialization-flow tests exercise the configured-component path. |
| api/assistant-api/internal/adapters/internal/dispatch_policy_test.go | Updates policy fixtures to include the media components required by the guarded routing behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User audio] --> B{Denoiser configured?}
    B -- Yes --> C[Denoise audio]
    C --> D[Denoised audio]
    B -- No --> E[Route configured components]
    D --> E
    E --> F[Speech-to-text]
    F --> G[VAD]
    G --> H[End-of-speech]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dispatch stt audio before vad"](https://github.com/rapidaai/voice-ai/commit/d741978be7e89c4aa2c7274043c2dc257c80dfda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56704560)</sub>

<!-- /greptile_comment -->