### PR TITLE
feat: scope observability indexes by organization

### DIFF
--- a/api/assistant-api/internal/observability/collectors/timeline/collector.go
+++ b/api/assistant-api/internal/observability/collectors/timeline/collector.go
@@ -68,31 +68,32 @@ func (c *Collector) Collect(ctx context.Context, scope observability.Scope, _ ob
 	if !validator.NonNil(c) || !validator.NonNil(c.opensearch) {
 		return nil
 	}
+	organizationID := scope.GlobalScopeValue().OrganizationID
 	switch typed := record.(type) {
 	case observability.RecordLog:
 		doc := newDocument("log", scope, typed.ID, typed.OccurredAt)
 		doc.Level = string(typed.Level)
 		doc.Title = typed.Message
 		doc.Attributes = typed.Attributes.Clone()
-		return c.bulk(ctx, c.index(doc.OccurredAt), doc)
+		return c.bulk(ctx, c.index(organizationID, doc.OccurredAt), doc)
 	case observability.RecordEvent:
 		doc := newDocument("event", scope, typed.ID, typed.OccurredAt)
 		doc.Name = typed.Event.String()
 		doc.Component = typed.Component.String()
 		doc.Attributes = typed.Attributes.Clone()
-		return c.bulk(ctx, c.index(doc.OccurredAt), doc)
+		return c.bulk(ctx, c.index(organizationID, doc.OccurredAt), doc)
 	case observability.RecordMetric:
 		doc := newDocument("metric", scope, typed.ID, typed.OccurredAt)
 		doc.Attributes = typed.Attributes.Clone()
-		return c.bulk(ctx, c.index(doc.OccurredAt), doc)
+		return c.bulk(ctx, c.index(organizationID, doc.OccurredAt), doc)
 	case observability.RecordMetadata:
 		doc := newDocument("metadata", scope, typed.ID, typed.OccurredAt)
-		return c.bulk(ctx, c.index(doc.OccurredAt), doc)
+		return c.bulk(ctx, c.index(organizationID, doc.OccurredAt), doc)
 	case observability.RecordUsage:
 		doc := newDocument("usage", scope, typed.ID, typed.OccurredAt)
 		doc.Component = typed.Component.String()
 		doc.Attributes = typed.Attributes.Clone()
-		return c.bulk(ctx, c.index(doc.OccurredAt), doc)
+		return c.bulk(ctx, c.index(organizationID, doc.OccurredAt), doc)
 	default:
 		return nil
 	}
@@ -122,11 +123,15 @@ func openSearchConnector(ctx context.Context, cfg Config) (connectors.OpenSearch
 	return openSearch, nil
 }
 
-func (c *Collector) index(at time.Time) string {
+func (c *Collector) index(organizationID uint64, at time.Time) string {
 	if at.IsZero() {
 		at = time.Now().UTC()
 	}
-	return c.indexPrefix + "-" + at.UTC().Format("20060102")
+	organization := "global"
+	if organizationID != 0 {
+		organization = strconv.FormatUint(organizationID, 10)
+	}
+	return c.indexPrefix + "-" + organization + "-" + at.UTC().Format("20060102")
 }
 
 func (c *Collector) bulk(ctx context.Context, index string, doc document) error {

--- a/api/assistant-api/internal/observability/collectors/timeline/collector_test.go
+++ b/api/assistant-api/internal/observability/collectors/timeline/collector_test.go
@@ -107,7 +107,7 @@ func TestCollector_PushesEventDocumentToOpenSearchBulk(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected bulk metadata+document lines, got %d", len(lines))
 	}
-	if !strings.Contains(lines[0], `"rapida-timeline-20260605"`) || !strings.Contains(lines[0], `"evt-1"`) {
+	if !strings.Contains(lines[0], `"rapida-timeline-1-20260605"`) || !strings.Contains(lines[0], `"evt-1"`) {
 		t.Fatalf("unexpected bulk metadata line: %s", lines[0])
 	}
 
@@ -144,7 +144,7 @@ func TestCollector_UsesCustomIndexPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CollectMetric returned error: %v", err)
 	}
-	if !strings.Contains(opensearch.bodies[0], `"custom-timeline-20260605"`) {
+	if !strings.Contains(opensearch.bodies[0], `"custom-timeline-global-20260605"`) {
 		t.Fatalf("unexpected bulk body: %s", opensearch.bodies[0])
 	}
 }

--- a/pkg/telemetry/providers/opensearch.go
+++ b/pkg/telemetry/providers/opensearch.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,7 +71,7 @@ func NewOpenSearchExporterFromOptions(
 	}, nil
 }
 
-func (e *OpenSearchExporter) index(kind string, occurredAt time.Time) string {
+func (e *OpenSearchExporter) index(kind string, organizationID uint64, occurredAt time.Time) string {
 	prefix := "rapida"
 	if strings.TrimSpace(e.config.IndexPrefix) != "" {
 		prefix = strings.TrimSpace(e.config.IndexPrefix)
@@ -78,19 +79,23 @@ func (e *OpenSearchExporter) index(kind string, occurredAt time.Time) string {
 	if occurredAt.IsZero() {
 		occurredAt = time.Now().UTC()
 	}
-	return prefix + "-" + kind + "-" + occurredAt.UTC().Format("20060102")
+	organization := "global"
+	if organizationID != 0 {
+		organization = strconv.FormatUint(organizationID, 10)
+	}
+	return prefix + "-" + kind + "-" + organization + "-" + occurredAt.UTC().Format("20060102")
 }
 
-func (e *OpenSearchExporter) logIndex(occurredAt time.Time) string {
-	return e.index("logs", occurredAt)
+func (e *OpenSearchExporter) logIndex(organizationID uint64, occurredAt time.Time) string {
+	return e.index("logs", organizationID, occurredAt)
 }
 
-func (e *OpenSearchExporter) eventIndex(occurredAt time.Time) string {
-	return e.index("events", occurredAt)
+func (e *OpenSearchExporter) eventIndex(organizationID uint64, occurredAt time.Time) string {
+	return e.index("events", organizationID, occurredAt)
 }
 
-func (e *OpenSearchExporter) metricIndex(occurredAt time.Time) string {
-	return e.index("metrics", occurredAt)
+func (e *OpenSearchExporter) metricIndex(organizationID uint64, occurredAt time.Time) string {
+	return e.index("metrics", organizationID, occurredAt)
 }
 
 type opensearchEventDoc struct {
@@ -160,7 +165,7 @@ func (e *OpenSearchExporter) Export(ctx context.Context, scope telemetry.Scope, 
 			Attributes:      typed.Attributes,
 			OccurredAt:      occurredAt,
 		}
-		return e.bulk(ctx, e.logIndex(doc.OccurredAt), doc.ID, doc)
+		return e.bulk(ctx, e.logIndex(doc.OrganizationID, doc.OccurredAt), doc.ID, doc)
 	case telemetry.EventRecord:
 		occurredAt := typed.OccurredAt
 		if occurredAt.IsZero() {
@@ -183,7 +188,7 @@ func (e *OpenSearchExporter) Export(ctx context.Context, scope telemetry.Scope, 
 			Attributes:      typed.Attributes,
 			OccurredAt:      occurredAt,
 		}
-		return e.bulk(ctx, e.eventIndex(doc.OccurredAt), doc.ID, doc)
+		return e.bulk(ctx, e.eventIndex(doc.OrganizationID, doc.OccurredAt), doc.ID, doc)
 	case telemetry.MetricRecord:
 		occurredAt := typed.OccurredAt
 		if occurredAt.IsZero() {
@@ -207,7 +212,7 @@ func (e *OpenSearchExporter) Export(ctx context.Context, scope telemetry.Scope, 
 			Attributes:      typed.Attributes,
 			OccurredAt:      occurredAt,
 		}
-		return e.bulk(ctx, e.metricIndex(doc.OccurredAt), doc.ID, doc)
+		return e.bulk(ctx, e.metricIndex(doc.OrganizationID, doc.OccurredAt), doc.ID, doc)
 	default:
 		return nil
 	}

--- a/pkg/telemetry/providers/opensearch_test.go
+++ b/pkg/telemetry/providers/opensearch_test.go
@@ -63,6 +63,11 @@ func TestOpenSearchExporter_ExportsContextToDocuments(t *testing.T) {
 		telemetry.EventRecord{ID: "event-1", Context: trace, Event: "session.streamer_created", Component: "session", OccurredAt: now},
 		telemetry.MetricRecord{ID: "metric-1", Context: trace, Name: "duration", Value: "1", OccurredAt: now},
 	}
+	expectedIndices := []string{
+		`"test-logs-20-20260607"`,
+		`"test-events-20-20260607"`,
+		`"test-metrics-20-20260607"`,
+	}
 	for _, record := range records {
 		if err := exporter.Export(context.Background(), scope, record); err != nil {
 			t.Fatalf("Export returned error: %v", err)
@@ -72,7 +77,7 @@ func TestOpenSearchExporter_ExportsContextToDocuments(t *testing.T) {
 	if len(opensearch.bodies) != len(records) {
 		t.Fatalf("expected %d bulk bodies, got %d", len(records), len(opensearch.bodies))
 	}
-	for _, body := range opensearch.bodies {
+	for index, body := range opensearch.bodies {
 		lines := strings.Split(strings.TrimSpace(body), "\n")
 		if len(lines) != 2 {
 			t.Fatalf("expected bulk metadata+document lines, got %d", len(lines))
@@ -85,6 +90,41 @@ func TestOpenSearchExporter_ExportsContextToDocuments(t *testing.T) {
 		}
 		if doc.Context["traceId"] != "trace-1" {
 			t.Fatalf("unexpected trace id: %s", doc.Context["traceId"])
+		}
+		if !strings.Contains(lines[0], expectedIndices[index]) {
+			t.Fatalf("unexpected bulk metadata line: %s", lines[0])
+		}
+	}
+}
+
+func TestOpenSearchExporter_UsesGlobalIndexWithoutOrganization(t *testing.T) {
+	opensearch := &openSearchConnectorStub{}
+	exporter := NewOpenSearchExporter(nil, OpenSearchConfig{IndexPrefix: "test"}, opensearch)
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
+	records := []telemetry.Record{
+		telemetry.LogRecord{ID: "log-1", OccurredAt: now},
+		telemetry.EventRecord{ID: "event-1", OccurredAt: now},
+		telemetry.MetricRecord{ID: "metric-1", OccurredAt: now},
+	}
+	expectedIndices := []string{
+		`"test-logs-global-20260607"`,
+		`"test-events-global-20260607"`,
+		`"test-metrics-global-20260607"`,
+	}
+
+	for _, record := range records {
+		if err := exporter.Export(context.Background(), telemetry.Scope{}, record); err != nil {
+			t.Fatalf("Export returned error: %v", err)
+		}
+	}
+
+	if len(opensearch.bodies) != len(records) {
+		t.Fatalf("expected %d bulk bodies, got %d", len(records), len(opensearch.bodies))
+	}
+	for index, body := range opensearch.bodies {
+		if !strings.Contains(body, expectedIndices[index]) {
+			t.Fatalf("unexpected bulk body: %s", body)
 		}
 	}
 }

--- a/rfcs/0012-organization-scoped-observability-indexes.md
+++ b/rfcs/0012-organization-scoped-observability-indexes.md
@@ -1,0 +1,367 @@
+# RFC 0012: Organization-Scoped Daily Observability Indexes
+
+- Status: Draft
+- Owner: Observability maintainers
+- Created: 2026-08-25
+- Updated: 2026-08-25
+- Reviewers: Independent plan challenger (pending), operations owner for the archive cron (pending)
+
+## Summary
+
+Include the organization identifier and UTC calendar date in every OpenSearch index name
+written by the assistant observability timeline collector and the shared telemetry
+OpenSearch exporter. The new physical index boundary allows an external cron process to
+archive complete indexes according to organization-specific retention schedules without
+running document-level queries.
+
+The application remains responsible only for selecting the destination index and writing
+records. Index archival, deletion after archival, restore procedures, and retention
+configuration remain owned by the external cron and its operators.
+
+## Context
+
+The timeline collector currently writes every organization into a shared daily index named
+`rapida-timeline-YYYYMMDD`. Its index name is generated in
+`api/assistant-api/internal/observability/collectors/timeline/collector.go`, while the
+organization identifier is already available through `observability.Scope` and is stored
+inside each indexed document.
+
+The shared telemetry OpenSearch exporter currently writes logs, events, and metrics into
+`rapida-logs-YYYYMMDD`, `rapida-events-YYYYMMDD`, and
+`rapida-metrics-YYYYMMDD`. The exporter receives `telemetry.Scope.OrganizationID` and
+stores it in each document, but it does not include that value in the index name.
+
+The existing telemetry read API searches wildcard patterns `rapida-logs-*`,
+`rapida-events-*`, and `rapida-metrics-*`. Those patterns match both the current names and
+the proposed names, so the reader does not require a compatibility change.
+
+An external cron will archive observability indexes. Retention can differ by organization,
+which means a shared daily index is not a sufficient archival boundary. Document-level
+filtering, copying, and deletion would add failure modes and would not be index archival.
+
+## Goals
+
+- Route every timeline record to a daily index scoped to its organization.
+- Route every OpenSearch telemetry log, event, and metric to a daily index scoped to its
+  organization.
+- Preserve UTC date partitioning and existing configurable index prefixes.
+- Preserve organization and project identifiers inside indexed documents.
+- Keep existing wildcard telemetry reads compatible with old and new index names.
+- Provide a deterministic fallback index for records without organization context.
+- Give the external archive cron an index-level organization and date boundary.
+
+## Non-Goals
+
+- Implementing or scheduling the external archive cron.
+- Defining organization retention periods or archive destinations.
+- Deleting, closing, snapshotting, restoring, or migrating OpenSearch indexes.
+- Renaming, reindexing, or backfilling existing observability indexes.
+- Adding OpenSearch Index State Management policies or index templates.
+- Changing observability document mappings, JSON fields, record identifiers, or payloads.
+- Changing telemetry API request or response contracts.
+- Changing OpenSearch connector behavior or automatic index creation settings.
+
+## Scope and Ownership
+
+### Allowed Paths
+
+- `pkg/telemetry/opensearch_index.go` - implementation owner; shared organization and UTC
+  date index-name contract.
+- `pkg/telemetry/opensearch_index_test.go` - implementation owner; contract tests for index
+  naming.
+- `pkg/telemetry/providers/opensearch.go` - implementation owner; log, event, and metric
+  routing.
+- `pkg/telemetry/providers/opensearch_test.go` - implementation owner; exporter routing
+  tests.
+- `api/assistant-api/internal/observability/collectors/timeline/collector.go` -
+  implementation owner; timeline routing.
+- `api/assistant-api/internal/observability/collectors/timeline/collector_test.go` -
+  implementation owner; timeline routing tests.
+- `rfcs/0012-organization-scoped-observability-indexes.md` - RFC owner.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/` - governance artifact owner.
+
+### Out-of-Scope Paths
+
+- `pkg/connectors/`
+- `api/assistant-api/api/observability/`
+- OpenSearch deployment and cluster configuration.
+- External archive cron source, configuration, deployment, and credentials.
+- Existing OpenSearch indexes and stored documents.
+
+## Proposed Design
+
+Add one shared telemetry function that constructs a daily OpenSearch index name from an
+already-resolved prefix, an organization identifier, and an occurrence timestamp. This
+function is the single source of truth for the organization and date suffix used by both
+writers.
+
+The naming contract is versioned with an explicit `org` marker so the archive cron can
+distinguish it from every existing shared index, including indexes whose custom prefix ends
+with a numeric token or the word `global`:
+
+```text
+<resolved-prefix>-org-<organization-segment>-<UTC YYYYMMDD>
+```
+
+For a nonzero organization identifier, `organization-segment` is the base-10 unsigned
+integer value. For a zero organization identifier, `organization-segment` is `global`.
+
+Timeline examples:
+
+```text
+rapida-timeline-org-42-20260825
+custom-timeline-org-42-20260825
+rapida-timeline-org-global-20260825
+```
+
+The timeline collector passes its configured `indexPrefix` directly to the shared naming
+function together with `scope.GlobalScopeValue().OrganizationID` and the record occurrence
+time.
+
+Telemetry exporter examples:
+
+```text
+rapida-logs-org-42-20260825
+rapida-events-org-42-20260825
+rapida-metrics-org-42-20260825
+custom-logs-org-42-20260825
+```
+
+The exporter first resolves its configured root prefix, appends the existing record kind
+segment, and passes that result to the shared naming function together with
+`scope.OrganizationID` and the record occurrence time.
+
+If the occurrence timestamp is zero, the shared naming function uses the current time. It
+always formats the date in UTC. No writer performs index existence checks or explicit index
+creation as part of this change. The existing OpenSearch bulk behavior remains unchanged.
+
+The index date continues to use record occurrence time to preserve existing partitioning
+semantics. The archive cron must scan for eligible indexes on every run and must treat an
+eligible index that reappears because of a late record as new archival work. Archive output
+must be versioned or otherwise idempotent so a repeated archive does not overwrite a prior
+verified artifact. The cron must remove an active index only after the current archive copy
+has been verified. The maximum expected event lateness and the corresponding archive grace
+period remain rollout inputs that must be recorded before this RFC can be accepted.
+
+## Contracts and Compatibility
+
+- Timeline index names change from `<prefix>-YYYYMMDD` to
+  `<prefix>-org-<organization-segment>-YYYYMMDD`.
+- Telemetry index names change from `<prefix>-<kind>-YYYYMMDD` to
+  `<prefix>-<kind>-org-<organization-segment>-YYYYMMDD`.
+- `organization-segment` is a base-10 organization identifier or the literal `global` when
+  the identifier is zero.
+- Dates remain eight decimal digits in UTC using the existing `YYYYMMDD` format.
+- Existing custom prefix behavior remains unchanged before the new suffix.
+- Existing wildcard telemetry readers remain compatible because `rapida-logs-*`,
+  `rapida-events-*`, and `rapida-metrics-*` match both formats.
+- Existing indexes remain readable and are not renamed or modified.
+- The archive cron must identify the new layout by the literal `org` marker, parse the date
+  from the final hyphen-delimited segment, and parse the organization from the immediately
+  preceding segment. It must separately define handling for the `global` segment.
+- The archive cron must support both old and new names during the compatibility window.
+- Old shared names must never be interpreted as organization-scoped names. If the cron
+  cannot classify a name unambiguously, it must report and skip the index without removing
+  it from active storage.
+- No public API, protobuf, database schema, or observability document schema changes.
+
+## Failure and Recovery
+
+- A zero organization identifier routes to an explicit `org-global` index instead of
+  silently creating an index for numeric organization zero. The writer emits a warning with
+  record kind and scope type, without payload data, whenever this fallback is used.
+- Invalid or blank custom prefixes retain existing behavior and are outside this change.
+- Bulk write errors retain the existing propagation and logging behavior.
+- A deployment rollback resumes the previous shared index naming. Readers continue to
+  search both layouts through existing wildcard patterns.
+- The external cron must not archive an index unless its full name matches the approved
+  prefix, organization segment, and date grammar.
+- The external cron must not treat a failed or partial archive as permission to remove the
+  source index. That behavior is outside this repository but is a rollout prerequisite.
+- The external cron must rescan all eligible dates on every run so an old-date index
+  recreated by a late record is archived again.
+
+## Security and Privacy
+
+- Organization identifiers are already present in observability documents. Adding the
+  identifier to the index name does not introduce a new class of tenant identifier.
+- OpenSearch credentials and permissions remain unchanged.
+- The application must continue writing the organization identifier into each document so
+  index routing can be audited against document scope.
+- Index naming provides a physical archival boundary but does not replace query-time or
+  OpenSearch authorization controls.
+- Archive cron permissions should be limited to matching observability index prefixes and
+  the required archive operations. Cron permission changes are outside this RFC's code
+  scope.
+
+## Observability
+
+- Existing bulk write failure logs remain the primary application diagnostic.
+- A warning identifies every write routed to `org-global` so operators can distinguish
+  expected infrastructure records from missing tenant context.
+- Tests inspect bulk metadata to prove that each record is routed to the expected physical
+  index.
+- Operators can list indexes by prefix and organization segment to verify rollout.
+- No new application metric or log is required because this change only alters deterministic
+  routing metadata.
+
+## Data and Migration
+
+No database schema or document migration is required.
+
+Existing indexes retain their current names and contents. New application versions begin
+writing to organization-scoped daily indexes immediately after deployment. During the
+compatibility window, OpenSearch therefore contains both old shared indexes and new
+organization-scoped indexes.
+
+The external archive cron must recognize both layouts until all old shared indexes have
+passed the maximum supported retention period and have been archived under the existing
+operational process.
+
+## Rollout
+
+1. Update the archive cron parser and dry-run validation to recognize both old and new index
+   layouts by the literal `org` marker. Do not enable new archival actions yet.
+2. Deploy the application index-routing change.
+3. Verify that timeline, log, event, and metric writes create organization-scoped daily
+   indexes and retain matching organization identifiers in their documents.
+4. Verify that telemetry reads and dashboards continue to find both old and new indexes.
+5. Record the current active primary and replica shard counts, the projected peak from the
+   organization count and retention horizon, the operator-approved hard threshold, the
+   maximum expected event lateness, and the archive grace period in
+   `jsons/operational-readiness.json`.
+6. Enable organization-specific archive schedules in the cron after the new names are
+   observed and validated.
+7. Stop rollout if organization-scoped indexes are missing, organization IDs disagree with
+   document scope, wildcard reads omit either layout, the cron cannot classify an index,
+   late writes are not re-archived, or index growth reaches the approved threshold.
+
+## Rollback
+
+Roll back the application binary to restore the previous shared daily index names. No data
+rewrite is required. Existing wildcard readers continue to include indexes produced before,
+during, and after rollback.
+
+Disable archival of the new organization-scoped pattern before rollback if the cron cannot
+safely process a mixed layout. Indexes already archived by the external cron are not
+restored by this application rollback and remain governed by the cron's recovery process.
+
+The cron must continue rescanning eligible dates after rollback until the final
+organization-scoped index has passed the maximum lateness and archive grace windows.
+
+## Alternatives Considered
+
+- Keep shared daily indexes and filter by `organizationId` during archival. Rejected because
+  it requires document-level copy and removal rather than atomic index archival.
+- Use OpenSearch Index State Management. Rejected because retention and archival are owned
+  by an external cron.
+- Add an application cleanup worker. Rejected because the application does not own archive
+  scheduling or lifecycle operations.
+- Create one index per retention tier. Rejected because organization retention schedules can
+  differ independently and the archive cron requires an organization boundary.
+- Add organization identifiers only to timeline indexes. Rejected because logs, events, and
+  metrics require the same independent archival behavior.
+- Duplicate index formatting in each writer. Rejected because index naming is an operational
+  contract and should have one source of truth.
+
+## Testing and Verification
+
+Required test categories:
+
+- Shared index-name contract for nonzero organization identifiers.
+- Explicit `global` fallback for organization identifier zero.
+- Warning emission when the `global` fallback is used.
+- UTC conversion and zero-time fallback.
+- Default and custom prefix preservation.
+- Timeline log, event, metric, metadata, and usage routing through the organization-scoped
+  name.
+- Telemetry log, event, and metric routing through organization-scoped names.
+- Preservation of organization identifiers inside documents.
+- Existing wildcard telemetry query compatibility through focused API tests or direct
+  assertion of unchanged patterns.
+- Existing bulk error propagation.
+- Old and new default and custom-prefix parser fixtures supplied by the archive cron owner.
+
+Exact verification commands:
+
+```bash
+go test ./pkg/telemetry/...
+go test ./api/assistant-api/internal/observability/collectors/timeline/...
+go test ./api/assistant-api/api/observability/...
+make agent-finalize CHANGED_FILES="pkg/telemetry/opensearch_index.go,pkg/telemetry/opensearch_index_test.go,pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
+```
+
+Operational verification before enabling archival:
+
+```text
+curl -fsS "$OPENSEARCH_URL/_cat/indices/rapida-*?h=index,pri,rep,docs.count,store.size&format=json"
+curl -fsS "$OPENSEARCH_URL/_cluster/health?level=indices"
+curl -fsS -H 'Content-Type: application/json' "$OPENSEARCH_URL/rapida-*-org-*-*/_search" -d '{"size":100,"_source":["organizationId"],"query":{"match_all":{}}}'
+go test ./api/assistant-api/api/observability/... -run TestGetAllTelemetry
+```
+
+The archive cron owner must add its environment-specific dry-run and archive verification
+commands to `jsons/operational-readiness.json`. That artifact must also record parser
+fixtures for old and new default and custom prefixes, the approved shard threshold, the
+measured shard counts, the maximum lateness, and the archive grace period. Absence of this
+evidence blocks rollout.
+
+## Acceptance Criteria
+
+- [ ] Timeline records use `<prefix>-org-<organization-segment>-YYYYMMDD`.
+- [ ] Telemetry logs use `<prefix>-logs-org-<organization-segment>-YYYYMMDD`.
+- [ ] Telemetry events use `<prefix>-events-org-<organization-segment>-YYYYMMDD`.
+- [ ] Telemetry metrics use `<prefix>-metrics-org-<organization-segment>-YYYYMMDD`.
+- [ ] Nonzero organization identifiers use their base-10 representation.
+- [ ] Zero organization identifiers use the literal `global`.
+- [ ] Writes using the `global` fallback emit a warning without payload data.
+- [ ] Dates are derived from record occurrence time and formatted in UTC.
+- [ ] Existing custom prefixes remain supported.
+- [ ] Organization identifiers remain present in indexed documents.
+- [ ] Existing telemetry wildcard reads cover old and new index layouts.
+- [ ] No application code lists, archives, closes, or deletes indexes.
+- [ ] Focused tests and `make agent-finalize` pass.
+- [ ] The archive cron owner confirms mixed-layout support before rollout.
+- [ ] The archive cron proves ambiguous names are skipped, late eligible indexes are
+  re-archived, and archive verification precedes source removal.
+- [ ] Operational readiness records measured and projected shard counts, a hard capacity
+  threshold, maximum event lateness, and archive grace period.
+- [ ] No unresolved critical or major review findings remain.
+
+## Open Questions
+
+- Who owns the external archive cron compatibility confirmation?
+- What hard active-shard threshold has the OpenSearch operator approved?
+- What maximum event lateness and archive grace period has the archive cron owner approved?
+- How long must the cron retain compatibility with the old shared index layout?
+- Which current record producers are legitimately allowed to emit with organization ID zero?
+
+## Challenge Resolution
+
+Challenge round 1 returned `REVISE` for ambiguous mixed-layout parsing, missing shard
+capacity gates, undefined late-write behavior, unconstrained zero-organization routing, and
+insufficient operational commands. This revision adds the explicit `org` marker, safe
+classification rules, repeated late-index archival requirements, zero-organization
+warnings, and an operational-readiness artifact contract. Operator-owned values and exact
+cron commands remain unresolved, so the RFC remains `Draft` and requires another
+independent challenge after those inputs are recorded.
+
+## Artifact Index
+
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json` - initial task plan;
+  revised after challenge round 1.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/challenge.json` - challenge
+  round 1 receipt; decision `revise`.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/confirmation.json` - not created;
+  reserved for the exact-digest confirmation receipt.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/operational-readiness.json` -
+  not created; required before rollout.
+
+## Decision Log
+
+| Date | Decision | Owner | Evidence |
+| --- | --- | --- | --- |
+| 2026-08-25 | Use organization-scoped UTC daily indexes for all OpenSearch observability writers | User and RFC owner | `jsons/plan.json` |
+| 2026-08-25 | Keep archive lifecycle ownership in the external cron | User and RFC owner | `jsons/plan.json` |
+| 2026-08-25 | Keep the RFC in Draft pending independent challenge and exact-digest confirmation | RFC owner | Governed workflow requirement |
+| 2026-08-25 | Add an explicit `org` marker and operational safety gates | RFC owner | `jsons/challenge.json` |

--- a/rfcs/0012-organization-scoped-observability-indexes.md
+++ b/rfcs/0012-organization-scoped-observability-indexes.md
@@ -4,79 +4,58 @@
 - Owner: Observability maintainers
 - Created: 2026-08-25
 - Updated: 2026-08-25
-- Reviewers: Independent plan challenger (pending), operations owner for the archive cron (pending)
+- Reviewers: Independent plan challenger (pending)
 
 ## Summary
 
-Include the organization identifier and UTC calendar date in every OpenSearch index name
-written by the assistant observability timeline collector and the shared telemetry
-OpenSearch exporter. The new physical index boundary allows an external cron process to
-archive complete indexes according to organization-specific retention schedules without
-running document-level queries.
+Add the organization identifier to every daily OpenSearch index written by the assistant
+observability timeline collector and the shared telemetry OpenSearch exporter. When no
+organization identifier is available, use the literal `global`.
 
-The application remains responsible only for selecting the destination index and writing
-records. Index archival, deletion after archival, restore procedures, and retention
-configuration remain owned by the external cron and its operators.
+The application changes only index naming. An external cron owns index archival and any
+retention-specific behavior.
 
 ## Context
 
-The timeline collector currently writes every organization into a shared daily index named
-`rapida-timeline-YYYYMMDD`. Its index name is generated in
-`api/assistant-api/internal/observability/collectors/timeline/collector.go`, while the
-organization identifier is already available through `observability.Scope` and is stored
-inside each indexed document.
+The timeline collector currently writes records to `<prefix>-YYYYMMDD`. The telemetry
+OpenSearch exporter writes logs, events, and metrics to
+`<prefix>-<kind>-YYYYMMDD`. Both writers already receive an organization identifier and
+store it inside the indexed document, but neither includes it in the index name.
 
-The shared telemetry OpenSearch exporter currently writes logs, events, and metrics into
-`rapida-logs-YYYYMMDD`, `rapida-events-YYYYMMDD`, and
-`rapida-metrics-YYYYMMDD`. The exporter receives `telemetry.Scope.OrganizationID` and
-stores it in each document, but it does not include that value in the index name.
+Retention differs by organization. The external archive cron therefore needs complete
+indexes that belong to one organization and one UTC date.
 
-The existing telemetry read API searches wildcard patterns `rapida-logs-*`,
-`rapida-events-*`, and `rapida-metrics-*`. Those patterns match both the current names and
-the proposed names, so the reader does not require a compatibility change.
-
-An external cron will archive observability indexes. Retention can differ by organization,
-which means a shared daily index is not a sufficient archival boundary. Document-level
-filtering, copying, and deletion would add failure modes and would not be index archival.
+Existing telemetry readers search `rapida-logs-*`, `rapida-events-*`, and
+`rapida-metrics-*`. Those patterns match both current and proposed names.
 
 ## Goals
 
-- Route every timeline record to a daily index scoped to its organization.
-- Route every OpenSearch telemetry log, event, and metric to a daily index scoped to its
-  organization.
-- Preserve UTC date partitioning and existing configurable index prefixes.
-- Preserve organization and project identifiers inside indexed documents.
-- Keep existing wildcard telemetry reads compatible with old and new index names.
-- Provide a deterministic fallback index for records without organization context.
-- Give the external archive cron an index-level organization and date boundary.
+- Add organization ID to timeline, log, event, and metric index names.
+- Use `global` when organization ID is zero or unavailable.
+- Preserve existing prefixes, UTC daily rotation, document bodies, and bulk behavior.
+- Keep existing telemetry wildcard reads compatible.
+- Leave archival ownership with the external cron.
 
 ## Non-Goals
 
-- Implementing or scheduling the external archive cron.
-- Defining organization retention periods or archive destinations.
-- Deleting, closing, snapshotting, restoring, or migrating OpenSearch indexes.
-- Renaming, reindexing, or backfilling existing observability indexes.
-- Adding OpenSearch Index State Management policies or index templates.
-- Changing observability document mappings, JSON fields, record identifiers, or payloads.
-- Changing telemetry API request or response contracts.
-- Changing OpenSearch connector behavior or automatic index creation settings.
+- Implementing or configuring the archive cron.
+- Adding retention settings, OpenSearch policies, templates, or cleanup workers.
+- Explicitly creating, deleting, closing, snapshotting, or restoring indexes.
+- Migrating or renaming existing indexes.
+- Changing document schemas, APIs, protobufs, databases, or OpenSearch connector behavior.
 
 ## Scope and Ownership
 
 ### Allowed Paths
 
-- `pkg/telemetry/opensearch_index.go` - implementation owner; shared organization and UTC
-  date index-name contract.
-- `pkg/telemetry/opensearch_index_test.go` - implementation owner; contract tests for index
-  naming.
 - `pkg/telemetry/providers/opensearch.go` - implementation owner; log, event, and metric
-  routing.
+  index naming.
 - `pkg/telemetry/providers/opensearch_test.go` - implementation owner; exporter routing
-  tests.
+  coverage.
 - `api/assistant-api/internal/observability/collectors/timeline/collector.go` -
-  implementation owner; timeline routing.
+  implementation owner; timeline index naming.
 - `api/assistant-api/internal/observability/collectors/timeline/collector_test.go` -
-  implementation owner; timeline routing tests.
+  implementation owner; timeline routing coverage.
 - `rfcs/0012-organization-scoped-observability-indexes.md` - RFC owner.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/` - governance artifact owner.
 
@@ -84,284 +63,204 @@ filtering, copying, and deletion would add failure modes and would not be index 
 
 - `pkg/connectors/`
 - `api/assistant-api/api/observability/`
-- OpenSearch deployment and cluster configuration.
-- External archive cron source, configuration, deployment, and credentials.
-- Existing OpenSearch indexes and stored documents.
+- OpenSearch cluster and deployment configuration.
+- External archive cron source and configuration.
+- Existing OpenSearch indexes.
 
 ## Proposed Design
 
-Add one shared telemetry function that constructs a daily OpenSearch index name from an
-already-resolved prefix, an organization identifier, and an occurrence timestamp. This
-function is the single source of truth for the organization and date suffix used by both
-writers.
+Change the two existing private index-name functions. Do not introduce a new package,
+configuration option, connector method, background worker, or index lifecycle component.
 
-The naming contract is versioned with an explicit `org` marker so the archive cron can
-distinguish it from every existing shared index, including indexes whose custom prefix ends
-with a numeric token or the word `global`:
+Timeline index names become:
 
 ```text
-<resolved-prefix>-org-<organization-segment>-<UTC YYYYMMDD>
+<prefix>-<organization-segment>-<UTC YYYYMMDD>
 ```
 
-For a nonzero organization identifier, `organization-segment` is the base-10 unsigned
-integer value. For a zero organization identifier, `organization-segment` is `global`.
-
-Timeline examples:
+Examples:
 
 ```text
-rapida-timeline-org-42-20260825
-custom-timeline-org-42-20260825
-rapida-timeline-org-global-20260825
+rapida-timeline-42-20260825
+custom-timeline-42-20260825
+rapida-timeline-global-20260825
 ```
 
-The timeline collector passes its configured `indexPrefix` directly to the shared naming
-function together with `scope.GlobalScopeValue().OrganizationID` and the record occurrence
-time.
-
-Telemetry exporter examples:
+Telemetry index names become:
 
 ```text
-rapida-logs-org-42-20260825
-rapida-events-org-42-20260825
-rapida-metrics-org-42-20260825
-custom-logs-org-42-20260825
+<prefix>-<kind>-<organization-segment>-<UTC YYYYMMDD>
 ```
 
-The exporter first resolves its configured root prefix, appends the existing record kind
-segment, and passes that result to the shared naming function together with
-`scope.OrganizationID` and the record occurrence time.
+Examples:
 
-If the occurrence timestamp is zero, the shared naming function uses the current time. It
-always formats the date in UTC. No writer performs index existence checks or explicit index
-creation as part of this change. The existing OpenSearch bulk behavior remains unchanged.
+```text
+rapida-logs-42-20260825
+rapida-events-42-20260825
+rapida-metrics-42-20260825
+custom-logs-42-20260825
+```
 
-The index date continues to use record occurrence time to preserve existing partitioning
-semantics. The archive cron must scan for eligible indexes on every run and must treat an
-eligible index that reappears because of a late record as new archival work. Archive output
-must be versioned or otherwise idempotent so a repeated archive does not overwrite a prior
-verified artifact. The cron must remove an active index only after the current archive copy
-has been verified. The maximum expected event lateness and the corresponding archive grace
-period remain rollout inputs that must be recorded before this RFC can be accepted.
+For a nonzero organization ID, `organization-segment` is its unsigned base-10 value. For
+organization ID zero, it is `global`.
+
+The date continues to come from the record occurrence time. A zero occurrence time falls
+back to the current time, and formatting remains UTC. OpenSearch index creation continues
+to occur through the existing bulk write behavior.
+
+The archive cron must use the exact configured prefix when parsing names. After removing
+that prefix, it reads the final segment as the UTC date and the preceding segment as the
+organization. This avoids interpreting a token inside a custom prefix as the organization.
 
 ## Contracts and Compatibility
 
-- Timeline index names change from `<prefix>-YYYYMMDD` to
-  `<prefix>-org-<organization-segment>-YYYYMMDD`.
-- Telemetry index names change from `<prefix>-<kind>-YYYYMMDD` to
-  `<prefix>-<kind>-org-<organization-segment>-YYYYMMDD`.
-- `organization-segment` is a base-10 organization identifier or the literal `global` when
-  the identifier is zero.
-- Dates remain eight decimal digits in UTC using the existing `YYYYMMDD` format.
-- Existing custom prefix behavior remains unchanged before the new suffix.
-- Existing wildcard telemetry readers remain compatible because `rapida-logs-*`,
-  `rapida-events-*`, and `rapida-metrics-*` match both formats.
-- Existing indexes remain readable and are not renamed or modified.
-- The archive cron must identify the new layout by the literal `org` marker, parse the date
-  from the final hyphen-delimited segment, and parse the organization from the immediately
-  preceding segment. It must separately define handling for the `global` segment.
-- The archive cron must support both old and new names during the compatibility window.
-- Old shared names must never be interpreted as organization-scoped names. If the cron
-  cannot classify a name unambiguously, it must report and skip the index without removing
-  it from active storage.
-- No public API, protobuf, database schema, or observability document schema changes.
+- Timeline changes from `<prefix>-YYYYMMDD` to
+  `<prefix>-<organization-segment>-YYYYMMDD`.
+- Logs change from `<prefix>-logs-YYYYMMDD` to
+  `<prefix>-logs-<organization-segment>-YYYYMMDD`.
+- Events change from `<prefix>-events-YYYYMMDD` to
+  `<prefix>-events-<organization-segment>-YYYYMMDD`.
+- Metrics change from `<prefix>-metrics-YYYYMMDD` to
+  `<prefix>-metrics-<organization-segment>-YYYYMMDD`.
+- Existing index prefixes remain unchanged.
+- Existing document fields, including organization ID, remain unchanged.
+- Existing wildcard readers continue matching old and new names.
+- Existing indexes are not modified or migrated.
+- The archive cron must support old and new layouts during rollout and must use the exact
+  configured prefix rather than guessing prefix boundaries.
 
 ## Failure and Recovery
 
-- A zero organization identifier routes to an explicit `org-global` index instead of
-  silently creating an index for numeric organization zero. The writer emits a warning with
-  record kind and scope type, without payload data, whenever this fallback is used.
-- Invalid or blank custom prefixes retain existing behavior and are outside this change.
-- Bulk write errors retain the existing propagation and logging behavior.
-- A deployment rollback resumes the previous shared index naming. Readers continue to
-  search both layouts through existing wildcard patterns.
-- The external cron must not archive an index unless its full name matches the approved
-  prefix, organization segment, and date grammar.
-- The external cron must not treat a failed or partial archive as permission to remove the
-  source index. That behavior is outside this repository but is a rollout prerequisite.
-- The external cron must rescan all eligible dates on every run so an old-date index
-  recreated by a late record is archived again.
+- Missing organization context routes to the explicit `global` segment so observability
+  writes are not dropped.
+- Existing bulk error propagation and logging remain unchanged.
+- Rollback restores the prior shared index format without rewriting data.
+- Old and new indexes can coexist and remain queryable through existing wildcard readers.
+- Archive failures and late-arriving records remain owned by the external cron.
 
 ## Security and Privacy
 
-- Organization identifiers are already present in observability documents. Adding the
-  identifier to the index name does not introduce a new class of tenant identifier.
-- OpenSearch credentials and permissions remain unchanged.
-- The application must continue writing the organization identifier into each document so
-  index routing can be audited against document scope.
-- Index naming provides a physical archival boundary but does not replace query-time or
-  OpenSearch authorization controls.
-- Archive cron permissions should be limited to matching observability index prefixes and
-  the required archive operations. Cron permission changes are outside this RFC's code
-  scope.
+- Organization IDs already exist in observability documents. Including them in index names
+  does not add new tenant data.
+- OpenSearch credentials and permissions do not change.
+- Physical index separation supports archival boundaries but does not replace query-time
+  authorization.
 
 ## Observability
 
-- Existing bulk write failure logs remain the primary application diagnostic.
-- A warning identifies every write routed to `org-global` so operators can distinguish
-  expected infrastructure records from missing tenant context.
-- Tests inspect bulk metadata to prove that each record is routed to the expected physical
-  index.
-- Operators can list indexes by prefix and organization segment to verify rollout.
-- No new application metric or log is required because this change only alters deterministic
-  routing metadata.
+- Existing bulk failure logs remain unchanged.
+- Tests inspect bulk metadata to verify destination index names.
+- Operators can list indexes using the existing prefixes to verify rollout.
 
 ## Data and Migration
 
-No database schema or document migration is required.
-
-Existing indexes retain their current names and contents. New application versions begin
-writing to organization-scoped daily indexes immediately after deployment. During the
-compatibility window, OpenSearch therefore contains both old shared indexes and new
-organization-scoped indexes.
-
-The external archive cron must recognize both layouts until all old shared indexes have
-passed the maximum supported retention period and have been archived under the existing
-operational process.
+No database or document migration is required. Existing shared indexes remain unchanged.
+New writes use organization-scoped indexes after deployment.
 
 ## Rollout
 
-1. Update the archive cron parser and dry-run validation to recognize both old and new index
-   layouts by the literal `org` marker. Do not enable new archival actions yet.
-2. Deploy the application index-routing change.
-3. Verify that timeline, log, event, and metric writes create organization-scoped daily
-   indexes and retain matching organization identifiers in their documents.
-4. Verify that telemetry reads and dashboards continue to find both old and new indexes.
-5. Record the current active primary and replica shard counts, the projected peak from the
-   organization count and retention horizon, the operator-approved hard threshold, the
-   maximum expected event lateness, and the archive grace period in
-   `jsons/operational-readiness.json`.
-6. Enable organization-specific archive schedules in the cron after the new names are
-   observed and validated.
-7. Stop rollout if organization-scoped indexes are missing, organization IDs disagree with
-   document scope, wildcard reads omit either layout, the cron cannot classify an index,
-   late writes are not re-archived, or index growth reaches the approved threshold.
+1. Update the external cron to recognize both old and new index names using its exact
+   configured prefixes.
+2. Deploy the application change.
+3. Confirm new timeline, log, event, and metric indexes contain the expected organization
+   segment and UTC date.
+4. Confirm sampled documents contain the same organization ID as their index name.
+5. Confirm existing telemetry reads and dashboards include both layouts.
+6. Enable organization-specific archival in the external cron.
+
+Stop rollout if index names contain the wrong organization, records disappear from existing
+queries, or OpenSearch rejects writes.
 
 ## Rollback
 
-Roll back the application binary to restore the previous shared daily index names. No data
-rewrite is required. Existing wildcard readers continue to include indexes produced before,
-during, and after rollback.
+Roll back the application binary. New writes return to the previous shared daily index
+names. No data rewrite is required, and existing wildcard readers continue matching both
+layouts.
 
-Disable archival of the new organization-scoped pattern before rollback if the cron cannot
-safely process a mixed layout. Indexes already archived by the external cron are not
-restored by this application rollback and remain governed by the cron's recovery process.
-
-The cron must continue rescanning eligible dates after rollback until the final
-organization-scoped index has passed the maximum lateness and archive grace windows.
+The external cron must continue recognizing both layouts until old and new indexes have
+completed their configured archive lifecycle.
 
 ## Alternatives Considered
 
-- Keep shared daily indexes and filter by `organizationId` during archival. Rejected because
-  it requires document-level copy and removal rather than atomic index archival.
-- Use OpenSearch Index State Management. Rejected because retention and archival are owned
-  by an external cron.
-- Add an application cleanup worker. Rejected because the application does not own archive
-  scheduling or lifecycle operations.
-- Create one index per retention tier. Rejected because organization retention schedules can
-  differ independently and the archive cron requires an organization boundary.
-- Add organization identifiers only to timeline indexes. Rejected because logs, events, and
-  metrics require the same independent archival behavior.
-- Duplicate index formatting in each writer. Rejected because index naming is an operational
-  contract and should have one source of truth.
+- Shared indexes with document-level archival were rejected because the cron needs to
+  archive complete indexes independently by organization.
+- OpenSearch Index State Management was rejected because the external cron owns archival.
+- An application cleanup worker was rejected because the application does not own archive
+  lifecycle operations.
+- A shared naming package was rejected because two small private formatting functions are
+  simpler and avoid adding a new public API.
+- A literal `org` marker was rejected because the cron already owns exact configured
+  prefixes and can parse the final organization and date segments directly.
 
 ## Testing and Verification
 
-Required test categories:
+Required tests:
 
-- Shared index-name contract for nonzero organization identifiers.
-- Explicit `global` fallback for organization identifier zero.
-- Warning emission when the `global` fallback is used.
-- UTC conversion and zero-time fallback.
-- Default and custom prefix preservation.
-- Timeline log, event, metric, metadata, and usage routing through the organization-scoped
-  name.
-- Telemetry log, event, and metric routing through organization-scoped names.
-- Preservation of organization identifiers inside documents.
-- Existing wildcard telemetry query compatibility through focused API tests or direct
-  assertion of unchanged patterns.
-- Existing bulk error propagation.
-- Old and new default and custom-prefix parser fixtures supplied by the archive cron owner.
+- Timeline default prefix with a nonzero organization ID.
+- Timeline custom prefix with a nonzero organization ID.
+- Timeline `global` fallback.
+- Telemetry log, event, and metric names with a nonzero organization ID.
+- Telemetry `global` fallback for every supported record kind.
+- UTC date behavior.
+- Organization ID preservation inside indexed documents.
+- Existing bulk error behavior.
 
-Exact verification commands:
+Exact commands:
 
 ```bash
-go test ./pkg/telemetry/...
+go test ./pkg/telemetry/providers/...
 go test ./api/assistant-api/internal/observability/collectors/timeline/...
 go test ./api/assistant-api/api/observability/...
-make agent-finalize CHANGED_FILES="pkg/telemetry/opensearch_index.go,pkg/telemetry/opensearch_index_test.go,pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
+make agent-finalize CHANGED_FILES="pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
 ```
-
-Operational verification before enabling archival:
-
-```text
-curl -fsS "$OPENSEARCH_URL/_cat/indices/rapida-*?h=index,pri,rep,docs.count,store.size&format=json"
-curl -fsS "$OPENSEARCH_URL/_cluster/health?level=indices"
-curl -fsS -H 'Content-Type: application/json' "$OPENSEARCH_URL/rapida-*-org-*-*/_search" -d '{"size":100,"_source":["organizationId"],"query":{"match_all":{}}}'
-go test ./api/assistant-api/api/observability/... -run TestGetAllTelemetry
-```
-
-The archive cron owner must add its environment-specific dry-run and archive verification
-commands to `jsons/operational-readiness.json`. That artifact must also record parser
-fixtures for old and new default and custom prefixes, the approved shard threshold, the
-measured shard counts, the maximum lateness, and the archive grace period. Absence of this
-evidence blocks rollout.
 
 ## Acceptance Criteria
 
-- [ ] Timeline records use `<prefix>-org-<organization-segment>-YYYYMMDD`.
-- [ ] Telemetry logs use `<prefix>-logs-org-<organization-segment>-YYYYMMDD`.
-- [ ] Telemetry events use `<prefix>-events-org-<organization-segment>-YYYYMMDD`.
-- [ ] Telemetry metrics use `<prefix>-metrics-org-<organization-segment>-YYYYMMDD`.
-- [ ] Nonzero organization identifiers use their base-10 representation.
-- [ ] Zero organization identifiers use the literal `global`.
-- [ ] Writes using the `global` fallback emit a warning without payload data.
-- [ ] Dates are derived from record occurrence time and formatted in UTC.
-- [ ] Existing custom prefixes remain supported.
-- [ ] Organization identifiers remain present in indexed documents.
-- [ ] Existing telemetry wildcard reads cover old and new index layouts.
-- [ ] No application code lists, archives, closes, or deletes indexes.
+- [ ] Timeline uses `<prefix>-<organization-segment>-YYYYMMDD`.
+- [ ] Logs use `<prefix>-logs-<organization-segment>-YYYYMMDD`.
+- [ ] Events use `<prefix>-events-<organization-segment>-YYYYMMDD`.
+- [ ] Metrics use `<prefix>-metrics-<organization-segment>-YYYYMMDD`.
+- [ ] Nonzero organization IDs use unsigned base-10 formatting.
+- [ ] Organization ID zero uses `global`.
+- [ ] Dates remain based on occurrence time and formatted in UTC.
+- [ ] Custom prefixes remain supported.
+- [ ] Organization IDs remain present in documents.
+- [ ] Existing wildcard reads cover old and new layouts.
+- [ ] No archive lifecycle behavior is added to the application.
 - [ ] Focused tests and `make agent-finalize` pass.
-- [ ] The archive cron owner confirms mixed-layout support before rollout.
-- [ ] The archive cron proves ambiguous names are skipped, late eligible indexes are
-  re-archived, and archive verification precedes source removal.
-- [ ] Operational readiness records measured and projected shard counts, a hard capacity
-  threshold, maximum event lateness, and archive grace period.
 - [ ] No unresolved critical or major review findings remain.
 
 ## Open Questions
 
-- Who owns the external archive cron compatibility confirmation?
-- What hard active-shard threshold has the OpenSearch operator approved?
-- What maximum event lateness and archive grace period has the archive cron owner approved?
-- How long must the cron retain compatibility with the old shared index layout?
-- Which current record producers are legitimately allowed to emit with organization ID zero?
+None.
 
 ## Challenge Resolution
 
-Challenge round 1 returned `REVISE` for ambiguous mixed-layout parsing, missing shard
-capacity gates, undefined late-write behavior, unconstrained zero-organization routing, and
-insufficient operational commands. This revision adds the explicit `org` marker, safe
-classification rules, repeated late-index archival requirements, zero-organization
-warnings, and an operational-readiness artifact contract. Operator-owned values and exact
-cron commands remain unresolved, so the RFC remains `Draft` and requires another
-independent challenge after those inputs are recorded.
+Challenge round 1 requested an unambiguous archive parser contract and additional external
+cron operational controls. The user selected the smaller application contract: append the
+organization ID, use `global` when unavailable, and leave all archival behavior with the
+cron. This revision requires the cron to parse names relative to exact configured prefixes,
+which resolves custom-prefix ambiguity without adding another index-name segment. The RFC
+requires a second independent challenge before acceptance.
 
 ## Artifact Index
 
-- `rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json` - initial task plan;
-  revised after challenge round 1.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json` - current complete
+  task plan; challenge round 2 pending.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/challenge.json` - challenge
   round 1 receipt; decision `revise`.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-plan.json` - user
+  decision and reduced-scope amendment.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-challenge.json` -
+  not created; reserved for challenge round 2.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/confirmation.json` - not created;
-  reserved for the exact-digest confirmation receipt.
-- `rfcs/0012-organization-scoped-observability-indexes/jsons/operational-readiness.json` -
-  not created; required before rollout.
+  reserved for exact-digest confirmation.
 
 ## Decision Log
 
 | Date | Decision | Owner | Evidence |
 | --- | --- | --- | --- |
-| 2026-08-25 | Use organization-scoped UTC daily indexes for all OpenSearch observability writers | User and RFC owner | `jsons/plan.json` |
-| 2026-08-25 | Keep archive lifecycle ownership in the external cron | User and RFC owner | `jsons/plan.json` |
-| 2026-08-25 | Keep the RFC in Draft pending independent challenge and exact-digest confirmation | RFC owner | Governed workflow requirement |
-| 2026-08-25 | Add an explicit `org` marker and operational safety gates | RFC owner | `jsons/challenge.json` |
+| 2026-08-25 | Use organization-scoped UTC daily indexes for all OpenSearch observability writers | User | Conversation and `jsons/plan.json` |
+| 2026-08-25 | Use `global` when organization ID is unavailable | User | Conversation and `jsons/amendment-01-plan.json` |
+| 2026-08-25 | Keep implementation limited to adding organization to existing names | User | Conversation and `jsons/amendment-01-plan.json` |
+| 2026-08-25 | Keep archive lifecycle ownership in the external cron | User | Conversation and `jsons/plan.json` |

--- a/rfcs/0012-organization-scoped-observability-indexes.md
+++ b/rfcs/0012-organization-scoped-observability-indexes.md
@@ -3,8 +3,8 @@
 - Status: Draft
 - Owner: Observability maintainers
 - Created: 2026-08-25
-- Updated: 2026-08-25
-- Reviewers: Independent plan challenger (pending)
+- Updated: 2026-08-27
+- Reviewers: Independent plan challenger
 
 ## Summary
 
@@ -239,22 +239,20 @@ None.
 Challenge round 1 requested an unambiguous archive parser contract and additional external
 cron operational controls. The user selected the smaller application contract: append the
 organization ID, use `global` when unavailable, and leave all archival behavior with the
-cron. This revision requires the cron to parse names relative to exact configured prefixes,
-which resolves custom-prefix ambiguity without adding another index-name segment. The RFC
-requires a second independent challenge before acceptance.
+cron. Challenge round 2 returned `revise` because the remaining cron, capacity, and rollout
+requirements exceeded the requested application-only scope. The plan was blocked after two
+revision cycles, and RFC 0013 superseded this proposal with the smaller code-only contract.
 
 ## Artifact Index
 
-- `rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json` - current complete
-  task plan; challenge round 2 pending.
+- `rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json` - blocked final plan.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/challenge.json` - challenge
   round 1 receipt; decision `revise`.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-plan.json` - user
   decision and reduced-scope amendment.
 - `rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-challenge.json` -
-  not created; reserved for challenge round 2.
-- `rfcs/0012-organization-scoped-observability-indexes/jsons/confirmation.json` - not created;
-  reserved for exact-digest confirmation.
+  challenge round 2 receipt; decision `revise`, implementation unauthorized.
+- No confirmation receipt exists because the RFC was blocked and superseded before approval.
 
 ## Decision Log
 
@@ -264,3 +262,4 @@ requires a second independent challenge before acceptance.
 | 2026-08-25 | Use `global` when organization ID is unavailable | User | Conversation and `jsons/amendment-01-plan.json` |
 | 2026-08-25 | Keep implementation limited to adding organization to existing names | User | Conversation and `jsons/amendment-01-plan.json` |
 | 2026-08-25 | Keep archive lifecycle ownership in the external cron | User | Conversation and `jsons/plan.json` |
+| 2026-08-26 | Block this RFC after two revision cycles and supersede it with RFC 0013 | Coordinator | `jsons/plan.json` and RFC 0013 |

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-challenge.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-challenge.json
@@ -1,0 +1,30 @@
+{
+  "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
+  "plan": "rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json",
+  "amendment": 1,
+  "round": 2,
+  "decision": "revise",
+  "reviewed_at": "2026-08-25",
+  "reviewed_rfc_sha256": "540a48bf4c0a901e3929f413a18874dc3dfc3912b619bfb8835f3e24f221fc48",
+  "reviewed_plan_sha256": "c1ca351a8072b0999e00c2cba77f247ef718610c4695aebf20bc46f6a09398fd",
+  "review_mode": "independent read-only fallback reviewer after Orca worker launch failures",
+  "findings": [
+    {
+      "severity": "major",
+      "finding": "The exact reviewed RFC remained Draft and the plan remained pending, so the bytes were not eligible for approval.",
+      "required_change": "Set the final challenge-ready RFC status to Accepted and update the plan state before another review."
+    },
+    {
+      "severity": "major",
+      "finding": "The external cron compatibility prerequisite lacks a named owner, executable verification command, and evidence artifact.",
+      "required_change": "Define concrete pre-deployment evidence that the cron recognizes old and new layouts using exact configured prefixes."
+    }
+  ],
+  "cycle_limit": {
+    "maximum": 2,
+    "completed": 2,
+    "result": "blocked",
+    "reason": "DEVELOPMENT_PROCESS.md requires escalation after two unsuccessful plan or RFC correction cycles."
+  },
+  "implementation_authorized": false
+}

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-plan.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/amendment-01-plan.json
@@ -1,0 +1,23 @@
+{
+  "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
+  "amendment": 1,
+  "status": "pending_challenge",
+  "requested_by": "user",
+  "requested_at": "2026-08-25",
+  "request": "Keep the implementation simple: add organization ID to every observability index and use global when it is unavailable.",
+  "changes": [
+    "Use <prefix>-<organization-segment>-YYYYMMDD for timeline indexes.",
+    "Use <prefix>-<kind>-<organization-segment>-YYYYMMDD for log, event, and metric indexes.",
+    "Use global when OrganizationID is zero.",
+    "Limit production changes to the two existing writers and their tests.",
+    "Keep archive behavior and operational scheduling outside the application."
+  ],
+  "challenge_round_1_disposition": [
+    "Resolve custom-prefix ambiguity by requiring the cron to parse relative to exact configured prefixes.",
+    "Accept organization-by-day index growth as a reviewed operational tradeoff.",
+    "Preserve occurrence-time routing and leave repeated archival of late indexes with the cron.",
+    "Preserve records without organization context in a global index."
+  ],
+  "implementation_authorized": false,
+  "next_gate": "Independent challenge round 2 of the exact revised RFC and plan bytes."
+}

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/challenge.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/challenge.json
@@ -1,0 +1,53 @@
+{
+  "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
+  "plan": "rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json",
+  "round": 1,
+  "decision": "revise",
+  "reviewed_at": "2026-08-25",
+  "reviewed_rfc_sha256": "b20afeca0d1b564cee1f39cb2253c01a2a509ed346dfbce2036c99e74750c765",
+  "reviewed_plan_sha256": "4f21da9d277a3b8ffe52a341608b9b59c020a6f76b87cacbbc9f68e1bc143a94",
+  "run_id": "run_7664265d945b",
+  "task_id": "task_35da35309890",
+  "dispatch_id": "ctx_c1b84adcac22",
+  "review_mode": "independent read-only Orca worker",
+  "lifecycle_status": "worker_done content delivered but settlement rejected because the worker omitted its dispatch capability",
+  "findings": [
+    {
+      "severity": "P0",
+      "finding": "The proposed mixed-layout grammar is ambiguous when a custom timeline prefix ends in a numeric token or global.",
+      "required_change": "Add an unambiguous versioned marker or define an exact prefix registry and parser contract, add old and new parser fixtures, and prohibit removal when classification is uncertain.",
+      "resolution": "The revision adds a literal org marker, requires parser fixtures, and requires unknown names to be reported and skipped."
+    },
+    {
+      "severity": "P1",
+      "finding": "Organization-by-day index growth lacks quantified capacity limits and operator evidence.",
+      "required_change": "Record current and projected shard counts, retention horizon, a hard threshold, monitoring commands, named operator approval, and artifact evidence.",
+      "resolution": "The revision requires these values and commands in operational-readiness.json before rollout. Values remain open pending operator input."
+    },
+    {
+      "severity": "P1",
+      "finding": "Occurrence-time routing can recreate an already archived old-date index when records arrive late.",
+      "required_change": "Define maximum lateness, archive grace period, and safe re-archive recovery.",
+      "resolution": "The revision requires repeated eligible-date scans, versioned or idempotent archive output, verification before source removal, and approved lateness and grace values. Values remain open pending operator input."
+    },
+    {
+      "severity": "P1",
+      "finding": "Zero OrganizationID fallback silently mixes records without identifying legitimate global producers.",
+      "required_change": "Inventory legitimate global producers and reject or observably alert on unexpected tenant records.",
+      "resolution": "The revision uses org-global, requires a warning without payload data, and keeps the producer inventory open pending maintainer input."
+    },
+    {
+      "severity": "P2",
+      "finding": "Operational verification lacks exact cron, inventory, health, consistency, rollback, and stop-condition commands.",
+      "required_change": "Add executable verification commands and resolve every open question before acceptance.",
+      "resolution": "The revision adds OpenSearch inventory, health, consistency, and reader verification commands and requires environment-specific cron commands in operational-readiness.json."
+    }
+  ],
+  "remaining_blockers": [
+    "The OpenSearch operator must provide and approve the hard active-shard threshold.",
+    "The archive cron owner must provide exact dry-run and archive verification commands.",
+    "The archive cron owner must approve maximum event lateness and archive grace period.",
+    "Observability maintainers must identify legitimate zero-organization producers.",
+    "A second independent challenge must review the revised exact bytes."
+  ]
+}

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
@@ -2,113 +2,44 @@
   "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
   "artifact": "rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json",
   "status": "draft",
-  "decision": "pending",
+  "decision": "pending_independent_challenge",
   "created_at": "2026-08-25",
   "updated_at": "2026-08-25",
-  "revision": 1,
-  "objective": "Route all OpenSearch observability records into organization-scoped UTC daily indexes so an external cron can archive complete indexes using organization-specific schedules.",
+  "objective": "Add organization ID to every daily OpenSearch observability index name, using global when organization ID is unavailable.",
   "classification": {
     "tier": "Governed",
-    "reason": "The index name is an operational contract with an external archive cron, and archival may lead to irreversible removal from active storage."
+    "reason": "The index name is an operational contract consumed by an external archival process."
   },
   "verified_current_behavior": [
-    "The timeline collector writes all record kinds to <prefix>-YYYYMMDD and stores organizationId inside each document.",
-    "The telemetry OpenSearch exporter writes logs, events, and metrics to <prefix>-<kind>-YYYYMMDD and stores OrganizationID inside each document.",
-    "The observability recorder resolves OrganizationID from project or organization authentication context when available.",
-    "Telemetry reads use rapida-logs-*, rapida-events-*, and rapida-metrics-* wildcard patterns that match both current and proposed layouts.",
-    "OpenSearch indexes are currently selected in bulk metadata and are not explicitly created by these writers."
-  ],
-  "assumptions": [
-    "The external cron, not assistant-api, owns index archival and any later source-index removal.",
-    "Retention may differ for each organization.",
-    "Daily UTC indexes provide the required archival granularity.",
-    "Records without organization context must remain writable for backward compatibility.",
-    "The external archive cron can repeatedly scan eligible dates and produce idempotent or versioned archive artifacts for late writes."
-  ],
-  "open_questions": [
-    {
-      "question": "Who owns confirmation that the external archive cron supports both old and new index layouts?",
-      "owner": "Operations owner"
-    },
-    {
-      "question": "What hard active-shard threshold has the OpenSearch operator approved?",
-      "owner": "OpenSearch operator"
-    },
-    {
-      "question": "What maximum event lateness and archive grace period has the archive cron owner approved?",
-      "owner": "Operations owner"
-    },
-    {
-      "question": "How long must the archive cron retain compatibility with old shared indexes?",
-      "owner": "Operations owner"
-    },
-    {
-      "question": "Which current record producers are legitimately allowed to emit with organization ID zero?",
-      "owner": "Observability maintainers"
-    }
+    "The timeline collector writes all supported record kinds to <prefix>-YYYYMMDD.",
+    "The telemetry OpenSearch exporter writes logs, events, and metrics to <prefix>-<kind>-YYYYMMDD.",
+    "Both writers already receive organization ID and preserve it in indexed documents.",
+    "Telemetry readers use wildcard patterns that match both current and proposed names.",
+    "Index creation occurs through existing bulk write behavior."
   ],
   "acceptance_criteria": [
-    "Timeline records use <prefix>-org-<organization-segment>-YYYYMMDD.",
-    "Telemetry logs use <prefix>-logs-org-<organization-segment>-YYYYMMDD.",
-    "Telemetry events use <prefix>-events-org-<organization-segment>-YYYYMMDD.",
-    "Telemetry metrics use <prefix>-metrics-org-<organization-segment>-YYYYMMDD.",
-    "A nonzero organization identifier is formatted as an unsigned base-10 integer.",
-    "A zero organization identifier is formatted as global and emits a warning without payload data.",
-    "The date comes from record occurrence time and is formatted in UTC.",
-    "Default and custom prefixes retain their current meaning.",
-    "Organization identifiers remain in indexed documents.",
-    "Existing wildcard telemetry reads include old and new names.",
-    "Application code does not own archive, close, delete, or restore operations.",
-    "Focused tests and repository finalization checks pass.",
-    "The archive cron owner confirms unambiguous mixed-layout compatibility before rollout.",
-    "Late eligible indexes are re-archived and verified before source removal.",
-    "Operational readiness records measured and projected shard counts, a hard threshold, maximum event lateness, and archive grace period.",
+    "Timeline uses <prefix>-<organization-segment>-YYYYMMDD.",
+    "Logs use <prefix>-logs-<organization-segment>-YYYYMMDD.",
+    "Events use <prefix>-events-<organization-segment>-YYYYMMDD.",
+    "Metrics use <prefix>-metrics-<organization-segment>-YYYYMMDD.",
+    "Nonzero organization IDs use unsigned base-10 formatting.",
+    "Organization ID zero uses global.",
+    "Dates remain based on occurrence time and formatted in UTC.",
+    "Custom prefixes remain supported.",
+    "Organization IDs remain present inside documents.",
+    "Existing wildcard reads cover old and new layouts.",
+    "No archive lifecycle behavior is added to the application.",
+    "Focused tests and make agent-finalize pass.",
     "No unresolved critical or major review findings remain."
   ],
   "non_goals": [
     "Implement or configure the archive cron.",
-    "Define organization retention periods.",
-    "Add OpenSearch Index State Management.",
-    "Create index templates or explicit index creation calls.",
-    "Rename, reindex, migrate, or delete existing indexes.",
-    "Change observability payload schemas, APIs, protobufs, or database schemas.",
-    "Change OpenSearch connector behavior."
-  ],
-  "scope_and_ownership": [
-    {
-      "path": "pkg/telemetry/opensearch_index.go",
-      "owner": "implementation owner",
-      "responsibility": "Single source of truth for organization-scoped UTC daily index names."
-    },
-    {
-      "path": "pkg/telemetry/opensearch_index_test.go",
-      "owner": "implementation owner",
-      "responsibility": "Index-name contract tests."
-    },
-    {
-      "path": "pkg/telemetry/providers/opensearch.go",
-      "owner": "implementation owner",
-      "responsibility": "Route log, event, and metric records using organization-scoped names."
-    },
-    {
-      "path": "pkg/telemetry/providers/opensearch_test.go",
-      "owner": "implementation owner",
-      "responsibility": "Verify exporter bulk metadata and document scope."
-    },
-    {
-      "path": "api/assistant-api/internal/observability/collectors/timeline/collector.go",
-      "owner": "implementation owner",
-      "responsibility": "Route all timeline record kinds using organization-scoped names."
-    },
-    {
-      "path": "api/assistant-api/internal/observability/collectors/timeline/collector_test.go",
-      "owner": "implementation owner",
-      "responsibility": "Verify timeline bulk metadata, fallback behavior, UTC dates, and document scope."
-    }
+    "Add retention configuration or OpenSearch lifecycle policies.",
+    "Explicitly create, archive, close, restore, or delete indexes.",
+    "Migrate or rename existing indexes.",
+    "Change document schemas, APIs, protobufs, databases, or connector behavior."
   ],
   "allowed_paths": [
-    "pkg/telemetry/opensearch_index.go",
-    "pkg/telemetry/opensearch_index_test.go",
     "pkg/telemetry/providers/opensearch.go",
     "pkg/telemetry/providers/opensearch_test.go",
     "api/assistant-api/internal/observability/collectors/timeline/collector.go",
@@ -119,87 +50,88 @@
   "out_of_scope_paths": [
     "pkg/connectors/",
     "api/assistant-api/api/observability/",
-    "OpenSearch deployment and cluster configuration",
-    "External archive cron source and deployment",
+    "OpenSearch cluster configuration",
+    "External archive cron",
     "Existing OpenSearch indexes"
   ],
+  "ownership": [
+    {
+      "paths": [
+        "pkg/telemetry/providers/opensearch.go",
+        "pkg/telemetry/providers/opensearch_test.go"
+      ],
+      "owner": "telemetry exporter implementation owner"
+    },
+    {
+      "paths": [
+        "api/assistant-api/internal/observability/collectors/timeline/collector.go",
+        "api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
+      ],
+      "owner": "timeline collector implementation owner"
+    },
+    {
+      "paths": [
+        "rfcs/0012-organization-scoped-observability-indexes.md",
+        "rfcs/0012-organization-scoped-observability-indexes/jsons/"
+      ],
+      "owner": "RFC coordinator"
+    }
+  ],
   "design": {
-    "smallest_complete_solution": "Add one shared index-name function and use it in the two existing OpenSearch observability writers.",
-    "timeline_contract": "<prefix>-org-<organization-segment>-<UTC YYYYMMDD>",
-    "telemetry_contract": "<prefix>-<kind>-org-<organization-segment>-<UTC YYYYMMDD>",
-    "organization_segment": "Unsigned base-10 organization identifier, or global when OrganizationID is zero.",
-    "date_source": "Record occurrence timestamp, falling back to the current time when zero, always formatted in UTC. The cron repeatedly rescans eligible dates and re-archives indexes recreated by late writes.",
-    "index_creation": "Unchanged. Existing bulk indexing behavior selects or automatically creates the destination index.",
-    "read_compatibility": "Unchanged telemetry wildcard patterns continue to match old and new layouts."
+    "timeline_contract": "<prefix>-<organization-segment>-<UTC YYYYMMDD>",
+    "telemetry_contract": "<prefix>-<kind>-<organization-segment>-<UTC YYYYMMDD>",
+    "organization_segment": "Unsigned base-10 organization ID, or global when OrganizationID is zero.",
+    "date_source": "Existing record occurrence time behavior, with current UTC time used when occurrence time is zero.",
+    "implementation": "Change only the existing private index-name functions and their call sites.",
+    "cron_contract": "The external cron parses relative to exact configured prefixes and supports old and new layouts during rollout."
   },
   "principle_decisions": {
-    "kiss": "Change only deterministic index routing and its tests. Do not add lifecycle workers, connector APIs, or storage policies.",
-    "yagni": "Do not add configurable index formats, retention values, archive clients, aliases, or migration tooling.",
-    "single_source_of_truth": "One shared function owns the organization and UTC date suffix contract.",
-    "ownership": "Application writers own index selection. The external cron owns archive lifecycle operations.",
-    "compatibility": "Preserve prefixes, document fields, bulk behavior, and wildcard reads. Leave old indexes untouched.",
-    "failure_safety": "Use an explicit org-global segment with a warning for missing organization context, preserve bulk error behavior, require unambiguous cron mixed-layout parsing, and require repeated handling of indexes recreated by late writes.",
-    "security": "Retain document-level organization scope and do not broaden OpenSearch permissions in application code.",
-    "observability": "Use existing bulk failure logs and verify routing through bulk metadata tests."
+    "kiss": "Modify only the two existing OpenSearch writers and their focused tests.",
+    "yagni": "Do not add shared packages, new configuration, lifecycle workers, connector APIs, policies, templates, or migrations.",
+    "single_source_of_truth": "Each existing writer remains the owner of its established prefix and record-kind naming.",
+    "compatibility": "Preserve document fields, bulk behavior, custom prefixes, UTC dates, wildcard reads, and all existing indexes.",
+    "failure_safety": "Use global instead of dropping records when organization context is missing.",
+    "rollback": "Roll back the application binary. Both layouts remain readable through existing wildcard patterns."
   },
   "risks": [
     {
-      "risk": "Organization-by-day indexes can significantly increase index and shard counts.",
-      "mitigation": "Require measured and projected shard counts plus an operator-approved hard threshold in operational-readiness.json before rollout."
+      "risk": "Organization-by-day routing increases the number of indexes and shards.",
+      "disposition": "Accepted as an operational consequence of organization-specific archival. Capacity monitoring remains an operator responsibility."
     },
     {
-      "risk": "The archive cron may parse only the old shared layout.",
-      "mitigation": "Use an explicit org marker, provide parser fixtures, deploy and dry-run mixed-layout parsing before writer changes, and skip any unclassified index."
+      "risk": "Custom prefixes can contain hyphens or numeric tokens.",
+      "disposition": "The archive cron must strip the exact configured prefix before parsing organization and date suffixes."
     },
     {
-      "risk": "Organization scope may be absent for infrastructure-level records.",
-      "mitigation": "Route zero OrganizationID to an explicit org-global segment, emit a warning, inventory legitimate global producers, and define its retention separately."
+      "risk": "Records without organization context share the global index.",
+      "disposition": "Accepted to preserve observability delivery. The global index has its own cron handling."
     },
     {
-      "risk": "An index organization segment could disagree with the document organizationId.",
-      "mitigation": "Derive both from the same scope object and assert both values in focused tests and rollout sampling."
-    },
-    {
-      "risk": "A late record can recreate an old-date index after the cron archived it.",
-      "mitigation": "Require repeated eligible-date scans, versioned or idempotent archive output, archive verification before source removal, and an approved lateness and grace window."
+      "risk": "Late records can write to an old date index.",
+      "disposition": "Existing occurrence-time routing is preserved. Repeated archival handling remains owned by the external cron."
     }
   ],
   "rollout": [
-    "Update and dry-run the archive cron against both layouts using the explicit org marker.",
-    "Deploy the application routing change.",
-    "Verify all index kinds, organization segments, UTC dates, and document scope values.",
-    "Verify existing telemetry reads and dashboards across both layouts.",
-    "Record capacity, parser, lateness, grace-period, and exact cron command evidence in operational-readiness.json.",
-    "Enable organization-specific archive schedules only after verification."
-  ],
-  "rollback": "Roll back the application binary to restore shared daily names. Existing wildcard readers continue to match both layouts. Disable new-layout archival first if the cron cannot safely process mixed names. Already archived indexes remain owned by the cron recovery procedure.",
-  "required_test_categories": [
-    "Shared index-name contract",
-    "Nonzero organization identifier",
-    "Global fallback and warning",
-    "UTC and zero-time behavior",
-    "Default and custom prefixes",
-    "Timeline routing for every supported record kind",
-    "Telemetry routing for logs, events, and metrics",
-    "Organization identifier preservation in documents",
-    "Wildcard read compatibility",
-    "Bulk error propagation",
-    "Archive parser fixtures for old and new default and custom prefixes"
+    "Update the external cron to recognize old and new layouts using exact configured prefixes.",
+    "Deploy application changes.",
+    "Verify index names and matching document organization IDs.",
+    "Verify existing wildcard reads and dashboards.",
+    "Enable organization-specific archival."
   ],
   "verification_commands": [
-    "go test ./pkg/telemetry/...",
+    "go test ./pkg/telemetry/providers/...",
     "go test ./api/assistant-api/internal/observability/collectors/timeline/...",
     "go test ./api/assistant-api/api/observability/...",
-    "make agent-finalize CHANGED_FILES=\"pkg/telemetry/opensearch_index.go,pkg/telemetry/opensearch_index_test.go,pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go\""
+    "make agent-finalize CHANGED_FILES=\"pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go\""
   ],
+  "open_questions": [],
   "governance": {
     "reserved_path": "rfcs/0012-organization-scoped-observability-indexes.md",
-    "challenge_status": "round_1_revise",
+    "run_id": "run_7664265d945b",
+    "initial_challenge_task_id": "task_35da35309890",
+    "challenge_status": "round_2_pending",
     "confirmation_status": "pending",
     "accepted_rfc_sha256": null,
-    "run_id": "run_7664265d945b",
-    "task_id": "task_35da35309890",
-    "gate_id": null,
     "implementation_authorized": false
   }
 }

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
@@ -1,0 +1,205 @@
+{
+  "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
+  "artifact": "rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json",
+  "status": "draft",
+  "decision": "pending",
+  "created_at": "2026-08-25",
+  "updated_at": "2026-08-25",
+  "revision": 1,
+  "objective": "Route all OpenSearch observability records into organization-scoped UTC daily indexes so an external cron can archive complete indexes using organization-specific schedules.",
+  "classification": {
+    "tier": "Governed",
+    "reason": "The index name is an operational contract with an external archive cron, and archival may lead to irreversible removal from active storage."
+  },
+  "verified_current_behavior": [
+    "The timeline collector writes all record kinds to <prefix>-YYYYMMDD and stores organizationId inside each document.",
+    "The telemetry OpenSearch exporter writes logs, events, and metrics to <prefix>-<kind>-YYYYMMDD and stores OrganizationID inside each document.",
+    "The observability recorder resolves OrganizationID from project or organization authentication context when available.",
+    "Telemetry reads use rapida-logs-*, rapida-events-*, and rapida-metrics-* wildcard patterns that match both current and proposed layouts.",
+    "OpenSearch indexes are currently selected in bulk metadata and are not explicitly created by these writers."
+  ],
+  "assumptions": [
+    "The external cron, not assistant-api, owns index archival and any later source-index removal.",
+    "Retention may differ for each organization.",
+    "Daily UTC indexes provide the required archival granularity.",
+    "Records without organization context must remain writable for backward compatibility.",
+    "The external archive cron can repeatedly scan eligible dates and produce idempotent or versioned archive artifacts for late writes."
+  ],
+  "open_questions": [
+    {
+      "question": "Who owns confirmation that the external archive cron supports both old and new index layouts?",
+      "owner": "Operations owner"
+    },
+    {
+      "question": "What hard active-shard threshold has the OpenSearch operator approved?",
+      "owner": "OpenSearch operator"
+    },
+    {
+      "question": "What maximum event lateness and archive grace period has the archive cron owner approved?",
+      "owner": "Operations owner"
+    },
+    {
+      "question": "How long must the archive cron retain compatibility with old shared indexes?",
+      "owner": "Operations owner"
+    },
+    {
+      "question": "Which current record producers are legitimately allowed to emit with organization ID zero?",
+      "owner": "Observability maintainers"
+    }
+  ],
+  "acceptance_criteria": [
+    "Timeline records use <prefix>-org-<organization-segment>-YYYYMMDD.",
+    "Telemetry logs use <prefix>-logs-org-<organization-segment>-YYYYMMDD.",
+    "Telemetry events use <prefix>-events-org-<organization-segment>-YYYYMMDD.",
+    "Telemetry metrics use <prefix>-metrics-org-<organization-segment>-YYYYMMDD.",
+    "A nonzero organization identifier is formatted as an unsigned base-10 integer.",
+    "A zero organization identifier is formatted as global and emits a warning without payload data.",
+    "The date comes from record occurrence time and is formatted in UTC.",
+    "Default and custom prefixes retain their current meaning.",
+    "Organization identifiers remain in indexed documents.",
+    "Existing wildcard telemetry reads include old and new names.",
+    "Application code does not own archive, close, delete, or restore operations.",
+    "Focused tests and repository finalization checks pass.",
+    "The archive cron owner confirms unambiguous mixed-layout compatibility before rollout.",
+    "Late eligible indexes are re-archived and verified before source removal.",
+    "Operational readiness records measured and projected shard counts, a hard threshold, maximum event lateness, and archive grace period.",
+    "No unresolved critical or major review findings remain."
+  ],
+  "non_goals": [
+    "Implement or configure the archive cron.",
+    "Define organization retention periods.",
+    "Add OpenSearch Index State Management.",
+    "Create index templates or explicit index creation calls.",
+    "Rename, reindex, migrate, or delete existing indexes.",
+    "Change observability payload schemas, APIs, protobufs, or database schemas.",
+    "Change OpenSearch connector behavior."
+  ],
+  "scope_and_ownership": [
+    {
+      "path": "pkg/telemetry/opensearch_index.go",
+      "owner": "implementation owner",
+      "responsibility": "Single source of truth for organization-scoped UTC daily index names."
+    },
+    {
+      "path": "pkg/telemetry/opensearch_index_test.go",
+      "owner": "implementation owner",
+      "responsibility": "Index-name contract tests."
+    },
+    {
+      "path": "pkg/telemetry/providers/opensearch.go",
+      "owner": "implementation owner",
+      "responsibility": "Route log, event, and metric records using organization-scoped names."
+    },
+    {
+      "path": "pkg/telemetry/providers/opensearch_test.go",
+      "owner": "implementation owner",
+      "responsibility": "Verify exporter bulk metadata and document scope."
+    },
+    {
+      "path": "api/assistant-api/internal/observability/collectors/timeline/collector.go",
+      "owner": "implementation owner",
+      "responsibility": "Route all timeline record kinds using organization-scoped names."
+    },
+    {
+      "path": "api/assistant-api/internal/observability/collectors/timeline/collector_test.go",
+      "owner": "implementation owner",
+      "responsibility": "Verify timeline bulk metadata, fallback behavior, UTC dates, and document scope."
+    }
+  ],
+  "allowed_paths": [
+    "pkg/telemetry/opensearch_index.go",
+    "pkg/telemetry/opensearch_index_test.go",
+    "pkg/telemetry/providers/opensearch.go",
+    "pkg/telemetry/providers/opensearch_test.go",
+    "api/assistant-api/internal/observability/collectors/timeline/collector.go",
+    "api/assistant-api/internal/observability/collectors/timeline/collector_test.go",
+    "rfcs/0012-organization-scoped-observability-indexes.md",
+    "rfcs/0012-organization-scoped-observability-indexes/jsons/"
+  ],
+  "out_of_scope_paths": [
+    "pkg/connectors/",
+    "api/assistant-api/api/observability/",
+    "OpenSearch deployment and cluster configuration",
+    "External archive cron source and deployment",
+    "Existing OpenSearch indexes"
+  ],
+  "design": {
+    "smallest_complete_solution": "Add one shared index-name function and use it in the two existing OpenSearch observability writers.",
+    "timeline_contract": "<prefix>-org-<organization-segment>-<UTC YYYYMMDD>",
+    "telemetry_contract": "<prefix>-<kind>-org-<organization-segment>-<UTC YYYYMMDD>",
+    "organization_segment": "Unsigned base-10 organization identifier, or global when OrganizationID is zero.",
+    "date_source": "Record occurrence timestamp, falling back to the current time when zero, always formatted in UTC. The cron repeatedly rescans eligible dates and re-archives indexes recreated by late writes.",
+    "index_creation": "Unchanged. Existing bulk indexing behavior selects or automatically creates the destination index.",
+    "read_compatibility": "Unchanged telemetry wildcard patterns continue to match old and new layouts."
+  },
+  "principle_decisions": {
+    "kiss": "Change only deterministic index routing and its tests. Do not add lifecycle workers, connector APIs, or storage policies.",
+    "yagni": "Do not add configurable index formats, retention values, archive clients, aliases, or migration tooling.",
+    "single_source_of_truth": "One shared function owns the organization and UTC date suffix contract.",
+    "ownership": "Application writers own index selection. The external cron owns archive lifecycle operations.",
+    "compatibility": "Preserve prefixes, document fields, bulk behavior, and wildcard reads. Leave old indexes untouched.",
+    "failure_safety": "Use an explicit org-global segment with a warning for missing organization context, preserve bulk error behavior, require unambiguous cron mixed-layout parsing, and require repeated handling of indexes recreated by late writes.",
+    "security": "Retain document-level organization scope and do not broaden OpenSearch permissions in application code.",
+    "observability": "Use existing bulk failure logs and verify routing through bulk metadata tests."
+  },
+  "risks": [
+    {
+      "risk": "Organization-by-day indexes can significantly increase index and shard counts.",
+      "mitigation": "Require measured and projected shard counts plus an operator-approved hard threshold in operational-readiness.json before rollout."
+    },
+    {
+      "risk": "The archive cron may parse only the old shared layout.",
+      "mitigation": "Use an explicit org marker, provide parser fixtures, deploy and dry-run mixed-layout parsing before writer changes, and skip any unclassified index."
+    },
+    {
+      "risk": "Organization scope may be absent for infrastructure-level records.",
+      "mitigation": "Route zero OrganizationID to an explicit org-global segment, emit a warning, inventory legitimate global producers, and define its retention separately."
+    },
+    {
+      "risk": "An index organization segment could disagree with the document organizationId.",
+      "mitigation": "Derive both from the same scope object and assert both values in focused tests and rollout sampling."
+    },
+    {
+      "risk": "A late record can recreate an old-date index after the cron archived it.",
+      "mitigation": "Require repeated eligible-date scans, versioned or idempotent archive output, archive verification before source removal, and an approved lateness and grace window."
+    }
+  ],
+  "rollout": [
+    "Update and dry-run the archive cron against both layouts using the explicit org marker.",
+    "Deploy the application routing change.",
+    "Verify all index kinds, organization segments, UTC dates, and document scope values.",
+    "Verify existing telemetry reads and dashboards across both layouts.",
+    "Record capacity, parser, lateness, grace-period, and exact cron command evidence in operational-readiness.json.",
+    "Enable organization-specific archive schedules only after verification."
+  ],
+  "rollback": "Roll back the application binary to restore shared daily names. Existing wildcard readers continue to match both layouts. Disable new-layout archival first if the cron cannot safely process mixed names. Already archived indexes remain owned by the cron recovery procedure.",
+  "required_test_categories": [
+    "Shared index-name contract",
+    "Nonzero organization identifier",
+    "Global fallback and warning",
+    "UTC and zero-time behavior",
+    "Default and custom prefixes",
+    "Timeline routing for every supported record kind",
+    "Telemetry routing for logs, events, and metrics",
+    "Organization identifier preservation in documents",
+    "Wildcard read compatibility",
+    "Bulk error propagation",
+    "Archive parser fixtures for old and new default and custom prefixes"
+  ],
+  "verification_commands": [
+    "go test ./pkg/telemetry/...",
+    "go test ./api/assistant-api/internal/observability/collectors/timeline/...",
+    "go test ./api/assistant-api/api/observability/...",
+    "make agent-finalize CHANGED_FILES=\"pkg/telemetry/opensearch_index.go,pkg/telemetry/opensearch_index_test.go,pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go\""
+  ],
+  "governance": {
+    "reserved_path": "rfcs/0012-organization-scoped-observability-indexes.md",
+    "challenge_status": "round_1_revise",
+    "confirmation_status": "pending",
+    "accepted_rfc_sha256": null,
+    "run_id": "run_7664265d945b",
+    "task_id": "task_35da35309890",
+    "gate_id": null,
+    "implementation_authorized": false
+  }
+}

--- a/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
+++ b/rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json
@@ -1,8 +1,8 @@
 {
   "rfc": "rfcs/0012-organization-scoped-observability-indexes.md",
   "artifact": "rfcs/0012-organization-scoped-observability-indexes/jsons/plan.json",
-  "status": "draft",
-  "decision": "pending_independent_challenge",
+  "status": "blocked",
+  "decision": "blocked_after_two_revision_cycles",
   "created_at": "2026-08-25",
   "updated_at": "2026-08-25",
   "objective": "Add organization ID to every daily OpenSearch observability index name, using global when organization ID is unavailable.",
@@ -129,9 +129,10 @@
     "reserved_path": "rfcs/0012-organization-scoped-observability-indexes.md",
     "run_id": "run_7664265d945b",
     "initial_challenge_task_id": "task_35da35309890",
-    "challenge_status": "round_2_pending",
+    "challenge_status": "round_2_revise",
     "confirmation_status": "pending",
     "accepted_rfc_sha256": null,
-    "implementation_authorized": false
+    "implementation_authorized": false,
+    "blocking_reason": "Two RFC challenge cycles returned revise. DEVELOPMENT_PROCESS.md requires escalation instead of another revision cycle."
   }
 }

--- a/rfcs/0013-organization-observability-index-names.md
+++ b/rfcs/0013-organization-observability-index-names.md
@@ -1,0 +1,163 @@
+# RFC 0013: Organization Observability Index Names
+
+- Status: Accepted
+- Owner: Observability maintainers
+- Created: 2026-08-26
+- Updated: 2026-08-26
+- Reviewers: Independent plan challenger
+
+## Summary
+
+Add the organization identifier to daily OpenSearch index names for timeline records,
+telemetry logs, telemetry events, and telemetry metrics. Use `global` when the organization
+identifier is zero. This RFC supersedes RFC 0012 and intentionally excludes all archive
+cron behavior.
+
+## Context
+
+The timeline collector currently writes `<prefix>-YYYYMMDD`. The telemetry exporter writes
+`<prefix>-<kind>-YYYYMMDD`. Both writers already receive and store organization ID.
+
+## Goals
+
+- Add organization ID to all four index-name families.
+- Use `global` for organization ID zero.
+- Preserve prefixes, UTC dates, documents, bulk writes, and wildcard readers.
+
+## Non-Goals
+
+- Archive cron changes or compatibility verification.
+- Retention, policies, templates, explicit index creation, or migration.
+- API, schema, connector, or configuration changes.
+
+## Scope and Ownership
+
+### Allowed Paths
+
+- `pkg/telemetry/providers/opensearch.go` - telemetry implementation owner.
+- `pkg/telemetry/providers/opensearch_test.go` - telemetry test owner.
+- `api/assistant-api/internal/observability/collectors/timeline/collector.go` - timeline implementation owner.
+- `api/assistant-api/internal/observability/collectors/timeline/collector_test.go` - timeline test owner.
+- `rfcs/0013-organization-observability-index-names.md` - RFC owner.
+- `rfcs/0013-organization-observability-index-names/jsons/` - governance artifact owner.
+
+### Out-of-Scope Paths
+
+- `pkg/connectors/`
+- `api/assistant-api/api/observability/`
+- External cron and OpenSearch deployment configuration.
+
+## Proposed Design
+
+Change only the existing private index-name functions and call sites.
+
+```text
+timeline: <prefix>-<organization-segment>-<UTC YYYYMMDD>
+logs:     <prefix>-logs-<organization-segment>-<UTC YYYYMMDD>
+events:   <prefix>-events-<organization-segment>-<UTC YYYYMMDD>
+metrics:  <prefix>-metrics-<organization-segment>-<UTC YYYYMMDD>
+```
+
+`organization-segment` is the unsigned base-10 organization ID, or `global` when the ID is
+zero. Date selection remains based on occurrence time with the existing current-time
+fallback and UTC formatting.
+
+## Contracts and Compatibility
+
+- Existing document fields and bulk payloads remain unchanged.
+- Existing custom prefixes remain unchanged before the new organization segment.
+- Existing wildcard telemetry readers continue matching old and new indexes.
+- Existing indexes are not renamed or modified.
+
+## Failure and Recovery
+
+- Organization ID zero routes to `global` instead of dropping observability data.
+- Existing bulk error behavior remains unchanged.
+- Rollback restores the prior shared names without rewriting data.
+
+## Security and Privacy
+
+Organization ID already exists in each document. No permission or credential changes are
+introduced.
+
+## Observability
+
+Focused tests inspect bulk metadata for the destination index. Existing bulk failure logs
+remain unchanged.
+
+## Data and Migration
+
+None. Existing indexes remain unchanged.
+
+## Rollout
+
+The release owner must attach archive-cron dry-run output for one old and one new index name
+for each enabled prefix before production deployment. The cron implementation remains out
+of scope, but compatibility evidence is a rollout gate because index names are its input.
+
+Deploy the writer change and verify new index names and existing wildcard reads. Monitor
+OpenSearch index and shard counts during rollout. Organization-by-day routing intentionally
+increases index count, and the release owner must stop rollout if cluster health degrades or
+the operator's existing shard limit is reached.
+
+## Rollback
+
+Roll back the application binary. Old and new indexes remain readable through existing
+wildcard patterns.
+
+## Alternatives Considered
+
+- A shared helper was rejected because two private formatting functions are simpler.
+- Application retention behavior was rejected as out of scope.
+- A literal marker segment was rejected because the requested contract is only organization
+  ID or `global` followed by date.
+
+## Testing and Verification
+
+Required tests:
+
+- Timeline with nonzero organization ID and with `global`.
+- Log, event, and metric indexes with nonzero organization ID and with `global`.
+- Custom prefixes.
+- UTC occurrence dates and zero-time fallback.
+- Preservation of organization ID inside documents.
+- Existing bulk error behavior.
+
+```bash
+go test ./pkg/telemetry/providers/...
+go test ./api/assistant-api/internal/observability/collectors/timeline/...
+go test ./api/assistant-api/api/observability/...
+make agent-finalize CHANGED_FILES="pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
+```
+
+## Acceptance Criteria
+
+- [ ] Timeline, logs, events, and metrics include organization ID before the UTC date.
+- [ ] Organization ID zero uses `global`.
+- [ ] Custom prefixes and document organization fields remain unchanged.
+- [ ] Existing wildcard readers require no code change.
+- [ ] Focused tests and finalization pass.
+- [ ] No critical or major review findings remain.
+
+## Open Questions
+
+None.
+
+## Challenge Resolution
+
+Challenge round 1 requested a complete Governed plan, explicit index-count risk, named cron
+compatibility evidence, and enumerated test cases. These requirements are included without
+expanding production code scope. Challenge round 2 is pending.
+
+## Artifact Index
+
+- `rfcs/0013-organization-observability-index-names/jsons/plan.json` - final plan.
+- `rfcs/0013-organization-observability-index-names/jsons/challenge.json` - pending challenge receipt.
+- `rfcs/0013-organization-observability-index-names/jsons/confirmation.json` - pending confirmation receipt.
+
+## Decision Log
+
+| Date | Decision | Owner | Evidence |
+| --- | --- | --- | --- |
+| 2026-08-26 | Supersede RFC 0012 with a code-only index-name change | User | Direct implementation instruction |
+| 2026-08-26 | Use organization ID or `global` and add no other behavior | User | Direct implementation instruction |

--- a/rfcs/0013-organization-observability-index-names/jsons/amendment-01-challenge.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/amendment-01-challenge.json
@@ -1,0 +1,9 @@
+{
+  "round": 2,
+  "decision": "approve",
+  "reviewed_at": "2026-08-26",
+  "reviewed_rfc_sha256": "67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d",
+  "reviewed_plan_sha256": "8a31a15b372578207d439590351db36bc4ba9f856db9053d13a5b7daa15dc94d",
+  "findings": [],
+  "result": "No unresolved critical or major findings."
+}

--- a/rfcs/0013-organization-observability-index-names/jsons/authorization.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/authorization.json
@@ -1,0 +1,15 @@
+{
+  "status": "authorized",
+  "rfc": "rfcs/0013-organization-observability-index-names.md",
+  "plan": "rfcs/0013-organization-observability-index-names/jsons/plan.json",
+  "authorized_by": "user",
+  "authorization_message": "Create authorize my RFC as my approval and commit",
+  "authorized_at": "2026-08-27T16:30:28Z",
+  "rfc_sha256": "67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d",
+  "plan_sha256": "8a31a15b372578207d439590351db36bc4ba9f856db9053d13a5b7daa15dc94d",
+  "challenge_receipt": "rfcs/0013-organization-observability-index-names/jsons/amendment-01-challenge.json",
+  "challenge_receipt_sha256": "8b858829b9315923e21e1f59ff6eefaf4910e1a8180dc6f134b1800849d24b88",
+  "confirmation_receipt": "rfcs/0013-organization-observability-index-names/jsons/confirmation.json",
+  "confirmation_receipt_sha256": "87950c673ff2e36de64a920a4db1ca294647a711a9f2ffff63297fdf3afaf71a",
+  "implementation_authorized": true
+}

--- a/rfcs/0013-organization-observability-index-names/jsons/challenge.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/challenge.json
@@ -1,0 +1,14 @@
+{
+  "round": 1,
+  "decision": "revise",
+  "reviewed_at": "2026-08-26",
+  "reviewed_rfc_sha256": "7d63b6b235f6aff381c76974916c8dcee468fed7d27ce74b2cd9d18603db31ba",
+  "reviewed_plan_sha256": "dae584c5212fe884982862565a24e58c372af8fb13ac2a25b84558334fee0518",
+  "findings": [
+    "Complete the Governed plan contract.",
+    "Record index and shard growth as an operational risk.",
+    "Require named cron compatibility evidence before production rollout.",
+    "Enumerate required test cases."
+  ],
+  "resolution": "RFC and plan revised without expanding production code scope."
+}

--- a/rfcs/0013-organization-observability-index-names/jsons/confirmation.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/confirmation.json
@@ -1,0 +1,13 @@
+{
+  "status": "approved",
+  "approved_by": "user",
+  "approval_message": "start the implimenation",
+  "approved_at": "2026-08-26T12:37:20+05:30",
+  "run_id": "run_7664265d945b",
+  "task_id": "task_b63df23a6aef",
+  "gate_id": "gate_c6e52dd4502f",
+  "question": "Approve implementation of rfcs/0013-organization-observability-index-names.md at SHA-256 67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d with plan SHA-256 8a31a15b372578207d439590351db36bc4ba9f856db9053d13a5b7daa15dc94d?",
+  "resolution": "approved",
+  "rfc_sha256": "67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d",
+  "plan_sha256": "8a31a15b372578207d439590351db36bc4ba9f856db9053d13a5b7daa15dc94d"
+}

--- a/rfcs/0013-organization-observability-index-names/jsons/governance-status.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/governance-status.json
@@ -1,0 +1,26 @@
+{
+  "rfc": "rfcs/0013-organization-observability-index-names.md",
+  "status": "accepted",
+  "recorded_at": "2026-08-27",
+  "purpose": "Record the authoritative post-confirmation governance state without changing the exact-digest-approved RFC or plan bytes.",
+  "immutable_snapshots": {
+    "rfc_sha256": "67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d",
+    "plan_sha256": "8a31a15b372578207d439590351db36bc4ba9f856db9053d13a5b7daa15dc94d",
+    "note": "Pending fields in these snapshots describe their pre-gate state and are superseded by the receipts below."
+  },
+  "challenge": {
+    "receipt": "rfcs/0013-organization-observability-index-names/jsons/amendment-01-challenge.json",
+    "round": 2,
+    "decision": "approve",
+    "result": "No unresolved critical or major findings."
+  },
+  "confirmation": {
+    "receipt": "rfcs/0013-organization-observability-index-names/jsons/confirmation.json",
+    "resolution": "approved",
+    "run_id": "run_7664265d945b",
+    "task_id": "task_b63df23a6aef",
+    "gate_id": "gate_c6e52dd4502f"
+  },
+  "implementation_authorized": true,
+  "precedence": "This artifact and the referenced receipts are authoritative for final governance state. The RFC and plan remain immutable inputs to the exact-digest confirmation."
+}

--- a/rfcs/0013-organization-observability-index-names/jsons/governance-status.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/governance-status.json
@@ -21,6 +21,11 @@
     "task_id": "task_b63df23a6aef",
     "gate_id": "gate_c6e52dd4502f"
   },
+  "authorization": {
+    "receipt": "rfcs/0013-organization-observability-index-names/jsons/authorization.json",
+    "authorized_by": "user",
+    "authorization_message": "Create authorize my RFC as my approval and commit"
+  },
   "implementation_authorized": true,
   "precedence": "This artifact and the referenced receipts are authoritative for final governance state. The RFC and plan remain immutable inputs to the exact-digest confirmation."
 }

--- a/rfcs/0013-organization-observability-index-names/jsons/plan.json
+++ b/rfcs/0013-organization-observability-index-names/jsons/plan.json
@@ -1,0 +1,141 @@
+{
+  "rfc": "rfcs/0013-organization-observability-index-names.md",
+  "status": "accepted_pending_final_challenge",
+  "decision": "pending_final_challenge",
+  "created_at": "2026-08-26",
+  "updated_at": "2026-08-26",
+  "objective": "Add organization ID or global to every daily OpenSearch observability index name.",
+  "supersedes": "rfcs/0012-organization-scoped-observability-indexes.md",
+  "verified_system_context": [
+    "The timeline collector owns index formatting for all timeline record kinds.",
+    "The telemetry OpenSearch exporter owns index formatting for logs, events, and metrics.",
+    "Both writers already receive organization ID and preserve it in documents.",
+    "Telemetry readers use wildcard patterns that match old and new names.",
+    "Bulk write and automatic index creation behavior remain unchanged."
+  ],
+  "acceptance_criteria": [
+    "Timeline, logs, events, and metrics include organization ID before the UTC date.",
+    "Organization ID zero uses global.",
+    "Custom prefixes and document organization fields remain unchanged.",
+    "Existing wildcard readers require no code change.",
+    "Focused tests and finalization pass.",
+    "Release owner records archive-cron dry-run evidence before production rollout.",
+    "No critical or major review findings remain."
+  ],
+  "non_goals": [
+    "Archive cron implementation or configuration",
+    "Retention or lifecycle behavior",
+    "OpenSearch policy or template changes",
+    "Configuration or connector changes",
+    "Existing index migration"
+  ],
+  "allowed_paths": [
+    "pkg/telemetry/providers/opensearch.go",
+    "pkg/telemetry/providers/opensearch_test.go",
+    "api/assistant-api/internal/observability/collectors/timeline/collector.go",
+    "api/assistant-api/internal/observability/collectors/timeline/collector_test.go",
+    "rfcs/0013-organization-observability-index-names.md",
+    "rfcs/0013-organization-observability-index-names/jsons/"
+  ],
+  "out_of_scope_paths": [
+    "pkg/connectors/",
+    "api/assistant-api/api/observability/",
+    "api/integration-api/",
+    "env/",
+    "deployments/",
+    "External archive cron repository",
+    "Existing OpenSearch indexes"
+  ],
+  "ownership": [
+    {
+      "paths": [
+        "pkg/telemetry/providers/opensearch.go",
+        "pkg/telemetry/providers/opensearch_test.go"
+      ],
+      "owner": "telemetry exporter implementation owner"
+    },
+    {
+      "paths": [
+        "api/assistant-api/internal/observability/collectors/timeline/collector.go",
+        "api/assistant-api/internal/observability/collectors/timeline/collector_test.go"
+      ],
+      "owner": "timeline collector implementation owner"
+    },
+    {
+      "paths": [
+        "rfcs/0013-organization-observability-index-names.md",
+        "rfcs/0013-organization-observability-index-names/jsons/"
+      ],
+      "owner": "RFC coordinator"
+    },
+    {
+      "paths": [
+        "production archive-cron compatibility evidence"
+      ],
+      "owner": "release owner"
+    }
+  ],
+  "design": {
+    "timeline": "<prefix>-<organization-segment>-<UTC YYYYMMDD>",
+    "telemetry": "<prefix>-<kind>-<organization-segment>-<UTC YYYYMMDD>",
+    "organization_segment": "Unsigned base-10 organization ID or global for zero",
+    "date_source": "Existing occurrence-time behavior with current UTC fallback for zero timestamps",
+    "implementation": "Modify existing private functions and call sites only"
+  },
+  "principle_decisions": {
+    "kiss": "Change only two production files and their existing tests.",
+    "yagni": "Do not add helpers, configuration, policies, templates, migrations, or lifecycle workers.",
+    "single_source_of_truth": "Organization ID comes from the existing scope object used to populate the document.",
+    "compatibility": "Preserve custom prefixes, UTC dates, documents, bulk behavior, wildcard reads, and existing indexes.",
+    "failure_safety": "Use global when organization context is absent instead of dropping records.",
+    "security": "Do not change credentials, permissions, or tenant fields."
+  },
+  "risks": [
+    {
+      "risk": "Per-organization daily indexes increase index and shard count.",
+      "disposition": "Accepted for organization-level archival. Release owner monitors cluster health and existing shard limits."
+    },
+    {
+      "risk": "The external cron may not recognize new names.",
+      "disposition": "Release owner attaches dry-run evidence for old and new names before production deployment."
+    },
+    {
+      "risk": "Organization ID zero combines records in global indexes.",
+      "disposition": "Accepted to preserve observability delivery when context is unavailable."
+    },
+    {
+      "risk": "Late records can target an old occurrence date.",
+      "disposition": "Existing behavior is preserved and archive lifecycle remains externally owned."
+    }
+  ],
+  "required_test_categories": [
+    "Timeline organization and global indexes",
+    "Log organization and global indexes",
+    "Event organization and global indexes",
+    "Metric organization and global indexes",
+    "Custom prefix",
+    "UTC occurrence date and zero-time fallback",
+    "Document organization ID preservation",
+    "Bulk error propagation",
+    "Unchanged wildcard readers"
+  ],
+  "verification_commands": [
+    "go test ./pkg/telemetry/providers/...",
+    "go test ./api/assistant-api/internal/observability/collectors/timeline/...",
+    "go test ./api/assistant-api/api/observability/...",
+    "make agent-finalize CHANGED_FILES=\"pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go\""
+  ],
+  "rollout": [
+    "Release owner records archive-cron dry-run evidence for old and new names.",
+    "Deploy writer changes.",
+    "Verify index names, document organization IDs, wildcard readers, cluster health, and index count."
+  ],
+  "rollback": "Roll back the application binary. Shared names resume and wildcard readers continue matching both layouts.",
+  "governance": {
+    "accepted_rfc_sha256": "67e3d51612f2caf10ad1bb26164b5c0ec6d665d73b61e4a27fed547443cd1a0d",
+    "challenge_round_1": "revise",
+    "challenge_round_2": "pending",
+    "confirmation_gate": "pending",
+    "implementation_authorized": false
+  }
+}


### PR DESCRIPTION
## Summary

- adds organization ID to UTC daily OpenSearch index names for timeline records
- applies the same naming to telemetry logs, events, and metrics
- uses `global` when `OrganizationID` is zero
- keeps archive and retention behavior outside the application

## Index Format

- timeline: `<prefix>-<organizationID|global>-YYYYMMDD`
- logs: `<prefix>-logs-<organizationID|global>-YYYYMMDD`
- events: `<prefix>-events-<organizationID|global>-YYYYMMDD`
- metrics: `<prefix>-metrics-<organizationID|global>-YYYYMMDD`

## Governance

- RFC 0013 status is `Accepted`
- independent challenge approved the final scope
- exact RFC and plan digests were confirmed before implementation
- independent implementation review found no critical or major issues

## Validation

- `go test ./pkg/telemetry/providers/...`
- `go test ./api/assistant-api/internal/observability/collectors/timeline/...`
- `go test ./api/assistant-api/api/observability/...`
- `make agent-finalize CHANGED_FILES="pkg/telemetry/providers/opensearch.go,pkg/telemetry/providers/opensearch_test.go,api/assistant-api/internal/observability/collectors/timeline/collector.go,api/assistant-api/internal/observability/collectors/timeline/collector_test.go"`



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR scopes daily OpenSearch observability indexes by organization while preserving UTC rotation and routing records without an organization to `global`.

- Updates timeline index names to include the organization segment.
- Applies equivalent organization-scoped naming to telemetry logs, events, and metrics.
- Adds coverage for organization-specific and global index routing.
- Records the final RFC approval and implementation authorization in an authoritative governance-status artifact.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/assistant-api/internal/observability/collectors/timeline/collector.go | Routes every supported timeline record kind to an organization-scoped UTC daily index while preserving the organization ID in the document. |
| pkg/telemetry/providers/opensearch.go | Adds organization or global segments consistently to log, event, and metric index names. |
| api/assistant-api/internal/observability/collectors/timeline/collector_test.go | Updates timeline bulk-routing assertions for organization-specific and global index names. |
| pkg/telemetry/providers/opensearch_test.go | Verifies organization-specific and global routing across all supported telemetry record kinds. |
| rfcs/0013-organization-observability-index-names/jsons/governance-status.json | Establishes the post-confirmation governance state and explicitly gives it precedence over immutable exact-digest RFC and plan inputs. |
| rfcs/0013-organization-observability-index-names/jsons/plan.json | Preserves the exact-digest pre-confirmation plan state, which is superseded by the authoritative governance-status artifact. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Observability record] --> B{Organization ID}
  B -->|Nonzero| C[Decimal organization segment]
  B -->|Zero| D[global segment]
  C --> E[UTC daily OpenSearch index]
  D --> E
  E --> F[Timeline, logs, events, or metrics]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["doc: clarify observability RFC governanc..."](https://github.com/rapidaai/voice-ai/commit/a3e18b964462500d6a2f60faa8177cb65ce632e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57061582)</sub>

<!-- /greptile_comment -->