### PR TITLE
feat: implement ui brand theme customization

### DIFF
--- a/docker/ui/config.community.json
+++ b/docker/ui/config.community.json
@@ -54,7 +54,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/docker/ui/config.enterprise.json
+++ b/docker/ui/config.enterprise.json
@@ -54,7 +54,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/docker/ui/config.local-knowledge.json
+++ b/docker/ui/config.local-knowledge.json
@@ -55,7 +55,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/docker/ui/config.local.json
+++ b/docker/ui/config.local.json
@@ -55,7 +55,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/rfcs/0014-ui-brand-theme-customization.md
+++ b/rfcs/0014-ui-brand-theme-customization.md
@@ -1,6 +1,6 @@
 # RFC 0014: UI Brand and Theme Customization
 
-- Status: Draft
+- Status: Accepted
 - Owner: UI Platform
 - Created: 2026-08-31
 - Updated: 2026-08-31
@@ -54,8 +54,7 @@ new UI code.
 - Ensure UI navigation, page metadata, auth links, legal/support links, and
   documentation links use configured theme links or explicit neutral fallback
   behavior.
-- Remove direct Rapida logo component usage from tenant-visible UI surfaces when
-  configured logos exist.
+- Remove direct Rapida logo component usage from tenant-visible UI surfaces.
 - Add automated checks that catch new hardcoded Rapida brand literals in UI code
   outside an explicit allowlist.
 - Preserve existing default Rapida appearance for the stock config files.
@@ -119,12 +118,12 @@ implementation. The current fields are sufficient for the requested UI scope:
 - `theme.colors.light`
 - `theme.colors.dark`
 
-Introduce a small shared branded logo component only if it removes repeated
-logo selection code across header, sidebar, onboarding, and preview surfaces.
-The component should accept a full or compact variant, read `useTheme()`, choose
-the asset for the resolved mode, and fall back to text from `theme.brand.name`
-when no logo is configured. It must not fall back to embedded Rapida SVGs on
-tenant-visible surfaces.
+Introduce a shared `BrandedLogo` component for tenant-visible brand rendering in
+header, sidebar, onboarding, preview header, and preview chat. The component
+accepts a full or compact variant, reads `useTheme()`, chooses the asset for the
+resolved mode, and falls back to text from `theme.brand.name` when no logo is
+configured. It must not fall back to embedded Rapida SVGs on tenant-visible
+surfaces.
 
 Update preview call and chat surfaces to use the same brand contract:
 
@@ -148,15 +147,31 @@ points to them. White-label navigation must not point users to Rapida legal copy
 unless the selected config explicitly chooses those links.
 
 Static UI-shipped metadata such as `ui/public/LLMs.txt` must not be a second
-hand-maintained brand source. It should either be made neutral or generated from
-the selected build config. The preferred first implementation is neutral content
-unless product explicitly requires branded generated metadata.
+hand-maintained brand source. The first implementation makes this file neutral
+and removes Rapida-specific names, URLs, and author links. If product later
+requires branded AI metadata, a separate change can generate it from the
+selected UI config.
+
+Built-in static legal pages remain directly accessible for existing local
+routes, but tenant-visible navigation must use `theme.links.terms` and
+`theme.links.privacy`. White-label deployments that do not want bundled Rapida
+legal copy exposed through direct URLs can override those routes or remove the
+pages in a later, separate routing policy change.
 
 Extend `ui/scripts/check-theme-contract.mjs` to catch new hardcoded UI brand
-literals. The check should scan UI source and selected public metadata, ignore
-default config values, ignore tests where literal assertions are intentional,
-and ignore technical identifiers that are not user-visible branding. The
-allowlist must be explicit and small.
+literals inside this bounded scan set:
+
+- `ui/src/app/**/*.tsx`
+- `ui/src/app/**/*.ts`
+- `ui/src/theme/**/*.ts`
+- `ui/src/theme/**/*.tsx`
+- `ui/public/LLMs.txt`
+
+The scan excludes tests, provider catalogs, deployable config defaults, icon
+component definitions, generated files, package metadata, and non-rendered type
+or store names. Any remaining exception must be listed in an explicit allowlist
+with a short non-branding justification in the checker source or its adjacent
+test fixtures.
 
 ## Contracts and Compatibility
 
@@ -262,8 +277,9 @@ Focused UI tests must include:
 
 ## Acceptance Criteria
 
-- [ ] `CONFIG.theme` is the only source for tenant-visible UI brand name, logo,
-  favicon, primary color, docs links, legal links, and support link.
+- [ ] Inside the bounded brand scan set, `CONFIG.theme` is the only source for
+  tenant-visible UI brand name, logo, favicon, primary color, docs links, legal
+  links, and support link, except documented non-branding allowlist entries.
 - [ ] Preview call and preview chat pages no longer import or render Rapida logo
   components directly.
 - [ ] Assistant preview chat uses `theme.brand.name` for the assistant-side
@@ -279,20 +295,26 @@ Focused UI tests must include:
 
 ## Open Questions
 
-- Should `ui/public/LLMs.txt` become neutral, be removed, or be generated from
-  the selected UI config?
-- Should built-in static legal pages remain accessible for direct URLs in
-  white-label builds, or should those routes redirect to configured legal links?
 - Should UI package metadata icons in `ui/package.json` be included in a later
   desktop packaging scope?
 
 ## Challenge Resolution
 
-Pending independent plan challenge.
+- Round 1 recommendation was `revise`.
+- Resolved major finding: `ui/public/LLMs.txt` will become neutral in the first
+  implementation.
+- Resolved major finding: built-in static legal pages remain directly
+  accessible, while tenant-visible navigation must use configured legal links.
+- Resolved major finding: the brand-source acceptance criterion now has a
+  bounded scan set and an explicit allowlist policy.
+- Resolved minor finding: `BrandedLogo` is now required for tenant-visible
+  brand rendering in shell, onboarding, and preview surfaces.
 
 ## Artifact Index
 
-- `jsons/plan.json` - Initial UI-only implementation plan. Draft.
+- `jsons/plan.json` - Initial UI-only implementation plan. Accepted candidate.
+- `jsons/challenge.json` - Round 1 independent challenge. Resolved.
+- `jsons/challenge-02.json` - Round 2 independent challenge. Approved.
 
 ## Decision Log
 

--- a/rfcs/0014-ui-brand-theme-customization.md
+++ b/rfcs/0014-ui-brand-theme-customization.md
@@ -1,0 +1,301 @@
+# RFC 0014: UI Brand and Theme Customization
+
+- Status: Draft
+- Owner: UI Platform
+- Created: 2026-08-31
+- Updated: 2026-08-31
+- Reviewers: UI reviewer, product owner
+
+## Summary
+
+Complete the existing UI brand and theme configuration so web UI surfaces use
+the configured brand name, logo assets, favicon, documentation links, legal
+links, support link, and primary colors from `CONFIG.theme`.
+
+The current theming work already provides a strong foundation. This RFC limits
+the remaining work to UI runtime and UI-shipped static assets. Backend emails,
+email templates, API contracts, Go module paths, package names, and licensing
+identity are not part of this proposal.
+
+## Context
+
+The UI already loads `CONFIG.theme` from the selected deployable config and
+wraps React with the theme provider in `ui/src/index.tsx`. The provider applies
+the active brand id, color mode, favicon, browser theme color, and CSS brand
+tokens in `ui/src/theme/theme-provider.tsx`.
+
+The main shell is partially converted. Header, sidebar, footer, onboarding, and
+helmet components already read values through `useTheme()` for visible brand
+name, logo, or product links. The deployable config files under
+`ui/src/configs/` and `docker/ui/` already contain a root `theme` object with
+brand, link, mode, and color fields.
+
+The remaining UI gaps are places that bypass `CONFIG.theme` and still render
+Rapida-specific values. Verified examples include:
+
+- `ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx`: preview header
+  imports and renders `RapidaIcon` and `RapidaTextIcon` directly.
+- `ui/src/app/pages/preview-agent/voice-agent/text/conversations/index.tsx`:
+  assistant chat messages render a Rapida icon and the display name `Rapida`.
+- UI pages and components still contain hardcoded Rapida documentation URLs,
+  support email placeholders, product copy, static legal copy, public AI metadata,
+  and Rapida-hosted dashboard or tool assets.
+
+The theme contract checker already verifies single-source theme loading, shell
+semantic color usage, required deployable theme config presence, and removal of
+legacy dark-mode sources. It does not yet enforce the broader brand contract for
+new UI code.
+
+## Goals
+
+- Make `CONFIG.theme` the source of truth for user-visible UI brand identity.
+- Ensure preview call and preview chat render configured brand assets and brand
+  name.
+- Ensure UI navigation, page metadata, auth links, legal/support links, and
+  documentation links use configured theme links or explicit neutral fallback
+  behavior.
+- Remove direct Rapida logo component usage from tenant-visible UI surfaces when
+  configured logos exist.
+- Add automated checks that catch new hardcoded Rapida brand literals in UI code
+  outside an explicit allowlist.
+- Preserve existing default Rapida appearance for the stock config files.
+
+## Non-Goals
+
+- Backend email subjects, email sender identity, and email body templates.
+- Go module paths, generated clients, protobuf package names, npm package names,
+  import paths, and internal metadata keys such as `rapida.credential_id`.
+- Product or legal rewording beyond removing unintended UI hardcoding.
+- Provider catalog branding, provider names, and third-party provider logos.
+- Runtime tenant switching without rebuilding the selected UI bundle.
+- Authentication, authorization, API, database, or deployment contract changes.
+
+## Scope and Ownership
+
+### Allowed Paths
+
+- `ui/src/theme/` - UI theme contract and runtime theme ownership.
+- `ui/src/configs/` - development and production UI config defaults.
+- `docker/ui/config.*.json` - Docker edition UI config defaults.
+- `ui/src/app/components/` - shared UI components and branded UI surfaces.
+- `ui/src/app/pages/` - UI pages that render brand names, docs links, support
+  links, static legal pages, dashboard content, or preview chat.
+- `ui/src/app/routes/` - route-level branded layout surfaces.
+- `ui/public/` - UI-shipped public metadata and default brand assets.
+- `ui/scripts/check-theme-contract.mjs` and related tests - UI contract checks.
+- `ui/THEMING.md` - UI branding and theme documentation.
+
+### Out-of-Scope Paths
+
+- `api/**`
+- `pkg/clients/external/emailer/**`
+- `pkg/configs/emailer_config.go`
+- `cmd/**`
+- `protos/**`
+- `pkg/**` except files explicitly listed above, which are none.
+- `README.md`, `LICENSE.md`, `SECURITY.md`, and other repository identity docs.
+- Package manager lockfiles and generated artifacts.
+
+## Proposed Design
+
+Keep the existing build-time model. The selected UI config remains bundled into
+the web app, and there is no runtime brand fetch, tenant cache, or HTML bootstrap
+script.
+
+Use the existing `theme` object without changing `schemaVersion` for the first
+implementation. The current fields are sufficient for the requested UI scope:
+
+- `theme.brand.name`
+- `theme.brand.logos.full.light`
+- `theme.brand.logos.full.dark`
+- `theme.brand.logos.compact.light`
+- `theme.brand.logos.compact.dark`
+- `theme.brand.favicon`
+- `theme.links.documentation`
+- `theme.links.source`
+- `theme.links.support`
+- `theme.links.terms`
+- `theme.links.privacy`
+- `theme.colors.light`
+- `theme.colors.dark`
+
+Introduce a small shared branded logo component only if it removes repeated
+logo selection code across header, sidebar, onboarding, and preview surfaces.
+The component should accept a full or compact variant, read `useTheme()`, choose
+the asset for the resolved mode, and fall back to text from `theme.brand.name`
+when no logo is configured. It must not fall back to embedded Rapida SVGs on
+tenant-visible surfaces.
+
+Update preview call and chat surfaces to use the same brand contract:
+
+- Preview header uses the configured full logo for the active mode.
+- Assistant chat avatar uses the configured compact logo for the active mode.
+- Assistant chat display name uses `theme.brand.name`.
+- Avatar colors use existing semantic brand tokens instead of a fixed blue when
+  the configured compact logo is absent.
+
+Replace hardcoded documentation URLs in UI components with links derived from
+`theme.links.documentation`. Components that need section-specific docs should
+accept a relative documentation path and build the absolute URL from the theme
+documentation root, or should receive a fully configured URL from a theme-aware
+caller. Existing `DocNoticeBlock` behavior can remain as the display component,
+but ownership of branded URL construction must be explicit.
+
+Auth and legal navigation should use `theme.links.terms`,
+`theme.links.privacy`, and `theme.links.support`. The built-in Rapida legal
+pages may remain only as default deployment pages when the selected config
+points to them. White-label navigation must not point users to Rapida legal copy
+unless the selected config explicitly chooses those links.
+
+Static UI-shipped metadata such as `ui/public/LLMs.txt` must not be a second
+hand-maintained brand source. It should either be made neutral or generated from
+the selected build config. The preferred first implementation is neutral content
+unless product explicitly requires branded generated metadata.
+
+Extend `ui/scripts/check-theme-contract.mjs` to catch new hardcoded UI brand
+literals. The check should scan UI source and selected public metadata, ignore
+default config values, ignore tests where literal assertions are intentional,
+and ignore technical identifiers that are not user-visible branding. The
+allowlist must be explicit and small.
+
+## Contracts and Compatibility
+
+- No backend API contract changes.
+- No database or persistent-data changes.
+- No UI config schema version change is required for the initial implementation.
+- Existing default configs continue to render Rapida AI by setting
+  `theme.brand.name` and Rapida asset paths in config.
+- Missing configured logos fall back to configured brand text, not embedded
+  Rapida marks.
+- Invalid or empty theme fields continue to use the existing UI fallback
+  behavior from the theme config layer.
+
+## Failure and Recovery
+
+- If a configured logo URL is broken, the browser shows the configured alt text
+  from `theme.brand.name`; the shell remains usable.
+- If `theme.links.documentation`, `theme.links.terms`, `theme.links.privacy`,
+  `theme.links.source`, or `theme.links.support` are empty or malformed, the
+  existing config fallback behavior applies.
+- If the brand contract check reports hardcoded literals, implementation stops
+  until the source is moved to config, changed to neutral copy, or added to an
+  explicit allowlist with justification.
+
+## Security and Privacy
+
+- Theme values are public UI presentation config and must not contain secrets.
+- External links opened from themed URLs should preserve existing safe link
+  behavior, including `rel="noopener"` where a new tab is used.
+- The change must not weaken authentication, authorization, project isolation,
+  organization isolation, or credential handling.
+- Tenant-specific asset URLs are loaded by the browser. Operators own the
+  privacy and tracking implications of configured asset hosts.
+
+## Observability
+
+No new backend observability is required. UI diagnostics remain build-time and
+test-time checks:
+
+- Theme contract diagnostics identify the file and hardcoded brand violation.
+- Existing test failures identify surfaces that no longer honor configured
+  brand values.
+
+## Data and Migration
+
+None. This proposal changes bundled UI behavior and deployable config defaults
+only. No persistent data changes are required.
+
+## Rollout
+
+1. Update UI components and pages to consume the theme contract.
+2. Update or add focused UI tests for preview header, preview chat, auth links,
+   and any shared branded logo component.
+3. Extend the theme contract checker and its tests.
+4. Update `ui/THEMING.md` with the completed UI brand contract and the explicit
+   exclusions.
+5. Run targeted UI verification, full UI validation, and repository finalization.
+
+Rollout stops if the default Rapida config no longer renders the existing Rapida
+appearance, if custom brand tests still show Rapida text or marks, or if the
+theme contract checker cannot distinguish user-visible branding from technical
+identifiers.
+
+## Rollback
+
+Revert the UI component, public metadata, config, documentation, and contract
+checker changes. Because this RFC does not change backend contracts or data,
+rollback is a normal UI bundle rollback with no migration step.
+
+## Alternatives Considered
+
+- Add a second runtime brand manifest. Rejected because `CONFIG.theme` already
+  exists, is documented, and avoids another source of truth.
+- Rebrand backend email and repository identity in the same RFC. Rejected
+  because the current request is UI-only and email requires a separate backend
+  configuration owner.
+- Keep Rapida SVG components as universal fallback. Rejected for tenant-visible
+  UI because a missing logo would leak the default brand instead of using the
+  configured brand name.
+- Replace every technical identifier containing Rapida. Rejected because imports,
+  package names, metadata keys, and SDK names are compatibility contracts rather
+  than UI brand presentation.
+
+## Testing and Verification
+
+- `cd ui && yarn check:theme-contract`
+- `cd ui && yarn test:theme-contract`
+- `cd ui && yarn lint`
+- `cd ui && yarn checkTs`
+- `cd ui && yarn test --watchAll=false --runInBand`
+- `cd ui && yarn build`
+- `just agent-finalize "ui/src,ui/public,ui/scripts,ui/THEMING.md,docker/ui"`
+
+Focused UI tests must include:
+
+- Preview header renders configured logo and brand text fallback.
+- Preview chat assistant avatar and assistant display name use configured theme
+  values.
+- Auth links use configured terms, privacy, and support links.
+- Default Rapida configs still render the stock brand.
+- Custom test theme does not render Rapida text or embedded Rapida logo
+  components on tenant-visible UI surfaces.
+
+## Acceptance Criteria
+
+- [ ] `CONFIG.theme` is the only source for tenant-visible UI brand name, logo,
+  favicon, primary color, docs links, legal links, and support link.
+- [ ] Preview call and preview chat pages no longer import or render Rapida logo
+  components directly.
+- [ ] Assistant preview chat uses `theme.brand.name` for the assistant-side
+  display name.
+- [ ] Missing logo config falls back to configured brand text, not Rapida SVGs.
+- [ ] UI navigation and auth surfaces use configured legal and support links.
+- [ ] Hardcoded Rapida brand literals in UI source are either removed or listed
+  in a documented allowlist with a non-branding justification.
+- [ ] UI contract tests fail when new tenant-visible hardcoded Rapida brand
+  literals are added.
+- [ ] Default deployable configs retain the current Rapida AI appearance.
+- [ ] Backend email branding remains unchanged and explicitly out of scope.
+
+## Open Questions
+
+- Should `ui/public/LLMs.txt` become neutral, be removed, or be generated from
+  the selected UI config?
+- Should built-in static legal pages remain accessible for direct URLs in
+  white-label builds, or should those routes redirect to configured legal links?
+- Should UI package metadata icons in `ui/package.json` be included in a later
+  desktop packaging scope?
+
+## Challenge Resolution
+
+Pending independent plan challenge.
+
+## Artifact Index
+
+- `jsons/plan.json` - Initial UI-only implementation plan. Draft.
+
+## Decision Log
+
+| Date | Decision | Owner | Evidence |
+| --- | --- | --- | --- |
+| 2026-08-31 | Initial UI-only RFC draft | UI Platform | `jsons/plan.json` |

--- a/rfcs/0014-ui-brand-theme-customization/jsons/challenge-02.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/challenge-02.json
@@ -1,0 +1,15 @@
+{
+  "rfc": "rfcs/0014-ui-brand-theme-customization.md",
+  "created": "2026-08-31",
+  "reviewer": "independent challenger",
+  "recommendation": "approve",
+  "findings": [],
+  "resolved_prior_findings": [
+    "ui/public/LLMs.txt decision is explicit: make it neutral in first implementation.",
+    "Static legal route behavior is explicit: direct routes may remain, tenant-visible navigation must use configured links.",
+    "Brand-source acceptance is bounded by a concrete scan set and allowlist policy.",
+    "BrandedLogo is required for tenant-visible brand surfaces."
+  ],
+  "status_line_check": "The RFC bytes contain the sole metadata status line '- Status: Accepted'.",
+  "next_step": "Create exact-digest confirmation before implementation."
+}

--- a/rfcs/0014-ui-brand-theme-customization/jsons/challenge.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/challenge.json
@@ -1,0 +1,32 @@
+{
+  "rfc": "rfcs/0014-ui-brand-theme-customization.md",
+  "created": "2026-08-31",
+  "reviewer": "independent challenger",
+  "recommendation": "revise",
+  "findings": [
+    {
+      "severity": "major",
+      "finding": "Open questions for ui/public/LLMs.txt and direct static legal page access were implementation-shaping and blocked approval."
+    },
+    {
+      "severity": "major",
+      "finding": "Governance state was inconsistent because the RFC status was Accepted while challenge resolution was pending and the plan was marked accepted-candidate."
+    },
+    {
+      "severity": "major",
+      "finding": "The CONFIG.theme source-of-truth acceptance criterion was too broad to verify without a concrete scan boundary and allowlist policy."
+    },
+    {
+      "severity": "minor",
+      "finding": "The shared logo component was optional even though several surfaces require the same fallback contract."
+    }
+  ],
+  "resolution": [
+    "Chose neutral ui/public/LLMs.txt for the first implementation.",
+    "Chose to keep direct static legal routes accessible while tenant-visible navigation uses configured legal links.",
+    "Added a bounded brand scan contract and explicit allowlist policy.",
+    "Made BrandedLogo required for tenant-visible brand rendering in shell, onboarding, and preview surfaces.",
+    "Updated Challenge Resolution to record the round 1 outcome and resolutions."
+  ],
+  "next_step": "Rerun independent challenge on revised RFC bytes."
+}

--- a/rfcs/0014-ui-brand-theme-customization/jsons/confirmation.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/confirmation.json
@@ -1,0 +1,8 @@
+{
+  "rfc": "rfcs/0014-ui-brand-theme-customization.md",
+  "created": "2026-08-31",
+  "approved_by": "user",
+  "approved_digest_sha256": "d63f4eca773a483d45e325541c9c56cdfe96b8c43a5edddddd47f2128a303d8b",
+  "approval_text": "Approved: rfcs/0014-ui-brand-theme-customization.md d63f4eca773a483d45e325541c9c56cdfe96b8c43a5edddddd47f2128a303d8b",
+  "implementation_authorized": true
+}

--- a/rfcs/0014-ui-brand-theme-customization/jsons/implementation-review.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/implementation-review.json
@@ -1,0 +1,33 @@
+{
+  "reviewer": "Carson",
+  "review_type": "independent implementation review",
+  "status": "findings_resolved",
+  "findings": [
+    {
+      "severity": "major",
+      "summary": "Contract checker missed lowercase tenant-visible brand literals.",
+      "resolution": "Added lowercase brand literal detection while avoiding SDK package names and route path segments, and removed the reported visible lowercase copy."
+    },
+    {
+      "severity": "major",
+      "summary": "Brand literal allowlist skipped whole files and masked tenant-visible copy.",
+      "resolution": "Changed the allowlist to exact literals per file, removed reported tenant-visible copies, and retained only documented technical or legacy literals."
+    },
+    {
+      "severity": "major",
+      "summary": "Onboarding desktop logo selected the resolved mode logo for a dark brand panel.",
+      "resolution": "Added a colorMode override to BrandedLogo and used the dark full logo on the onboarding desktop brand panel."
+    },
+    {
+      "severity": "minor",
+      "summary": "Theme documentation did not describe the new brand literal scan and allowlist.",
+      "resolution": "Updated ui/THEMING.md with the scan set, exclusions, and exact-literal allowlist policy."
+    }
+  ],
+  "verification_after_resolution": [
+    "cd ui && yarn test:theme-contract",
+    "cd ui && yarn check:theme-contract",
+    "cd ui && yarn test --watchAll=false --runTestsByPath src/app/components/navigation/header/__tests__/header.test.tsx src/app/components/navigation/sidebar/__tests__/sidebar-shell.test.tsx src/app/routes/__tests__/onborading.test.tsx src/app/pages/authentication/__tests__/sign-in-sign-up.test.tsx src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx src/app/pages/assistant/view/conversations/conversation-messages.helpers.test.ts",
+    "cd ui && yarn checkTs"
+  ]
+}

--- a/rfcs/0014-ui-brand-theme-customization/jsons/plan.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/plan.json
@@ -1,6 +1,6 @@
 {
   "rfc": "rfcs/0014-ui-brand-theme-customization.md",
-  "status": "draft",
+  "status": "accepted-candidate",
   "created": "2026-08-31",
   "owner": "UI Platform",
   "classification": "Governed",
@@ -76,7 +76,7 @@
     }
   ],
   "acceptance_criteria": [
-    "CONFIG.theme is the only source for tenant-visible UI brand name, logo, favicon, primary color, docs links, legal links, and support link.",
+    "Inside the bounded brand scan set, CONFIG.theme is the only source for tenant-visible UI brand name, logo, favicon, primary color, docs links, legal links, and support link, except documented non-branding allowlist entries.",
     "Preview call and preview chat pages no longer import or render Rapida logo components directly.",
     "Assistant preview chat uses theme.brand.name for the assistant-side display name.",
     "Missing logo config falls back to configured brand text, not Rapida SVGs.",
@@ -98,10 +98,11 @@
     "Keep the current build-time CONFIG.theme model.",
     "Use existing ThemeManifest fields without a schema version change.",
     "Move preview header and preview chat brand rendering to useTheme.",
-    "Replace tenant-visible Rapida SVG fallbacks with configured brand text fallback.",
+    "Add a shared BrandedLogo component and replace tenant-visible Rapida SVG fallbacks with configured brand text fallback.",
     "Route docs, legal, support, and source links through theme.links where those links are UI-owned.",
-    "Make public UI metadata neutral or generate it from selected config.",
-    "Extend the theme contract checker with an explicit allowlist for non-brand technical identifiers."
+    "Make ui/public/LLMs.txt neutral for the first implementation.",
+    "Keep built-in static legal pages directly accessible, but route tenant-visible navigation through theme.links.terms and theme.links.privacy.",
+    "Extend the theme contract checker over the bounded brand scan set with an explicit allowlist for non-brand technical identifiers."
   ],
   "risks": [
     {
@@ -116,6 +117,32 @@
       "risk": "Broken configured logo assets degrade visual quality.",
       "mitigation": "Use configured alt text and brand text fallback."
     }
+  ],
+  "brand_scan_contract": {
+    "included_paths": [
+      "ui/src/app/**/*.tsx",
+      "ui/src/app/**/*.ts",
+      "ui/src/theme/**/*.ts",
+      "ui/src/theme/**/*.tsx",
+      "ui/public/LLMs.txt"
+    ],
+    "excluded_paths": [
+      "tests",
+      "provider catalogs",
+      "deployable config defaults",
+      "icon component definitions",
+      "generated files",
+      "package metadata",
+      "non-rendered type or store names"
+    ],
+    "allowlist_policy": "Every exception requires a short non-branding justification in the checker source or adjacent test fixtures."
+  },
+  "challenge_resolution": [
+    "Round 1 recommended revise.",
+    "ui/public/LLMs.txt will become neutral in the first implementation.",
+    "Built-in static legal pages remain directly accessible, while tenant-visible navigation must use configured legal links.",
+    "The brand-source acceptance criterion now has a bounded scan set and explicit allowlist policy.",
+    "BrandedLogo is required for tenant-visible brand rendering in shell, onboarding, and preview surfaces."
   ],
   "rollback": "Revert UI component, public metadata, config, documentation, and theme contract checker changes. No backend or data rollback is required.",
   "verification_commands": [

--- a/rfcs/0014-ui-brand-theme-customization/jsons/plan.json
+++ b/rfcs/0014-ui-brand-theme-customization/jsons/plan.json
@@ -1,0 +1,132 @@
+{
+  "rfc": "rfcs/0014-ui-brand-theme-customization.md",
+  "status": "draft",
+  "created": "2026-08-31",
+  "owner": "UI Platform",
+  "classification": "Governed",
+  "objective": "Complete UI-only brand and theme customization by making tenant-visible UI surfaces use CONFIG.theme for brand identity, links, assets, and primary colors.",
+  "inferred_integration_type": "ui",
+  "defaults": {
+    "brand_source": "CONFIG.theme",
+    "selected_configs": [
+      "ui/src/configs/config.development.json",
+      "ui/src/configs/config.production.json",
+      "docker/ui/config.community.json",
+      "docker/ui/config.enterprise.json",
+      "docker/ui/config.local.json",
+      "docker/ui/config.local-knowledge.json"
+    ],
+    "runtime_model": "build-time bundled UI config",
+    "fallback_behavior": "use configured brand text when a logo asset is absent"
+  },
+  "accepted_scope": {
+    "allowed_paths": [
+      "ui/src/theme/",
+      "ui/src/configs/",
+      "docker/ui/config.*.json",
+      "ui/src/app/components/",
+      "ui/src/app/pages/",
+      "ui/src/app/routes/",
+      "ui/public/",
+      "ui/scripts/check-theme-contract.mjs",
+      "ui/scripts/check-theme-contract.test.mjs",
+      "ui/THEMING.md"
+    ],
+    "out_of_scope_paths": [
+      "api/**",
+      "pkg/clients/external/emailer/**",
+      "pkg/configs/emailer_config.go",
+      "cmd/**",
+      "protos/**",
+      "README.md",
+      "LICENSE.md",
+      "SECURITY.md",
+      "package manager lockfiles",
+      "generated artifacts"
+    ]
+  },
+  "verified_context": [
+    {
+      "path": "ui/src/index.tsx",
+      "finding": "React is already wrapped with ThemeProvider using CONFIG.theme."
+    },
+    {
+      "path": "ui/src/theme/theme-provider.tsx",
+      "finding": "ThemeProvider applies data-brand, data-color-mode, favicon, theme color, and brand CSS variables."
+    },
+    {
+      "path": "ui/src/app/components/navigation/header/index.tsx",
+      "finding": "Header uses configured full logo when present but falls back to Rapida SVG components."
+    },
+    {
+      "path": "ui/src/app/components/navigation/sidebar/index.tsx",
+      "finding": "Sidebar uses configured full or compact logo when present but falls back to Rapida SVG components."
+    },
+    {
+      "path": "ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx",
+      "finding": "Preview header imports and renders RapidaIcon and RapidaTextIcon directly."
+    },
+    {
+      "path": "ui/src/app/pages/preview-agent/voice-agent/text/conversations/index.tsx",
+      "finding": "Preview chat renders a Rapida icon and the assistant-side display name Rapida."
+    },
+    {
+      "path": "ui/scripts/check-theme-contract.mjs",
+      "finding": "Theme contract checks deployable theme config and shell colors, but not broader user-visible brand literals."
+    }
+  ],
+  "acceptance_criteria": [
+    "CONFIG.theme is the only source for tenant-visible UI brand name, logo, favicon, primary color, docs links, legal links, and support link.",
+    "Preview call and preview chat pages no longer import or render Rapida logo components directly.",
+    "Assistant preview chat uses theme.brand.name for the assistant-side display name.",
+    "Missing logo config falls back to configured brand text, not Rapida SVGs.",
+    "UI navigation and auth surfaces use configured legal and support links.",
+    "Hardcoded Rapida brand literals in UI source are either removed or listed in a documented allowlist with a non-branding justification.",
+    "UI contract tests fail when new tenant-visible hardcoded Rapida brand literals are added.",
+    "Default deployable configs retain the current Rapida AI appearance.",
+    "Backend email branding remains unchanged and explicitly out of scope."
+  ],
+  "non_goals": [
+    "Backend email subjects, sender identity, and body templates.",
+    "Go module paths, generated clients, protobuf package names, npm package names, import paths, and internal metadata keys.",
+    "Product or legal rewording beyond removing unintended UI hardcoding.",
+    "Provider catalog branding, provider names, and third-party provider logos.",
+    "Runtime tenant switching without rebuilding the selected UI bundle.",
+    "Authentication, authorization, API, database, or deployment contract changes."
+  ],
+  "implementation_outline": [
+    "Keep the current build-time CONFIG.theme model.",
+    "Use existing ThemeManifest fields without a schema version change.",
+    "Move preview header and preview chat brand rendering to useTheme.",
+    "Replace tenant-visible Rapida SVG fallbacks with configured brand text fallback.",
+    "Route docs, legal, support, and source links through theme.links where those links are UI-owned.",
+    "Make public UI metadata neutral or generate it from selected config.",
+    "Extend the theme contract checker with an explicit allowlist for non-brand technical identifiers."
+  ],
+  "risks": [
+    {
+      "risk": "The brand literal scanner may flag technical identifiers that are not tenant-visible.",
+      "mitigation": "Use a narrow allowlist and focus scanning on UI source and selected public metadata."
+    },
+    {
+      "risk": "Static legal pages contain product-specific legal text.",
+      "mitigation": "Use configured legal links for navigation and decide whether direct routes remain accessible before acceptance."
+    },
+    {
+      "risk": "Broken configured logo assets degrade visual quality.",
+      "mitigation": "Use configured alt text and brand text fallback."
+    }
+  ],
+  "rollback": "Revert UI component, public metadata, config, documentation, and theme contract checker changes. No backend or data rollback is required.",
+  "verification_commands": [
+    "cd ui && yarn check:theme-contract",
+    "cd ui && yarn test:theme-contract",
+    "cd ui && yarn lint",
+    "cd ui && yarn checkTs",
+    "cd ui && yarn test --watchAll=false --runInBand",
+    "cd ui && yarn build",
+    "just agent-finalize \"ui/src,ui/public,ui/scripts,ui/THEMING.md,docker/ui\""
+  ],
+  "requires_independent_challenge": true,
+  "requires_confirmation_before_implementation": true
+}

--- a/ui/THEMING.md
+++ b/ui/THEMING.md
@@ -121,6 +121,14 @@ yarn test --watchAll=false --runInBand
 yarn build
 ```
 
+The theme contract check also scans renderable UI source for hardcoded Rapida
+brand literals. The scan covers `ui/src/app/**/*.ts`, `ui/src/app/**/*.tsx`,
+`ui/src/theme/**/*.ts`, `ui/src/theme/**/*.tsx`, and `ui/public/LLMs.txt`, while
+excluding tests, provider catalogs, and generated style output. Exceptions are
+declared in `scripts/check-theme-contract.mjs` as exact literals with a short
+reason. Do not skip an entire file for branding unless every allowed literal is
+listed there.
+
 Schema changes require incrementing `schemaVersion`, updating the config
 validator and every deployable config together, and documenting the migration
 here. Invalid theme configuration fails closed before React renders and shows a

--- a/ui/public/LLMs.txt
+++ b/ui/public/LLMs.txt
@@ -1,23 +1,13 @@
-# RapidaAI
+# Application
 
 ## Overview
-[Welcome to Rapida documentation](https://doc.rapida.ai/): This page serves as an introduction to the Rapida documentation, providing users with essential information on how to navigate and utilize the resources available.
-
-## Blog
-[Rapida](https://blog.rapida.ai/): The official blog of Rapida, featuring updates, insights, and articles related to the application and its features.
-
-## Home
-[rapida.ai: Home](https://www.rapida.ai/): The main homepage of Rapida, offering an overview of the application, its functionalities, and access to various resources.
+This deployment exposes product documentation, account access, release updates,
+and legal resources through links configured by the UI theme manifest.
 
 ## User Accounts
-[Signin to your account](https://www.rapida.ai/auth/signin): A page dedicated to the login process for existing users, detailing the steps to access their accounts securely.
+Users can sign in, create accounts when enabled, and manage access according to
+the workspace authentication settings.
 
-[Signing up to your account](https://www.rapida.ai/auth/signup): This page outlines the registration process for new users, including the necessary steps to create an account and start using Rapida.
-
-## News and Updates
-[News](https://blog.rapida.ai/tag/news/): A section that provides the latest news and updates regarding Rapida, including feature releases and important announcements.
 ## Legal Information
-[Terms of Service](https://www.rapida.ai/static/terms-conditions): The legal agreement that outlines the terms and conditions for using the Rapida application and services.
-[Privacy Policy](https://www.rapida.ai/static/privacy-policy): This document explains how Rapida collects, uses, and protects user data, ensuring compliance with privacy regulations.
-## Contributors
-[Prashant Srivastav](https://blog.rapida.ai/author/prashant-srivastav/): A contributor to the Rapida project, providing insights and expertise in the development and documentation of the application.
+Terms, privacy, support, and documentation links are tenant-configurable through
+CONFIG.theme.links.

--- a/ui/scripts/check-theme-contract.mjs
+++ b/ui/scripts/check-theme-contract.mjs
@@ -51,6 +51,67 @@ export const THEME_CONFIG_PATHS = Object.freeze([
   'docker/ui/config.local-knowledge.json',
 ]);
 const GENERATED_STYLES_DIRECTORY = 'ui/src/styles/generated';
+const BRAND_LITERAL_SCAN_DIRECTORIES = Object.freeze([
+  'ui/src/app',
+  'ui/src/theme',
+]);
+const BRAND_LITERAL_SCAN_FILES = Object.freeze(['ui/public/LLMs.txt']);
+export const BRAND_LITERAL_ALLOWLIST = Object.freeze({
+  'ui/src/app/components/Icon/Rapida.tsx': {
+    literals: ['Rapida'],
+    reason:
+      'legacy icon component definition, not tenant-visible branding by itself',
+  },
+  'ui/src/app/components/Icon/RapidaText.tsx': {
+    literals: ['Rapida'],
+    reason:
+      'legacy icon component definition, not tenant-visible branding by itself',
+  },
+  'ui/src/app/components/integration-document/endpoint-integration.tsx': {
+    literals: ['Rapida', 'rapida'],
+    reason:
+      'SDK package and client class names are external developer API identifiers',
+  },
+  'ui/src/app/pages/static-pages/terms.tsx': {
+    literals: ['Rapida.AI', 'support@rapida.ai'],
+    reason:
+      'legacy direct legal route content remains outside tenant-visible navigation',
+  },
+  'ui/src/app/pages/static-pages/privacy.tsx': {
+    literals: ['Rapida', 'Rapida.AI', 'support@rapida.ai'],
+    reason:
+      'legacy direct legal route content remains outside tenant-visible navigation',
+  },
+  'ui/src/app/pages/main/web-dashboard/index.tsx': {
+    literals: ['cdn-01.rapida.ai'],
+    reason: 'dashboard content feed URL is a technical asset source',
+  },
+  'ui/src/app/pages/assistant/actions/create-assistant/create-agentkit.tsx': {
+    literals: ['Rapida'],
+    reason:
+      'AgentKit and orchestration names are deployment product identifiers',
+  },
+  'ui/src/app/pages/assistant/actions/create-assistant-version/create-agent-kit-version.tsx':
+    {
+      literals: ['Rapida'],
+      reason: 'AgentKit name is a deployment product identifier',
+    },
+  'ui/src/app/pages/assistant/view/conversations/conversation-messages.helpers.ts':
+    {
+      literals: ['rapida'],
+      reason:
+        'legacy conversation role value is mapped to a tenant-neutral display label',
+    },
+  'ui/src/app/components/base/modal/assistant-instruction-modal/index.tsx': {
+    literals: ['cdn-01.rapida.ai'],
+    reason: 'web widget script URL is a deployment snippet asset source',
+  },
+  'ui/src/app/components/base/modal/assistant-web-widget-deployment-modal/index.tsx':
+    {
+      literals: ['cdn-01.rapida.ai'],
+      reason: 'web widget script URL is a deployment snippet asset source',
+    },
+});
 const HARD_CODED_PALETTES = Object.freeze([
   'white',
   'black',
@@ -67,6 +128,14 @@ const HARD_CODED_COLOR_UTILITY = new RegExp(
   )})(?:-[0-9]{1,3})?(?:\/[0-9]{1,3})?!?)(?=$|[^A-Za-z0-9_-])`,
   'g',
 );
+
+const BRAND_LITERAL_PATTERNS = Object.freeze([
+  /\bRapida(?:\s+AI|\.AI|AI| Assistant)?\b/g,
+  /(?<![-/.@])\brapida(?:\s+ai| assistant)?\b(?![.-])/g,
+  /\b(?:doc|docs|www|blog)\.rapida\.ai\b/g,
+  /\bcdn-01\.rapida\.ai\b/g,
+  /\b[A-Za-z0-9._%+-]+@rapida\.ai\b/g,
+]);
 
 const toPosixPath = path => path.split(sep).join('/');
 
@@ -135,6 +204,62 @@ const walkFiles = directory => {
   }
   return files;
 };
+
+const isBrandScanFile = sourcePath => {
+  if (
+    sourcePath.includes('/__tests__/') ||
+    sourcePath.includes('/components/providers/') ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(sourcePath)
+  ) {
+    return false;
+  }
+
+  return /\.(?:tsx?|txt)$/.test(sourcePath);
+};
+
+const collectBrandScanFiles = repoRoot => {
+  const files = [];
+
+  for (const directory of BRAND_LITERAL_SCAN_DIRECTORIES) {
+    const directoryPath = resolve(repoRoot, directory);
+    try {
+      if (statSync(directoryPath).isDirectory()) {
+        files.push(...walkFiles(directoryPath));
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+
+  for (const file of BRAND_LITERAL_SCAN_FILES) {
+    const filePath = resolve(repoRoot, file);
+    try {
+      if (statSync(filePath).isFile()) files.push(filePath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+
+  return files
+    .map(filePath => ({
+      filePath,
+      sourcePath: toPosixPath(relative(repoRoot, filePath)),
+    }))
+    .filter(({ sourcePath }) => isBrandScanFile(sourcePath));
+};
+
+export function findHardcodedBrandLiterals(source) {
+  const literals = new Set();
+
+  for (const pattern of BRAND_LITERAL_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of source.matchAll(pattern)) {
+      literals.add(match[0]);
+    }
+  }
+
+  return [...literals].sort();
+}
 
 export function validateLegacyThemeRemoval(repoRoot = DEFAULT_REPO_ROOT) {
   const diagnostics = [];
@@ -271,12 +396,36 @@ export function validateSingleSourceTheme(repoRoot = DEFAULT_REPO_ROOT) {
   return diagnostics.sort();
 }
 
+export function validateBrandLiterals(repoRoot = DEFAULT_REPO_ROOT) {
+  const diagnostics = [];
+
+  for (const { filePath, sourcePath } of collectBrandScanFiles(repoRoot)) {
+    const allowedLiterals = new Set(
+      BRAND_LITERAL_ALLOWLIST[sourcePath]?.literals ?? [],
+    );
+
+    const source = readFileSync(filePath, 'utf8');
+    for (const literal of findHardcodedBrandLiterals(source)) {
+      if (allowedLiterals.has(literal)) continue;
+
+      pushDiagnostic(
+        diagnostics,
+        sourcePath,
+        `hardcoded brand literal is not allowed: ${literal}`,
+      );
+    }
+  }
+
+  return diagnostics.sort();
+}
+
 export function checkThemeContract(repoRoot = DEFAULT_REPO_ROOT) {
   return [
     ...validateLegacyThemeRemoval(repoRoot),
     ...validateShellFiles(repoRoot),
     ...validateThemeConfigFiles(repoRoot),
     ...validateSingleSourceTheme(repoRoot),
+    ...validateBrandLiterals(repoRoot),
   ].sort();
 }
 

--- a/ui/scripts/check-theme-contract.test.mjs
+++ b/ui/scripts/check-theme-contract.test.mjs
@@ -7,10 +7,13 @@ import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
+  BRAND_LITERAL_ALLOWLIST,
   SHELL_CONTRACTS,
   THEME_CONFIG_PATHS,
   checkThemeContract,
+  findHardcodedBrandLiterals,
   findHardcodedColorUtilities,
+  validateBrandLiterals,
   validateLegacyThemeRemoval,
   validateShellSource,
   validateSingleSourceTheme,
@@ -234,4 +237,66 @@ test('allows external script elements in the public index', context => {
   );
 
   assert.deepEqual(validateSingleSourceTheme(repoRoot), []);
+});
+
+test('finds hardcoded brand literals in renderable UI source', () => {
+  const source = `
+    const title = "Rapida AI";
+    const lower = "supported by rapida";
+    const docs = "https://doc.rapida.ai/assistants";
+    const cdn = "https://cdn-01.rapida.ai/script.js";
+    const support = "support@rapida.ai";
+  `;
+
+  assert.deepEqual(findHardcodedBrandLiterals(source), [
+    'Rapida AI',
+    'cdn-01.rapida.ai',
+    'doc.rapida.ai',
+    'rapida',
+    'support@rapida.ai',
+  ]);
+});
+
+test('rejects brand literals from scanned UI files', context => {
+  const repoRoot = createFixtureRepo(context);
+  writeFixtureFile(
+    repoRoot,
+    'ui/src/app/pages/dashboard.tsx',
+    'export const title = "Rapida AI";\n',
+  );
+  writeFixtureFile(
+    repoRoot,
+    'ui/src/app/pages/dashboard.test.tsx',
+    'expect("Rapida AI").toBeTruthy();\n',
+  );
+
+  assert.deepEqual(validateBrandLiterals(repoRoot), [
+    'ui/src/app/pages/dashboard.tsx: hardcoded brand literal is not allowed: Rapida AI',
+  ]);
+});
+
+test('allowlisted files still reject unlisted brand literals', context => {
+  const repoRoot = createFixtureRepo(context);
+  writeFixtureFile(
+    repoRoot,
+    'ui/src/app/pages/main/web-dashboard/index.tsx',
+    `
+      export const feed = "https://cdn-01.rapida.ai/web/feed.json";
+      export const title = "Rapida AI";
+    `,
+  );
+
+  assert.deepEqual(validateBrandLiterals(repoRoot), [
+    'ui/src/app/pages/main/web-dashboard/index.tsx: hardcoded brand literal is not allowed: Rapida AI',
+  ]);
+});
+
+test('documents every brand literal allowlist entry with a reason', () => {
+  for (const [sourcePath, entry] of Object.entries(BRAND_LITERAL_ALLOWLIST)) {
+    assert.match(sourcePath, /^ui\/src\/app\/.+\.(?:ts|tsx)$/);
+    assert.ok(Array.isArray(entry.literals));
+    assert.ok(entry.literals.length > 0);
+    assert.equal(typeof entry.reason, 'string');
+    assert.ok(entry.reason.length > 20);
+  }
 });

--- a/ui/src/app/components/base/modal/assistant-instruction-modal/index.tsx
+++ b/ui/src/app/components/base/modal/assistant-instruction-modal/index.tsx
@@ -1,25 +1,35 @@
 import { ModalProps } from '@/app/components/base/modal';
-import { Modal, ModalHeader, ModalBody, ModalFooter } from '@/app/components/carbon/modal';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@/app/components/carbon/modal';
 import { FC, HTMLAttributes, memo } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { CodeHighlighting } from '@/app/components/code-highlighting';
 import { DeploymentSectionHeader } from '@/app/components/base/modal/deployment-modal-primitives';
+import { useDocumentationUrl } from '@/theme/documentation-url';
 
 interface AssistantInstructionDialogProps
-  extends ModalProps,
-    HTMLAttributes<HTMLDivElement> {
+  extends ModalProps, HTMLAttributes<HTMLDivElement> {
   assistantId: string;
 }
 
 export const AssistantWebwidgetDeploymentDialog: FC<AssistantInstructionDialogProps> =
   memo(({ assistantId, modalOpen, setModalOpen }) => {
+    const documentationUrl = useDocumentationUrl();
+
     return (
       <Modal open={modalOpen} onClose={() => setModalOpen(false)} size="md">
-        <ModalHeader onClose={() => setModalOpen(false)} title="Deployment completed">
+        <ModalHeader
+          onClose={() => setModalOpen(false)}
+          title="Deployment completed"
+        >
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            Add the following snippets to your website to start
-            receiving messages.
+            Add the following snippets to your website to start receiving
+            messages.
           </p>
         </ModalHeader>
 
@@ -47,7 +57,7 @@ window.chatbotConfig = {
   layout: "docked-right",
   position: "bottom-right",
   showLauncher: true,
-  name: "Rapida Assistant",
+  name: "Assistant",
   theme: {
     mode: "light",
   },
@@ -64,9 +74,7 @@ window.chatbotConfig = {
           <PrimaryButton
             size="lg"
             type="button"
-            onClick={() =>
-              window.open('https://doc.rapida.ai', '_blank')
-            }
+            onClick={() => window.open(documentationUrl, '_blank')}
           >
             <span>View Documentation</span>
             <ExternalLink className="w-4 h-4 ml-1" strokeWidth={1.5} />

--- a/ui/src/app/components/base/modal/assistant-phone-call-deployment-modal/index.tsx
+++ b/ui/src/app/components/base/modal/assistant-phone-call-deployment-modal/index.tsx
@@ -242,8 +242,8 @@ const SipIntegrationInstructions: FC<{
       >
         <InputHelper>
           {inboundRegistrationEnabled
-            ? 'Inbound registration is enabled. Use this DNS as the default Rapida SIP target.'
-            : 'Point your SIP trunk / PBX outbound proxy to this address. Rapida accepts SIP INVITE and establishes an RTP media session directly.'}
+            ? 'Inbound registration is enabled. Use this DNS as the default SIP target.'
+            : 'Point your SIP trunk / PBX outbound proxy to this address. The service accepts SIP INVITE and establishes an RTP media session directly.'}
         </InputHelper>
       </CodeRow>
 

--- a/ui/src/app/components/brand/branded-logo.tsx
+++ b/ui/src/app/components/brand/branded-logo.tsx
@@ -1,0 +1,47 @@
+import { ImgHTMLAttributes } from 'react';
+import { useTheme } from '@/theme/theme-provider';
+import { ResolvedThemeMode } from '@/theme/types';
+import { cn } from '@/utils';
+
+type BrandedLogoVariant = 'full' | 'compact';
+
+interface BrandedLogoProps
+  extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt'> {
+  variant?: BrandedLogoVariant;
+  colorMode?: ResolvedThemeMode;
+  textClassName?: string;
+}
+
+export function BrandedLogo({
+  variant = 'full',
+  colorMode,
+  className,
+  textClassName,
+  ...attributes
+}: BrandedLogoProps) {
+  const { resolvedMode, theme } = useTheme();
+  const logo = theme.brand.logos?.[variant][colorMode ?? resolvedMode];
+
+  if (logo) {
+    return (
+      <img
+        {...attributes}
+        src={logo}
+        alt={theme.brand.name}
+        className={cn('block object-contain', className)}
+      />
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'block min-w-0 truncate font-semibold text-primary',
+        className,
+        textClassName,
+      )}
+    >
+      {theme.brand.name}
+    </span>
+  );
+}

--- a/ui/src/app/components/configuration/config-prompt/index.test.tsx
+++ b/ui/src/app/components/configuration/config-prompt/index.test.tsx
@@ -64,16 +64,16 @@ describe('ConfigPrompt argument hints', () => {
     );
 
     expect(
-      screen.getByRole('button', { name: /Rapida Reserved Variables/i }),
+      screen.getByRole('button', { name: /Reserved Variables/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /These variables are preserved and replaced by Rapida at runtime/i,
+        /These variables are preserved and replaced at runtime/i,
       ),
     ).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole('button', { name: /Rapida Reserved Variables/i }),
+      screen.getByRole('button', { name: /Reserved Variables/i }),
     );
 
     expect(screen.getByText(/Runtime value/i)).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('ConfigPrompt argument hints', () => {
   it('does not show runtime argument hint text when hints are not provided', () => {
     render(<ConfigPrompt existingPrompt={basePrompt} onChange={() => {}} />);
     expect(
-      screen.queryByText(/Rapida Reserved Variables/i),
+      screen.queryByText(/Reserved Variables/i),
     ).not.toBeInTheDocument();
   });
 
@@ -117,7 +117,7 @@ describe('ConfigPrompt argument hints', () => {
     expect(screen.getByText('Arguments')).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Rapida reserved variables are preserved and replaced at runtime/i,
+        /Reserved variables are preserved and replaced at runtime/i,
       ),
     ).toBeInTheDocument();
     expect(

--- a/ui/src/app/components/configuration/config-prompt/index.tsx
+++ b/ui/src/app/components/configuration/config-prompt/index.tsx
@@ -155,7 +155,7 @@ export const ConfigPrompt: FC<IPromptProps> = ({
             >
               <div className="w-full flex items-center justify-between gap-2 text-left">
                 <span className="text-[11px] font-semibold tracking-[0.08em] uppercase text-gray-500 dark:text-gray-400">
-                  Rapida Reserved Variables
+                  Reserved Variables
                 </span>
                 <ChevronDown
                   className={`h-4 w-4 text-gray-500 transition-transform ${showReservedVariables ? 'rotate-180' : ''}`}
@@ -163,7 +163,7 @@ export const ConfigPrompt: FC<IPromptProps> = ({
                 />
               </div>
               <InputHelper className="mt-1">
-                These variables are preserved and replaced by Rapida at runtime.
+                These variables are preserved and replaced at runtime.
               </InputHelper>
             </button>
 
@@ -238,8 +238,8 @@ export const ConfigPrompt: FC<IPromptProps> = ({
           </div>
           {showRuntimeReplacementHint && !hideArgumentRuntimeHint && (
             <InputHelper className="mb-2">
-              Add only your template-specific variables here. Rapida reserved
-              variables are preserved and replaced at runtime.
+              Add only your template-specific variables here. Reserved variables
+              are preserved and replaced at runtime.
             </InputHelper>
           )}
           <div className="text-sm grid bg-light-background dark:bg-gray-950 w-full border border-gray-300 dark:border-gray-700 divide-y divide-gray-300 dark:divide-gray-700">

--- a/ui/src/app/components/container/message/notice-block/doc-notice-block.tsx
+++ b/ui/src/app/components/container/message/notice-block/doc-notice-block.tsx
@@ -1,24 +1,27 @@
 import { FC } from 'react';
 import { Information } from '@carbon/icons-react';
 import { Link } from '@carbon/react';
+import { useDocumentationUrl } from '@/theme/documentation-url';
 
 export const DocNoticeBlock: FC<{
   children: React.ReactNode;
-  docUrl: string;
+  docPath?: string;
+  docUrl?: string;
   linkText?: string;
-}> = ({
-  children,
-  docUrl,
-  linkText = 'Read documentation',
-}) => {
+}> = ({ children, docPath = '', docUrl, linkText = 'Read documentation' }) => {
+  const configuredDocUrl = useDocumentationUrl(docPath);
+
   return (
     <div className="flex items-center gap-3 w-full px-4 py-3 bg-blue-50 dark:bg-blue-900/20 border-l-[3px] border-blue-600 dark:border-blue-400">
-      <Information size={20} className="shrink-0 text-blue-600 dark:text-blue-400" />
+      <Information
+        size={20}
+        className="shrink-0 text-blue-600 dark:text-blue-400"
+      />
       <span className="text-sm flex-1 text-gray-800 dark:text-gray-200">
         {children}
       </span>
       <Link
-        href={docUrl}
+        href={docUrl ?? configuredDocUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="!font-semibold shrink-0"

--- a/ui/src/app/components/indicators/source/index.tsx
+++ b/ui/src/app/components/indicators/source/index.tsx
@@ -34,7 +34,7 @@ const sourceConfig: Record<
   'rapida-app': {
     tagType: 'blue',
     icon: <Application size={16} />,
-    label: 'Rapida App',
+    label: 'App',
   },
   'node-sdk': { tagType: 'green', icon: <Code size={16} />, label: 'Node SDK' },
   'go-sdk': { tagType: 'cyan', icon: <Code size={16} />, label: 'Go SDK' },

--- a/ui/src/app/components/navigation/header/__tests__/header.test.tsx
+++ b/ui/src/app/components/navigation/header/__tests__/header.test.tsx
@@ -7,9 +7,9 @@ import { Header } from '../index';
 
 const theme = developmentConfig.theme as unknown as ThemeManifest;
 
-const renderHeader = (ariaLabel?: string) =>
+const renderHeader = (ariaLabel?: string, renderTheme: ThemeManifest = theme) =>
   render(
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={renderTheme}>
       <Header aria-label={ariaLabel} />
     </ThemeProvider>,
   );
@@ -42,5 +42,19 @@ describe('Header', () => {
       'aria-label',
       'Project navigation',
     );
+  });
+
+  it('falls back to configured brand text when no logo is configured', () => {
+    renderHeader(undefined, {
+      ...theme,
+      brand: {
+        ...theme.brand,
+        name: 'Tenant Voice',
+        logos: undefined,
+      },
+    });
+
+    expect(screen.getByText('Tenant Voice')).toBeInTheDocument();
+    expect(screen.queryByAltText('Rapida AI')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/navigation/header/index.tsx
+++ b/ui/src/app/components/navigation/header/index.tsx
@@ -1,16 +1,14 @@
 import React, { FC, HTMLAttributes, memo } from 'react';
 import { Header as CarbonHeader } from '@carbon/react';
 import { useTheme } from '@/theme/theme-provider';
-import { RapidaIcon } from '@/app/components/Icon/Rapida';
-import { RapidaTextIcon } from '@/app/components/Icon/RapidaText';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
 import { cn } from '@/utils';
 
 interface HeaderProps extends HTMLAttributes<HTMLElement> {}
 
 export const Header: FC<HeaderProps> = memo(
   ({ className, 'aria-label': ariaLabel, ...attributes }) => {
-    const { resolvedMode, theme } = useTheme();
-    const fullLogo = theme.brand.logos?.full[resolvedMode];
+    const { theme } = useTheme();
 
     return (
       <CarbonHeader
@@ -22,18 +20,11 @@ export const Header: FC<HeaderProps> = memo(
         )}
       >
         <div className="flex h-full min-w-0 items-center">
-          {fullLogo ? (
-            <img
-              src={fullLogo}
-              alt={theme.brand.name}
-              className="block h-6 w-auto max-w-[12rem] object-contain object-left"
-            />
-          ) : (
-            <div className="flex items-center gap-2 text-primary">
-              <RapidaIcon className="h-6 w-6 shrink-0" />
-              <RapidaTextIcon className="h-[18px] w-auto" />
-            </div>
-          )}
+          <BrandedLogo
+            variant="full"
+            className="h-6 w-auto max-w-[12rem] object-left"
+            textClassName="text-base"
+          />
         </div>
       </CarbonHeader>
     );

--- a/ui/src/app/components/navigation/sidebar/index.tsx
+++ b/ui/src/app/components/navigation/sidebar/index.tsx
@@ -7,14 +7,12 @@ import { Vault } from '@/app/components/navigation/sidebar/vault';
 import { Knowledge } from '@/app/components/navigation/sidebar/knowledge';
 import { Aside } from '@/app/components/aside';
 import { ExternalTool } from '@/app/components/navigation/sidebar/external-tools';
-import { RapidaIcon } from '@/app/components/Icon/Rapida';
-import { RapidaTextIcon } from '@/app/components/Icon/RapidaText';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
 import { SidePanelClose, SidePanelOpen } from '@carbon/icons-react';
 import { useSidebar } from '@/context/sidebar-context';
 import { cn } from '@/utils/index';
 import { useRapidaStore } from '@/hooks';
 import { Text } from '@/app/components/carbon/text';
-import { useTheme } from '@/theme/theme-provider';
 import { useWorkspace } from '@/workspace';
 
 /**
@@ -24,7 +22,6 @@ import { useWorkspace } from '@/workspace';
  */
 export function SidebarNavigation(props: {}) {
   const workspace = useWorkspace();
-  const { resolvedMode, theme } = useTheme();
   const { locked, setLocked, open } = useSidebar();
   const { loading, loadingType } = useRapidaStore();
   const isLoading = loading && loadingType === 'block';
@@ -38,30 +35,16 @@ export function SidebarNavigation(props: {}) {
           open ? 'justify-start' : 'justify-center',
         )}
       >
-        {theme.brand.logos ? (
-          <img
-            src={
-              open
-                ? theme.brand.logos.full[resolvedMode]
-                : theme.brand.logos.compact[resolvedMode]
-            }
-            alt={theme.brand.name}
-            className={cn(
-              'block object-contain',
-              open ? 'h-6 w-auto max-w-[12rem] object-left' : 'h-6 w-6',
-            )}
-          />
-        ) : (
-          <div className="flex items-center gap-2 text-primary">
-            <RapidaIcon className="h-6 w-6 shrink-0" />
-            <RapidaTextIcon
-              className={cn(
-                'h-[18px] transition-all duration-200',
-                open ? 'opacity-100' : 'opacity-0 w-0',
-              )}
-            />
-          </div>
-        )}
+        <BrandedLogo
+          variant={open ? 'full' : 'compact'}
+          className={cn(
+            open ? 'h-6 w-auto max-w-[12rem] object-left' : 'h-6 w-6',
+          )}
+          textClassName={cn(
+            'transition-all duration-200',
+            open ? 'text-base opacity-100' : 'w-6 text-center text-xs',
+          )}
+        />
       </div>
 
       {/* ── Nav groups — scrollable ── */}

--- a/ui/src/app/components/prompt-editor/index.tsx
+++ b/ui/src/app/components/prompt-editor/index.tsx
@@ -65,7 +65,7 @@ const PromptEditor = ({
                 label: item.label,
                 kind: monaco.languages.CompletionItemKind.Variable,
                 insertText: item.insertText,
-                detail: 'Rapida reserved variable',
+                detail: 'Reserved variable',
                 documentation: {
                   value: item.description,
                 },

--- a/ui/src/app/components/tools/common/components.tsx
+++ b/ui/src/app/components/tools/common/components.tsx
@@ -22,13 +22,13 @@ import { parseJsonParameters, stringifyParameters } from './hooks';
 
 interface DocumentationNoticeProps {
   title?: string;
-  documentationUrl: string;
+  documentationPath: string;
 }
 
 export const DocumentationNotice: FC<DocumentationNoticeProps> = ({
-  title = 'Know more about knowledge tool definition that can be supported by rapida',
-  documentationUrl,
-}) => <DocNoticeBlock docUrl={documentationUrl}>{title}</DocNoticeBlock>;
+  title = 'Know more about supported knowledge tool definitions',
+  documentationPath,
+}) => <DocNoticeBlock docPath={documentationPath}>{title}</DocNoticeBlock>;
 
 // ============================================================================
 // Tool Definition Form
@@ -38,7 +38,7 @@ interface ToolDefinitionFormProps {
   toolDefinition: ToolDefinition;
   onChangeToolDefinition: (value: ToolDefinition) => void;
   inputClass?: string;
-  documentationUrl?: string;
+  documentationPath?: string;
   documentationTitle?: string;
 }
 
@@ -46,7 +46,7 @@ export const ToolDefinitionForm: FC<ToolDefinitionFormProps> = ({
   toolDefinition,
   onChangeToolDefinition,
   inputClass,
-  documentationUrl = 'https://doc.rapida.ai/assistants/overview',
+  documentationPath = '/assistants/overview',
   documentationTitle,
 }) => {
   const llmTooltip =
@@ -56,7 +56,7 @@ export const ToolDefinitionForm: FC<ToolDefinitionFormProps> = ({
     <div>
       <DocumentationNotice
         title={documentationTitle}
-        documentationUrl={documentationUrl}
+        documentationPath={documentationPath}
       />
       <div className="px-6 pb-6 mt-4 max-w-6xl">
         <Stack gap={6}>
@@ -289,16 +289,14 @@ export const AssistantMappingTable = <
       onChange([...parameters, createNewParameter()]);
       return;
     }
-    onChange(
-      [
-        ...parameters,
-        {
-          type: defaultNewType,
-          key: getDefaultKey(defaultNewType),
-          value: '',
-        } as TItem,
-      ],
-    );
+    onChange([
+      ...parameters,
+      {
+        type: defaultNewType,
+        key: getDefaultKey(defaultNewType),
+        value: '',
+      } as TItem,
+    ]);
   }, [parameters, onChange, createNewParameter, defaultNewType, getDefaultKey]);
 
   return (

--- a/ui/src/app/components/tools/end-of-conversation/__tests__/index.test.tsx
+++ b/ui/src/app/components/tools/end-of-conversation/__tests__/index.test.tsx
@@ -10,12 +10,12 @@ import {
 jest.mock('../../common', () => ({
   ToolDefinitionForm: ({
     documentationTitle,
-    documentationUrl,
+    documentationPath,
     toolDefinition,
   }: any) => (
     <div>
       <div data-testid="doc-title">{documentationTitle}</div>
-      <div data-testid="doc-url">{documentationUrl}</div>
+      <div data-testid="doc-path">{documentationPath}</div>
       <div data-testid="tool-name">{toolDefinition?.name}</div>
     </div>
   ),
@@ -43,10 +43,10 @@ describe('end-of-conversation tool', () => {
     );
 
     expect(screen.getByTestId('doc-title')).toHaveTextContent(
-      'Know more about End of Conversation that can be supported by rapida',
+      'Know more about supported End of Conversation behavior',
     );
-    expect(screen.getByTestId('doc-url')).toHaveTextContent(
-      'https://doc.rapida.ai/assistants/tools/add-end-of-conversation-tool',
+    expect(screen.getByTestId('doc-path')).toHaveTextContent(
+      '/assistants/tools/add-end-of-conversation-tool',
     );
     expect(screen.getByTestId('tool-name')).toHaveTextContent(
       'end_conversation',

--- a/ui/src/app/components/tools/end-of-conversation/index.tsx
+++ b/ui/src/app/components/tools/end-of-conversation/index.tsx
@@ -16,8 +16,8 @@ export const ConfigureEndOfConversation: FC<ConfigureToolProps> = ({
         toolDefinition={toolDefinition}
         onChangeToolDefinition={onChangeToolDefinition}
         inputClass={inputClass}
-        documentationUrl="https://doc.rapida.ai/assistants/tools/add-end-of-conversation-tool"
-        documentationTitle="Know more about End of Conversation that can be supported by rapida"
+        documentationPath="/assistants/tools/add-end-of-conversation-tool"
+        documentationTitle="Know more about supported End of Conversation behavior"
       />
     )}
   </>

--- a/ui/src/app/components/tools/knowledge-retrieval/index.tsx
+++ b/ui/src/app/components/tools/knowledge-retrieval/index.tsx
@@ -128,7 +128,7 @@ export const ConfigureKnowledgeRetrieval: FC<ConfigureToolProps> = ({
           toolDefinition={toolDefinition}
           onChangeToolDefinition={onChangeToolDefinition}
           inputClass={inputClass}
-          documentationUrl="https://doc.rapida.ai/assistants/tools/add-knowledge-tool"
+          documentationPath="/assistants/tools/add-knowledge-tool"
         />
       )}
     </>

--- a/ui/src/app/components/tools/transfer-call/index.tsx
+++ b/ui/src/app/components/tools/transfer-call/index.tsx
@@ -124,7 +124,7 @@ export const ConfigureTransferCall: FC<ConfigureToolProps> = ({
               <SelectItem value="ring-ring" text="ring-ring" />
               <SelectItem value="transfer-music" text="transfer-music" />
             </Select>
-              <Slider
+            <Slider
               id="transfer-delay"
               labelText={
                 <span className="inline-flex items-center gap-1">
@@ -154,8 +154,8 @@ export const ConfigureTransferCall: FC<ConfigureToolProps> = ({
           toolDefinition={toolDefinition}
           onChangeToolDefinition={onChangeToolDefinition}
           inputClass={inputClass}
-          documentationUrl="https://doc.rapida.ai/assistants/tools/add-transfer-call-tool"
-          documentationTitle="Know more about Transfer Call that can be supported by rapida"
+          documentationPath="/assistants/tools/add-transfer-call-tool"
+          documentationTitle="Know more about supported Transfer Call behavior"
         />
       )}
     </>

--- a/ui/src/app/pages/__tests__/create-flows.validation.test.tsx
+++ b/ui/src/app/pages/__tests__/create-flows.validation.test.tsx
@@ -7,6 +7,9 @@ import { CreateEndpointPage } from '@/app/pages/endpoint/actions/create-endpoint
 import { CreateNewVersionEndpointPage } from '@/app/pages/endpoint/actions/create-endpoint-version';
 import { CreateAssistantPage } from '@/app/pages/assistant/actions/create-assistant';
 import { CreateVersionAssistantPage } from '@/app/pages/assistant/actions/create-assistant-version';
+import developmentConfig from '@/configs/config.development.json';
+import { ThemeProvider } from '@/theme/theme-provider';
+import { ThemeManifest } from '@/theme/types';
 import {
   CreateEndpointProviderModel,
   ForgotPassword,
@@ -279,8 +282,21 @@ const getLatestConfigPromptProps = () =>
 const getLatestTextProviderProps = () =>
   mockTextProvider.mock.calls[mockTextProvider.mock.calls.length - 1]?.[0];
 
+const theme = developmentConfig.theme as unknown as ThemeManifest;
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+
 describe('Requested create/update flow pages', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
     jest.clearAllMocks();
     mockParams = {};
     mockConfigPrompt.mockClear();
@@ -313,8 +329,8 @@ describe('Requested create/update flow pages', () => {
       cb(null, { getSuccess: () => true });
     });
 
-    render(<ForgotPasswordPage />);
-    fireEvent.change(screen.getByPlaceholderText('eg: john@rapida.ai'), {
+    renderWithTheme(<ForgotPasswordPage />);
+    fireEvent.change(screen.getByPlaceholderText('eg: john@example.com'), {
       target: { value: 'user@x.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Send Email' }));
@@ -458,7 +474,7 @@ describe('Requested create/update flow pages', () => {
   });
 
   it('create assistant blocks continue when prompt content is empty', () => {
-    render(<CreateAssistantPage />);
+    renderWithTheme(<CreateAssistantPage />);
     const assistantConfigPrompt = getLatestConfigPromptProps();
     expect(assistantConfigPrompt.showRuntimeReplacementHint).toBe(true);
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
@@ -468,7 +484,7 @@ describe('Requested create/update flow pages', () => {
   });
 
   it('create assistant moves forward after prompt content edit', () => {
-    render(<CreateAssistantPage />);
+    renderWithTheme(<CreateAssistantPage />);
 
     const assistantConfigPrompt = getLatestConfigPromptProps();
     act(() => {
@@ -484,7 +500,7 @@ describe('Requested create/update flow pages', () => {
   });
 
   it('create assistant validates using changed provider', () => {
-    render(<CreateAssistantPage />);
+    renderWithTheme(<CreateAssistantPage />);
 
     const assistantTextProviderProps = getLatestTextProviderProps();
     act(() => {

--- a/ui/src/app/pages/assistant/actions/configure-assistant-tool/create-assistant-tool.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-tool/create-assistant-tool.tsx
@@ -227,7 +227,7 @@ export const CreateTool: FC<{ assistantId: string }> = ({ assistantId }) => {
                     <ToolDefinitionForm
                       toolDefinition={toolDefinition}
                       onChangeToolDefinition={setToolDefinition}
-                      documentationUrl="https://doc.rapida.ai/assistants/tools"
+                      documentationPath="/assistants/tools"
                     />
                   ),
                 },

--- a/ui/src/app/pages/assistant/actions/configure-assistant-tool/update-assistant-tool.tsx
+++ b/ui/src/app/pages/assistant/actions/configure-assistant-tool/update-assistant-tool.tsx
@@ -270,7 +270,7 @@ export const UpdateTool: FC<{ assistantId: string }> = ({ assistantId }) => {
                     <ToolDefinitionForm
                       toolDefinition={toolDefinition}
                       onChangeToolDefinition={setToolDefinition}
-                      documentationUrl="https://doc.rapida.ai/assistants/tools"
+                      documentationPath="/assistants/tools"
                     />
                   ),
                 },

--- a/ui/src/app/pages/assistant/actions/create-assistant-version/create-agent-kit-version.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant-version/create-agent-kit-version.tsx
@@ -426,7 +426,7 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
             body: (
               <>
                 <DocNoticeBlock
-                  docUrl="https://doc.rapida.ai/assistants/create-new-version"
+                  docPath="/assistants/create-new-version"
                   linkText="Read docs"
                 >
                   New versions of the assistant will not be deployed

--- a/ui/src/app/pages/assistant/actions/create-assistant-version/create-websocket-version.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant-version/create-websocket-version.tsx
@@ -3,10 +3,7 @@ import { useRapidaStore } from '@/hooks';
 import { useCredential } from '@/hooks/use-credential';
 import { useParams } from 'react-router-dom';
 import { Helmet } from '@/app/components/helmet';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import { TabForm } from '@/app/components/form/tab-form';
 import { FieldSet } from '@/app/components/form/fieldset';
@@ -229,12 +226,14 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
               'Set up a new WebSocket connection to the server where your agent is running.',
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => showDialog(navigator.goBack)}
                 >
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   onClick={() => {
                     if (validateWebsocket()) {
                       setActiveTab('commit-assistant');
@@ -247,7 +246,7 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
             ],
             body: (
               <>
-                <DocNoticeBlock docUrl="https://doc.rapida.ai/assistants/create-new-version">
+                <DocNoticeBlock docPath="/assistants/create-new-version">
                   Please note that new versions of the assistant will not be
                   deployed automatically.
                 </DocNoticeBlock>
@@ -295,12 +294,14 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
               'Provide a clear description of the changes made in this version to help others understand what has been updated.',
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => showDialog(navigator.goBack)}
                 >
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   onClick={() => {
                     createProviderModel();
                   }}
@@ -311,7 +312,7 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
             ],
             body: (
               <>
-                <DocNoticeBlock docUrl="https://doc.rapida.ai/assistants/create-new-version">
+                <DocNoticeBlock docPath="/assistants/create-new-version">
                   Please note that new versions of the assistant will not be
                   deployed automatically.
                 </DocNoticeBlock>

--- a/ui/src/app/pages/assistant/actions/create-assistant-version/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant-version/index.tsx
@@ -306,7 +306,7 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
             body: (
               <>
                 <DocNoticeBlock
-                  docUrl="https://doc.rapida.ai/assistants/create-new-version"
+                  docPath="/assistants/create-new-version"
                   linkText="Read docs"
                 >
                   New versions of the assistant will not be deployed
@@ -325,7 +325,7 @@ const CreateNewVersion: FC<{ assistantId: string }> = ({ assistantId }) => {
 
                   {/* Prompt template section */}
                   <div className="flex flex-col gap-6">
-                    <DocNoticeBlock docUrl="https://doc.rapida.ai/assistants/prompt-templating">
+                    <DocNoticeBlock docPath="/assistants/prompt-templating">
                       Prompt variables and system arguments are resolved at
                       runtime. Read the prompt templating guide before creating
                       the version.

--- a/ui/src/app/pages/assistant/actions/create-assistant/create-agentkit.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant/create-agentkit.tsx
@@ -327,7 +327,7 @@ export function CreateAgentKit() {
             body: (
               <>
                 <DocNoticeBlock
-                  docUrl="https://doc.rapida.ai/assistants/overview"
+                  docPath="/assistants/overview"
                   linkText="Read docs"
                 >
                   Deploy your agent on-premises with the Rapida orchestration
@@ -669,7 +669,7 @@ export function CreateAgentKit() {
             body: (
               <>
                 <DocNoticeBlock
-                  docUrl="https://doc.rapida.ai/assistants/overview"
+                  docPath="/assistants/overview"
                   linkText="Read docs"
                 >
                   Choose how you'd like to start engaging with users and add

--- a/ui/src/app/pages/assistant/actions/create-assistant/create-websocket.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant/create-websocket.tsx
@@ -2,10 +2,7 @@ import { useState } from 'react';
 import { Helmet } from '@/app/components/helmet';
 import { useRapidaStore } from '@/hooks';
 import { TabForm } from '@/app/components/form/tab-form';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import {
   Assistant,
@@ -37,8 +34,12 @@ import { Globe } from 'lucide-react';
 import { APiParameter } from '@/app/components/external-api/api-parameter';
 import { connectionConfig } from '@/configs';
 import toast from 'react-hot-toast';
+import { useDocumentationUrl } from '@/theme/documentation-url';
+import { useTheme } from '@/theme/theme-provider';
 
 export function CreateWebsocket() {
+  const { theme } = useTheme();
+  const assistantDocsUrl = useDocumentationUrl('/assistants/overview');
   const { authId, token, projectId } = useCurrentCredential();
   const {
     goToAssistant,
@@ -196,12 +197,12 @@ export function CreateWebsocket() {
                 <YellowNoticeBlock className="flex items-center">
                   <Info className="shrink-0 w-4 h-4" />
                   <div className="ms-3 text-sm font-medium">
-                    Connect your external AI agent to Rapida using a WebSocket
-                    endpoint.
+                    Connect your external AI agent to {theme.brand.name} using a
+                    WebSocket endpoint.
                   </div>
                   <a
                     target="_blank"
-                    href="https://doc.rapida.ai/assistants/overview"
+                    href={assistantDocsUrl}
                     className="h-7 flex items-center font-medium hover:underline ml-auto text-yellow-600"
                     rel="noreferrer"
                   >
@@ -250,12 +251,14 @@ export function CreateWebsocket() {
             ),
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => showDialog(navigator.goBack)}
                 >
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   isLoading={loading}
                   onClick={() => {
                     if (validateWebsocket()) setActiveTab('define-assistant');
@@ -273,12 +276,14 @@ export function CreateWebsocket() {
               'Provide the name, a brief description, and relevant tags for your assistant to help identify and categorize it.',
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => showDialog(navigator.goBack)}
                 >
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   isLoading={loading}
                   onClick={createAssistant}
                 >
@@ -327,14 +332,16 @@ export function CreateWebsocket() {
             code: 'deployment',
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => {
                     if (assistant) goToAssistant(assistant.getId());
                   }}
                 >
                   Skip
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   isLoading={loading}
                   onClick={() => {
                     if (assistant) goToAssistant(assistant.getId());
@@ -354,7 +361,7 @@ export function CreateWebsocket() {
                   </div>
                   <a
                     target="_blank"
-                    href="https://doc.rapida.ai/assistants/overview"
+                    href={assistantDocsUrl}
                     className="h-7 flex items-center font-medium hover:underline ml-auto text-yellow-600"
                     rel="noreferrer"
                   >

--- a/ui/src/app/pages/assistant/actions/create-assistant/index.tsx
+++ b/ui/src/app/pages/assistant/actions/create-assistant/index.tsx
@@ -67,12 +67,14 @@ import {
   AssistantTemplate,
   ConfigureAssistantTemplateDialog,
 } from '@/app/components/base/modal/configure-assistant-template-modal';
+import { useTheme } from '@/theme/theme-provider';
 
 /**
  *
  * @returns
  */
 export function CreateAssistantPage() {
+  const { theme } = useTheme();
   /**
    * credentils and authentication parameters
    */
@@ -439,10 +441,10 @@ export function CreateAssistantPage() {
             body: (
               <>
                 <DocNoticeBlock
-                  docUrl="https://doc.rapida.ai/assistants/overview"
+                  docPath="/assistants/overview"
                   linkText="Read docs"
                 >
-                  Rapida Assistant enables you to deploy intelligent
+                  {theme.brand.name} enables you to deploy intelligent
                   conversational agents across multiple channels.
                 </DocNoticeBlock>
                 <div className="px-8 pt-6 pb-8 max-w-4xl flex flex-col gap-8">
@@ -486,7 +488,7 @@ export function CreateAssistantPage() {
                   {/* Prompt template section */}
                   <div className="flex flex-col gap-6">
                     <SectionDivider label="Prompt Template" />
-                    <DocNoticeBlock docUrl="https://doc.rapida.ai/assistants/prompt-templating">
+                    <DocNoticeBlock docPath="/assistants/prompt-templating">
                       Prompt variables and system arguments are resolved at
                       runtime. Read the prompt templating guide before
                       finalizing your instruction.

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-experience.design.test.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/__tests__/configure-experience.design.test.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import developmentConfig from '@/configs/config.development.json';
+import { ThemeProvider } from '@/theme/theme-provider';
+import { ThemeManifest } from '@/theme/types';
 import {
   ConfigureExperience,
   DEFAULT_IDEAL_TIMEOUT,
 } from '../configure-experience';
 
 const mockSlider = jest.fn();
+const theme = developmentConfig.theme as unknown as ThemeManifest;
 
 jest.mock('@/app/components/carbon/form', () => ({
   Stack: ({ children }: any) => <div>{children}</div>,
@@ -49,15 +53,25 @@ jest.mock('@carbon/react', () => ({
 
 describe('ConfigureExperience', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
     mockSlider.mockClear();
   });
 
   it('defaults idle timeout to 10 seconds within backend validation limits', () => {
     render(
-      <ConfigureExperience
-        experienceConfig={{}}
-        setExperienceConfig={jest.fn()}
-      />,
+      <ThemeProvider theme={theme}>
+        <ConfigureExperience
+          experienceConfig={{}}
+          setExperienceConfig={jest.fn()}
+        />
+      </ThemeProvider>,
     );
 
     const idleTimeoutSlider = mockSlider.mock.calls

--- a/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-experience.tsx
+++ b/ui/src/app/pages/assistant/actions/create-deployment/commons/configure-experience.tsx
@@ -12,6 +12,7 @@ import {
   Toggle,
 } from '@carbon/react';
 import { Information } from '@carbon/icons-react';
+import { useDocumentationUrl } from '@/theme/documentation-url';
 
 export interface ExperienceConfig {
   greeting?: string;
@@ -25,9 +26,6 @@ export interface ExperienceConfig {
   idleTimeoutBackoffTimes?: string;
   suggestions?: string[];
 }
-
-const EXPERIENCE_DOCS_URL =
-  'https://doc.rapida.ai/assistants/configuration/experience';
 
 const ERROR_MESSAGE_OPTIONS = [
   'Sorry, something went wrong. Please try again.',
@@ -62,6 +60,9 @@ export const ConfigureExperience: FC<{
   experienceConfig: ExperienceConfig;
   setExperienceConfig: (config: ExperienceConfig) => void;
 }> = ({ experienceConfig, setExperienceConfig }) => {
+  const experienceDocsUrl = useDocumentationUrl(
+    '/assistants/configuration/experience',
+  );
   const update = (field: keyof ExperienceConfig, value: string) =>
     setExperienceConfig({ ...experienceConfig, [field]: value });
   const updateBoolean = (field: keyof ExperienceConfig, value: boolean) =>
@@ -87,7 +88,7 @@ export const ConfigureExperience: FC<{
             <Button
               kind="primary"
               size="sm"
-              href={EXPERIENCE_DOCS_URL}
+              href={experienceDocsUrl}
               target="_blank"
               rel="noreferrer"
             >

--- a/ui/src/app/pages/assistant/view/conversations/conversation-messages.helpers.test.ts
+++ b/ui/src/app/pages/assistant/view/conversations/conversation-messages.helpers.test.ts
@@ -14,6 +14,7 @@ const metric = (name: string, value: string): Metric => {
 describe('conversation message helpers', () => {
   it('returns expected visual metadata for known and unknown roles', () => {
     expect(getRoleVisual('assistant').label).toBe('Assistant');
+    expect(getRoleVisual('rapida').label).toBe('Assistant');
     expect(getRoleVisual('user').shortLabel).toBe('U');
     expect(getRoleVisual('custom').shortLabel).toBe('C');
   });

--- a/ui/src/app/pages/assistant/view/conversations/conversation-messages.helpers.ts
+++ b/ui/src/app/pages/assistant/view/conversations/conversation-messages.helpers.ts
@@ -11,8 +11,8 @@ export const getRoleVisual = (role: string): RoleVisual => {
   const normalized = role.toLowerCase();
   if (normalized === 'rapida') {
     return {
-      label: 'Rapida',
-      shortLabel: 'R',
+      label: 'Assistant',
+      shortLabel: 'A',
       toneClassName:
         'bg-blue-100 dark:bg-blue-900/60 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800',
     };

--- a/ui/src/app/pages/authentication/__tests__/sign-in-sign-up.test.tsx
+++ b/ui/src/app/pages/authentication/__tests__/sign-in-sign-up.test.tsx
@@ -11,6 +11,13 @@ const mockNavigate = jest.fn();
 const mockShowLoader = jest.fn();
 const mockHideLoader = jest.fn();
 const mockGoTo = jest.fn();
+const mockTheme = {
+  links: {
+    terms: 'https://example.com/terms',
+    privacy: 'https://example.com/privacy',
+    support: 'mailto:support@example.com',
+  },
+};
 
 let mockSearchParams = new URLSearchParams();
 let mockLocationState: any = undefined;
@@ -83,6 +90,10 @@ jest.mock('@/hooks/use-global-navigator', () => ({
   }),
 }));
 
+jest.mock('@/theme/theme-provider', () => ({
+  useTheme: () => ({ theme: mockTheme }),
+}));
+
 jest.mock('@/configs', () => ({
   connectionConfig: {},
 }));
@@ -109,9 +120,14 @@ jest.mock('@/app/components/carbon/notification', () => ({
 }));
 
 jest.mock('@/app/components/carbon/button', () => ({
-  PrimaryButton: ({ children, isLoading: _i, renderIcon: _r, hasIconOnly: _h, iconDescription: _d, ...props }: any) => (
-    <button {...props}>{children}</button>
-  ),
+  PrimaryButton: ({
+    children,
+    isLoading: _i,
+    renderIcon: _r,
+    hasIconOnly: _h,
+    iconDescription: _d,
+    ...props
+  }: any) => <button {...props}>{children}</button>,
 }));
 
 jest.mock('@carbon/react', () => ({
@@ -185,8 +201,8 @@ describe('Authentication pages', () => {
 
     renderWithAuth(<SignInPage />, setAuthentication);
 
-    fireEvent.change(screen.getByPlaceholderText('eg: john@rapida.ai'), {
-      target: { value: 'john@rapida.ai' },
+    fireEvent.change(screen.getByPlaceholderText('eg: john@example.com'), {
+      target: { value: 'john@example.com' },
     });
     fireEvent.change(screen.getByPlaceholderText('******'), {
       target: { value: 'secret' },
@@ -213,10 +229,9 @@ describe('Authentication pages', () => {
       'href',
       '/auth/signup',
     );
-    expect(screen.getByRole('link', { name: "Can't sign in?" })).toHaveAttribute(
-      'href',
-      '/auth/forgot-password',
-    );
+    expect(
+      screen.getByRole('link', { name: "Can't sign in?" }),
+    ).toHaveAttribute('href', '/auth/forgot-password');
     expect(screen.getByTestId('social-buttons')).toBeInTheDocument();
   });
 
@@ -255,7 +270,7 @@ describe('Authentication pages', () => {
   });
 
   it('sign-up prefills email from location state and submits register', async () => {
-    mockLocationState = { email: 'prefilled@rapida.ai' };
+    mockLocationState = { email: 'prefilled@example.com' };
     mockParams = { next: '/workspace/overview' };
 
     const setAuthentication = jest.fn((_auth, cb) => cb());
@@ -271,10 +286,10 @@ describe('Authentication pages', () => {
     renderWithAuth(<SignUpPage />, setAuthentication);
 
     const emailInput = screen.getByPlaceholderText(
-      'eg: john@rapida.ai',
+      'eg: john@example.com',
     ) as HTMLInputElement;
     await waitFor(() => {
-      expect(emailInput.value).toBe('prefilled@rapida.ai');
+      expect(emailInput.value).toBe('prefilled@example.com');
     });
 
     fireEvent.change(screen.getByPlaceholderText('eg: John Doe'), {
@@ -308,11 +323,10 @@ describe('Authentication pages', () => {
     );
     expect(
       screen.getByRole('link', { name: 'Terms and Conditions' }),
-    ).toHaveAttribute('href', '/static/terms-conditions');
-    expect(screen.getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
-      'href',
-      '/static/privacy-policy',
-    );
+    ).toHaveAttribute('href', mockTheme.links.terms);
+    expect(
+      screen.getByRole('link', { name: 'Privacy Policy' }),
+    ).toHaveAttribute('href', mockTheme.links.privacy);
   });
 
   it('sign-up shows API human error message on register failure', async () => {
@@ -330,8 +344,8 @@ describe('Authentication pages', () => {
     fireEvent.change(screen.getByPlaceholderText('eg: John Doe'), {
       target: { value: 'John Doe' },
     });
-    fireEvent.change(screen.getByPlaceholderText('eg: john@rapida.ai'), {
-      target: { value: 'john@rapida.ai' },
+    fireEvent.change(screen.getByPlaceholderText('eg: john@example.com'), {
+      target: { value: 'john@example.com' },
     });
     fireEvent.change(screen.getByPlaceholderText('********'), {
       target: { value: 'secret' },

--- a/ui/src/app/pages/authentication/forgot-password/index.tsx
+++ b/ui/src/app/pages/authentication/forgot-password/index.tsx
@@ -11,12 +11,15 @@ import { PrimaryButton } from '@/app/components/carbon/button';
 import { Notification } from '@/app/components/carbon/notification';
 import { ArrowRight } from '@carbon/icons-react';
 import { Link } from '@carbon/react';
+import { useTheme } from '@/theme/theme-provider';
 
 export function ForgotPasswordPage() {
+  const { theme } = useTheme();
   const { register, handleSubmit } = useForm();
   const { loading, showLoader, hideLoader } = useRapidaStore();
   const [error, setError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const supportContact = theme.links.support.replace(/^mailto:/, '');
 
   const afterForgotPassword = useCallback(
     (err: ServiceError | null, fpr: ForgotPasswordResponse | null) => {
@@ -27,7 +30,7 @@ export function ForgotPasswordPage() {
       if (fpr?.getSuccess()) {
         setError('');
         setSuccessMessage(
-          "Thanks! An email was sent that will ask you to click on a link to verify that you own this account. If you don't get the email, please contact support@rapida.ai.",
+          `Thanks! An email was sent that will ask you to click on a link to verify that you own this account. If you don't get the email, please contact support at ${supportContact}.`,
         );
       } else {
         let errorMessage = fpr?.getError();
@@ -37,7 +40,7 @@ export function ForgotPasswordPage() {
         return;
       }
     },
-    [],
+    [hideLoader, supportContact],
   );
 
   const onForgotPassword = data => {
@@ -64,7 +67,7 @@ export function ForgotPasswordPage() {
             required
             autoComplete="email"
             disabled={loading}
-            placeholder="eg: john@rapida.ai"
+            placeholder="eg: john@example.com"
             {...register('email')}
           />
           {error && (

--- a/ui/src/app/pages/authentication/sign-in/index.tsx
+++ b/ui/src/app/pages/authentication/sign-in/index.tsx
@@ -108,7 +108,7 @@ export function SignInPage() {
             type="email"
             required
             autoComplete="email"
-            placeholder="eg: john@rapida.ai"
+            placeholder="eg: john@example.com"
             {...register('email')}
           />
           <PasswordInput

--- a/ui/src/app/pages/authentication/sign-up/index.tsx
+++ b/ui/src/app/pages/authentication/sign-up/index.tsx
@@ -17,6 +17,7 @@ import { PrimaryButton } from '@/app/components/carbon/button';
 import { Notification } from '@/app/components/carbon/notification';
 import { ArrowRight } from '@carbon/icons-react';
 import { Link, PasswordInput } from '@carbon/react';
+import { useTheme } from '@/theme/theme-provider';
 
 interface CustomizedState {
   email: string;
@@ -24,6 +25,7 @@ interface CustomizedState {
 
 export function SignUpPage() {
   const workspace = useWorkspace();
+  const { theme } = useTheme();
   const { setAuthentication } = useContext(AuthContext);
   const location = useLocation();
   const locationState = location?.state as CustomizedState;
@@ -130,7 +132,7 @@ export function SignUpPage() {
               type="email"
               required
               autoComplete="email"
-              placeholder="eg: john@rapida.ai"
+              placeholder="eg: john@example.com"
               {...register('email', { required: 'Please enter email' })}
             />
             <PasswordInput
@@ -162,11 +164,11 @@ export function SignUpPage() {
         <Stack gap={2}>
           <p className="text-sm text-gray-600 dark:text-gray-400">
             By signing up, you agree to the{' '}
-            <Link href="/static/terms-conditions" target="_blank" inline>
+            <Link href={theme.links.terms} target="_blank" inline>
               Terms and Conditions
             </Link>{' '}
             and{' '}
-            <Link href="/static/privacy-policy" target="_blank" inline>
+            <Link href={theme.links.privacy} target="_blank" inline>
               Privacy Policy
             </Link>
             .

--- a/ui/src/app/pages/endpoint/actions/create-endpoint-version/index.tsx
+++ b/ui/src/app/pages/endpoint/actions/create-endpoint-version/index.tsx
@@ -1,10 +1,7 @@
 import { FC, useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast/headless';
 import { Helmet } from '@/app/components/helmet';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import { TabForm } from '@/app/components/form/tab-form';
 import ConfirmDialog from '@/app/components/base/modal/confirm-ui';
@@ -297,7 +294,10 @@ export const CreateNewVersionEndpointPage: FC = () => {
             code: 'choose-model',
             body: (
               <>
-                <DocNoticeBlock docUrl="https://doc.rapida.ai/endpoint/create-new-version" linkText="Read docs">
+                <DocNoticeBlock
+                  docPath="/endpoint/create-new-version"
+                  linkText="Read docs"
+                >
                   New versions of the endpoint will not be deployed
                   automatically. You must promote them manually.
                 </DocNoticeBlock>
@@ -327,12 +327,11 @@ export const CreateNewVersionEndpointPage: FC = () => {
             ),
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
-                  onClick={() => setIsShow(true)}
-                >
+                <SecondaryButton size="lg" onClick={() => setIsShow(true)}>
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   isLoading={loading}
                   onClick={onvalidateEndpointInstruction}
                 >
@@ -349,12 +348,11 @@ export const CreateNewVersionEndpointPage: FC = () => {
               'Write a brief note describing what changed in this version.',
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
-                  onClick={() => setIsShow(true)}
-                >
+                <SecondaryButton size="lg" onClick={() => setIsShow(true)}>
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   isLoading={loading}
                   onClick={() => {
                     createEndpointProviderModel();
@@ -377,7 +375,8 @@ export const CreateNewVersionEndpointPage: FC = () => {
                     />
                     <InputHelper>
                       Summarize the changes made to the endpoint, highlight key
-                      updates, and specify why these modifications are necessary.
+                      updates, and specify why these modifications are
+                      necessary.
                     </InputHelper>
                   </FieldSet>
                 </div>

--- a/ui/src/app/pages/endpoint/view/try-playground/index.tsx
+++ b/ui/src/app/pages/endpoint/view/try-playground/index.tsx
@@ -3,6 +3,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { TryChatComplete } from '@/app/pages/endpoint/view/try-playground/experiment-prompt/try-chat-complete';
 import { Helmet } from '@/app/components/helmet';
 import { Launch } from '@carbon/icons-react';
+import { useDocumentationUrl } from '@/theme/documentation-url';
 
 const overviewSections = [
   {
@@ -65,6 +66,8 @@ export function Playground(props: {
   currentEndpoint: Endpoint;
   currentEndpointProviderModel: EndpointProviderModel;
 }) {
+  const apiReferenceUrl = useDocumentationUrl('/api-reference/endpoint/invoke');
+
   return (
     <PanelGroup direction="horizontal" className="grow">
       <Helmet title={props.currentEndpoint.getName()} />
@@ -85,7 +88,7 @@ export function Playground(props: {
           </p>
           <a
             target="_blank"
-            href="https://doc.rapida.ai/api-reference/endpoint/invoke"
+            href={apiReferenceUrl}
             className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
             rel="noreferrer"
           >

--- a/ui/src/app/pages/external-integration/rapida-credentials/index.tsx
+++ b/ui/src/app/pages/external-integration/rapida-credentials/index.tsx
@@ -16,7 +16,14 @@ import { AuthContext } from '@/context/auth-context';
 import { PageHeaderBlock } from '@/app/components/blocks/page-header-block';
 import { PageTitleBlock } from '@/app/components/blocks/page-title-block';
 import { PageTitleWithCount } from '@/app/components/blocks/page-title-with-count';
-import { Add, Renew, View, ViewOff, Copy, Checkmark } from '@carbon/icons-react';
+import {
+  Add,
+  Renew,
+  View,
+  ViewOff,
+  Copy,
+  Checkmark,
+} from '@carbon/icons-react';
 import { connectionConfig } from '@/configs';
 import { toHumanReadableDate } from '@/utils/date';
 import { DocNoticeBlock } from '@/app/components/container/message/notice-block/doc-notice-block';
@@ -151,9 +158,9 @@ export function ProjectCredentialPage() {
           </button>
         </div>
       </PageHeaderBlock>
-      <DocNoticeBlock docUrl="https://doc.rapida.ai/integrations/rapida-credentials">
+      <DocNoticeBlock docPath="/integrations/rapida-credentials">
         These are project-specific keys. They are used to authenticate and
-        interact with the Rapida service for this particular project.
+        interact with the platform service for this particular project.
       </DocNoticeBlock>
       {ourKeys && ourKeys.length > 0 ? (
         <section className="grid content-start grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 grow shrink-0 m-4">
@@ -224,22 +231,14 @@ const CredentialCard: FC<{ credential: ProjectCredential }> = ({
               onClick={() => setIsVisible(!isVisible)}
               title={isVisible ? 'Hide' : 'Show'}
             >
-              {isVisible ? (
-                <ViewOff size={16} />
-              ) : (
-                <View size={16} />
-              )}
+              {isVisible ? <ViewOff size={16} /> : <View size={16} />}
             </GhostButton>
             <GhostButton
               size="md"
               onClick={() => copyToClipboard(credential.getKey())}
               title="Copy"
             >
-              {isCopied ? (
-                <Checkmark size={16} />
-              ) : (
-                <Copy size={16} />
-              )}
+              {isCopied ? <Checkmark size={16} /> : <Copy size={16} />}
             </GhostButton>
           </div>
         </div>
@@ -282,9 +281,9 @@ export function PersonalCredentialPage() {
           <PageTitleBlock>Personal Tokens</PageTitleBlock>
         </div>
       </PageHeaderBlock>
-      <DocNoticeBlock docUrl="https://doc.rapida.ai/integrations/rapida-credentials">
-        These are your personal access tokens. They are used to authenticate
-        and interact with the Rapida service across all your projects.
+      <DocNoticeBlock docPath="/integrations/rapida-credentials">
+        These are your personal access tokens. They are used to authenticate and
+        interact with the platform service across all your projects.
       </DocNoticeBlock>
       <section className="grid content-start grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 grow shrink-0 m-4">
         <BaseCard>
@@ -309,18 +308,14 @@ export function PersonalCredentialPage() {
                     onClick={() => setIsVisible(!isVisible)}
                     title={isVisible ? 'Hide' : 'Show'}
                   >
-                    {isVisible ? (
-                      <ViewOff size={16} />
-                    ) : (
-                      <View size={16} />
-                    )}
+                    {isVisible ? <ViewOff size={16} /> : <View size={16} />}
                   </GhostButton>
-                  <GhostButton size="md" onClick={() => copyToClipboard(token)} title="Copy">
-                    {isCopied ? (
-                      <Checkmark size={16} />
-                    ) : (
-                      <Copy size={16} />
-                    )}
+                  <GhostButton
+                    size="md"
+                    onClick={() => copyToClipboard(token)}
+                    title="Copy"
+                  >
+                    {isCopied ? <Checkmark size={16} /> : <Copy size={16} />}
                   </GhostButton>
                 </div>
               </div>

--- a/ui/src/app/pages/knowledge-base/action/create-knowledge-document/create-knowledge-document.tsx
+++ b/ui/src/app/pages/knowledge-base/action/create-knowledge-document/create-knowledge-document.tsx
@@ -4,10 +4,7 @@ import { useCredential } from '@/hooks/use-credential';
 import { useRapidaStore } from '@/hooks/use-rapida-store';
 import { KnowledgeDocument } from '@rapidaai/react';
 import { useCreateKnowledgeDocumentPageStore } from '@/hooks/use-create-knowledge-document-page-store';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import { ManualFile } from '@/app/pages/knowledge-base/action/components/datasource-uploader/manual-file';
 import { useGlobalNavigation } from '@/hooks/use-global-navigator';
@@ -66,7 +63,7 @@ export function CreateKnowledgeDocumentPage() {
 
   return (
     <div className="max-w-4xl mx-auto">
-      <DocNoticeBlock docUrl="https://doc.rapida.ai/knowledge/overview">
+      <DocNoticeBlock docPath="/knowledge/overview">
         Upload your text files (e.g., .txt, .doc, .docx, .pdf). Maximum file
         size: 10 MB per file.
       </DocNoticeBlock>
@@ -78,8 +75,11 @@ export function CreateKnowledgeDocumentPage() {
       <div className="flex items-center justify-between px-6 pb-6">
         <ErrorMessage message={errorMessage} className="rounded-none!" />
         <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-          <SecondaryButton size="lg" onClick={() => goBack()}>Cancel</SecondaryButton>
-          <PrimaryButton size="lg"
+          <SecondaryButton size="lg" onClick={() => goBack()}>
+            Cancel
+          </SecondaryButton>
+          <PrimaryButton
+            size="lg"
             isLoading={loading}
             onClick={onCreateKnowledgeDocument}
           >

--- a/ui/src/app/pages/knowledge-base/action/create-knowledge-document/create-knowledge-structure-document.tsx
+++ b/ui/src/app/pages/knowledge-base/action/create-knowledge-document/create-knowledge-structure-document.tsx
@@ -4,10 +4,7 @@ import { useCredential } from '@/hooks/use-credential';
 import { useRapidaStore } from '@/hooks/use-rapida-store';
 import { KnowledgeDocument } from '@rapidaai/react';
 import { useCreateKnowledgeDocumentPageStore } from '@/hooks/use-create-knowledge-document-page-store';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import { ManualFile } from '@/app/pages/knowledge-base/action/components/datasource-uploader/manual-file';
 import { useGlobalNavigation } from '@/hooks/use-global-navigator';
@@ -132,9 +129,9 @@ export function CreateKnowledgeStructureDocumentPage() {
         {/* Upload section */}
         <div className="flex flex-col gap-6">
           <SectionDivider label="Documents" />
-          <DocNoticeBlock docUrl="https://doc.rapida.ai/knowledge/overview">
-            Upload your structured files (e.g., .csv, .xls, .json). Maximum
-            file size: 10 MB per file.
+          <DocNoticeBlock docPath="/knowledge/overview">
+            Upload your structured files (e.g., .csv, .xls, .json). Maximum file
+            size: 10 MB per file.
           </DocNoticeBlock>
           <ManualFile
             accepts={{
@@ -149,8 +146,11 @@ export function CreateKnowledgeStructureDocumentPage() {
         <div className="flex items-center justify-between">
           <ErrorMessage message={errorMessage} className="rounded-none!" />
           <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none ml-auto">
-            <SecondaryButton size="lg" onClick={() => goBack()}>Cancel</SecondaryButton>
-            <PrimaryButton size="lg"
+            <SecondaryButton size="lg" onClick={() => goBack()}>
+              Cancel
+            </SecondaryButton>
+            <PrimaryButton
+              size="lg"
               isLoading={loading}
               onClick={onCreateKnowledgeDocument}
             >

--- a/ui/src/app/pages/knowledge-base/action/create-knowledge/index.tsx
+++ b/ui/src/app/pages/knowledge-base/action/create-knowledge/index.tsx
@@ -6,10 +6,7 @@ import { useCreateKnowledgePageStore } from '@/hooks/use-create-knowledge-page-s
 import { useCallback, useEffect, useState } from 'react';
 import { useCredential } from '@/hooks/use-credential';
 import { useRapidaStore } from '@/hooks/use-rapida-store';
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from '@/app/components/carbon/button';
+import { PrimaryButton, SecondaryButton } from '@/app/components/carbon/button';
 import { ButtonSet } from '@carbon/react';
 import { KnowledgeDocument } from '@rapidaai/react';
 import { TabForm } from '@/app/components/form/tab-form';
@@ -77,9 +74,7 @@ export function CreateKnowledgePage() {
 
   const createKnowledge = () => {
     if (name.trim() === '') {
-      setErrorMessage(
-        'Please provide a name for your knowledge base.',
-      );
+      setErrorMessage('Please provide a name for your knowledge base.');
       return;
     }
     setErrorMessage('');
@@ -147,7 +142,7 @@ export function CreateKnowledgePage() {
             code: 'configure-embedding',
             body: (
               <>
-                <DocNoticeBlock docUrl="https://doc.rapida.ai/knowledge/overview">
+                <DocNoticeBlock docPath="/knowledge/overview">
                   A knowledge base is a curated collection of documents grouped
                   by domain or topic. The embedding provider controls how your
                   documents are vectorised for semantic retrieval.
@@ -167,14 +162,10 @@ export function CreateKnowledgePage() {
             ),
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
-                  onClick={() => setIsShow(true)}
-                >
+                <SecondaryButton size="lg" onClick={() => setIsShow(true)}>
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
-                  onClick={onValidateEmbedding}
-                >
+                <PrimaryButton size="lg" onClick={onValidateEmbedding}>
                   Define knowledge profile
                 </PrimaryButton>
               </ButtonSet>,
@@ -268,12 +259,11 @@ export function CreateKnowledgePage() {
             ),
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
-                  onClick={() => setIsShow(true)}
-                >
+                <SecondaryButton size="lg" onClick={() => setIsShow(true)}>
                   Cancel
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   onClick={createKnowledge}
                   isLoading={loading}
                 >
@@ -290,14 +280,16 @@ export function CreateKnowledgePage() {
             body: <ManualFile />,
             actions: [
               <ButtonSet className="!w-full [&>button]:!flex-1 [&>button]:!max-w-none">
-                <SecondaryButton size="lg"
+                <SecondaryButton
+                  size="lg"
                   onClick={() => {
                     if (knowledge?.getId()) goToKnowledge(knowledge?.getId());
                   }}
                 >
                   Skip
                 </SecondaryButton>
-                <PrimaryButton size="lg"
+                <PrimaryButton
+                  size="lg"
                   onClick={createKnowledgeDocument}
                   isLoading={loading}
                 >

--- a/ui/src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ConversationMessages } from '../index';
+
+jest.mock('@uiw/react-markdown-preview', () => ({
+  __esModule: true,
+  default: ({ source }: { source: string }) => <div>{source}</div>,
+}));
+
+jest.mock('@/app/components/base/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/app/components/base/modal/message-feedback-modal', () => ({
+  MessageFeedbackDialog: () => null,
+}));
+
+jest.mock('@/hooks/use-credential', () => ({
+  useCurrentCredential: () => ({ user: { name: 'Jordan' } }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+jest.mock('@/theme/theme-provider', () => ({
+  useTheme: () => ({
+    resolvedMode: 'light',
+    theme: {
+      brand: {
+        name: 'Tenant Voice',
+        logos: {
+          full: {
+            light: '/tenant/full-light.svg',
+            dark: '/tenant/full-dark.svg',
+          },
+          compact: {
+            light: '/tenant/compact-light.svg',
+            dark: '/tenant/compact-dark.svg',
+          },
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock('@rapidaai/react', () => ({
+  Feedback: {
+    Helpful: 'helpful',
+    NotHelpful: 'not-helpful',
+  },
+  MessageRole: {
+    User: 'user',
+    Assistant: 'assistant',
+  },
+  MessageStatus: {
+    Complete: 'complete',
+  },
+  useAgentMessages: () => ({
+    messages: [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        time: new Date('2026-01-01T00:00:00Z'),
+        messages: ['Hello from the assistant'],
+        status: 'complete',
+      },
+    ],
+  }),
+  useMessageFeedback: () => ({
+    handleHelpfulnessFeedback: jest.fn(),
+    handleMessageFeedback: jest.fn(),
+  }),
+}));
+
+describe('ConversationMessages', () => {
+  it('renders assistant identity from the configured theme', () => {
+    render(<ConversationMessages vag={{} as any} />);
+
+    expect(screen.getByText('Tenant Voice')).toBeInTheDocument();
+    expect(screen.getByAltText('Tenant Voice')).toHaveAttribute(
+      'src',
+      '/tenant/compact-light.svg',
+    );
+    expect(screen.queryByText('Rapida')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/pages/preview-agent/voice-agent/text/conversations/index.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/text/conversations/index.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@/app/components/base/tooltip';
-import { RapidaIcon } from '@/app/components/Icon/Rapida';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
 import { TextImage } from '@/app/components/text-image';
 import { toHumanReadableRelativeTimeFromDate } from '@/utils/date';
 import {
@@ -17,11 +17,13 @@ import { useCurrentCredential } from '@/hooks/use-credential';
 import { MessageFeedbackDialog } from '@/app/components/base/modal/message-feedback-modal';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { cn } from '@/utils';
+import { useTheme } from '@/theme/theme-provider';
 
 export const ConversationMessages: FC<{ vag: VoiceAgent }> = ({ vag }) => {
   const messages = useAgentMessages(vag);
   const [searchParams] = useSearchParams();
   const { user } = useCurrentCredential();
+  const { theme } = useTheme();
   const queryName = searchParams.get('name');
   const ctrRef = useRef<HTMLDivElement>(null);
   /**
@@ -70,8 +72,12 @@ export const ConversationMessages: FC<{ vag: VoiceAgent }> = ({ vag }) => {
               {isUser ? (
                 <TextImage name={user?.name || queryName || 'user'} size={10} />
               ) : (
-                <div className="bg-blue-600 w-10 h-10 flex items-center justify-center rounded-xs">
-                  <RapidaIcon className="text-white h-full w-full p-1.5" />
+                <div className="bg-primary text-on-primary w-10 h-10 flex items-center justify-center rounded-xs">
+                  <BrandedLogo
+                    variant="compact"
+                    className="h-full w-full p-1.5 object-contain text-on-primary"
+                    textClassName="px-1 text-center text-[10px] leading-tight"
+                  />
                 </div>
               )}
             </div>
@@ -79,7 +85,7 @@ export const ConversationMessages: FC<{ vag: VoiceAgent }> = ({ vag }) => {
             {/* HEADER */}
             <div className="flex items-baseline gap-2">
               <div className="text-md font-semibold">
-                {isUser ? user?.name || queryName || 'User' : 'Rapida'}
+                {isUser ? user?.name || queryName || 'User' : theme.brand.name}
               </div>
               <span className="text-sm opacity-70">
                 {toHumanReadableRelativeTimeFromDate(group.items[0].time)}

--- a/ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx
@@ -26,8 +26,7 @@ import { Text } from '@/app/components/carbon/text';
 import { ArrowLeft } from '@carbon/icons-react';
 import { TextArea } from '@/app/components/carbon/form';
 import { CustomerOptions } from '@/app/components/navigation/actionable-header';
-import { RapidaIcon } from '@/app/components/Icon/Rapida';
-import { RapidaTextIcon } from '@/app/components/Icon/RapidaText';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -613,9 +612,9 @@ export const VoiceAgentDebugger: FC<{
   const metricCount = Object.keys(metrics).length;
 
   const deployment = assistant
-    ? (debug
+    ? ((debug
         ? assistant.getDebuggerdeployment()
-        : assistant.getApideployment()) ?? null
+        : assistant.getApideployment()) ?? null)
     : null;
   const stt = deployment?.getInputaudio() ?? null;
   const tts = deployment?.getOutputaudio() ?? null;
@@ -809,10 +808,13 @@ const AssistantPlaceholder: FC<{
 };
 
 export const PreviewAgentHeader: FC = () => (
-  <header className="flex h-12 shrink-0 items-center justify-between border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-    <div className="flex min-w-0 items-center gap-2 px-4 text-blue-600 dark:text-blue-500">
-      <RapidaIcon className="h-6 w-6 shrink-0" />
-      <RapidaTextIcon className="h-5 shrink-0" />
+  <header className="flex h-12 shrink-0 items-center justify-between border-b border-border-subtle bg-shell">
+    <div className="flex min-w-0 items-center px-4">
+      <BrandedLogo
+        variant="full"
+        className="h-6 w-auto max-w-[12rem] object-left"
+        textClassName="text-base"
+      />
     </div>
     <CustomerOptions showProjectSelector={false} />
   </header>

--- a/ui/src/app/pages/user/account-setting/account-setting.tsx
+++ b/ui/src/app/pages/user/account-setting/account-setting.tsx
@@ -113,7 +113,7 @@ export const AccountSetting = () => {
               <Input
                 disabled
                 value={user?.email}
-                placeholder="eg: john@rapida.ai"
+                placeholder="eg: john@example.com"
               ></Input>
             </FieldSet>
           </div>
@@ -158,7 +158,9 @@ export const AccountSetting = () => {
             </FieldSet>
           </div>
           <div className="flex-col gap-6">
-            <PrimaryButton size="md" renderIcon={ChevronRight}
+            <PrimaryButton
+              size="md"
+              renderIcon={ChevronRight}
               type="submit"
               form="account-settings-form"
               isLoading={loading}

--- a/ui/src/app/pages/workspace/access-security/index.tsx
+++ b/ui/src/app/pages/workspace/access-security/index.tsx
@@ -2,8 +2,12 @@ import React, { useState } from 'react';
 import { Switch } from '@headlessui/react';
 import { Helmet } from '@/app/components/helmet';
 import { DescriptiveHeading } from '@/app/components/heading/descriptive-heading';
+import { useDocumentationUrl } from '@/theme/documentation-url';
+
 export function AccessSecurityPage() {
   const [enabled, setEnabled] = useState(true);
+  const documentationUrl = useDocumentationUrl();
+
   return (
     <>
       <Helmet title="Organization Security"></Helmet>
@@ -25,7 +29,7 @@ export function AccessSecurityPage() {
                 organization's identity provider (SSO).
               </p>
               <a
-                href="https://docs.rapida.ai"
+                href={documentationUrl}
                 className="text-blue-600 dark:text-blue-400 text-sm flex items-center"
               >
                 Read the support documentation

--- a/ui/src/app/routes/onborading.tsx
+++ b/ui/src/app/routes/onborading.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/app/pages/user-onboarding';
 import { ProgressIndicator, ProgressStep, Tag } from '@carbon/react';
 import { useTheme } from '@/theme/theme-provider';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
 
 // ── Step definitions ──────────────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ const FEATURES = [
 
 export function OnboardingLayout() {
   const location = useLocation();
-  const { theme, resolvedMode } = useTheme();
+  const { theme } = useTheme();
 
   const currentStep =
     STEPS.find(s => location.pathname.includes(s.path))?.step ?? 1;
@@ -65,17 +66,12 @@ export function OnboardingLayout() {
 
         {/* Logo */}
         <div className="relative px-10 pt-10">
-          {theme.brand.logos ? (
-            <img
-              src={theme.brand.logos.full.dark}
-              alt={theme.brand.name}
-              className="h-8"
-            />
-          ) : (
-            <span className="text-lg font-semibold text-foreground">
-              {theme.brand.name}
-            </span>
-          )}
+          <BrandedLogo
+            variant="full"
+            colorMode="dark"
+            className="h-8"
+            textClassName="text-lg text-foreground"
+          />
         </div>
 
         {/* Tagline + feature highlights */}
@@ -112,17 +108,11 @@ export function OnboardingLayout() {
       <main className="flex-1 flex flex-col min-w-0">
         {/* Mobile header */}
         <div className="lg:hidden flex items-center justify-between px-6 py-4 border-b border-border-subtle">
-          {theme.brand.logos ? (
-            <img
-              src={theme.brand.logos.compact[resolvedMode]}
-              alt={theme.brand.name}
-              className="h-7 w-7 object-contain"
-            />
-          ) : (
-            <span className="font-semibold text-primary">
-              {theme.brand.name}
-            </span>
-          )}
+          <BrandedLogo
+            variant="compact"
+            className="h-7 w-7"
+            textClassName="text-sm"
+          />
           <Tag size="sm" type="blue">
             Step {currentStep} of {STEPS.length}
           </Tag>

--- a/ui/src/configs/config.development.json
+++ b/ui/src/configs/config.development.json
@@ -55,7 +55,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/ui/src/configs/config.production.json
+++ b/ui/src/configs/config.production.json
@@ -9,9 +9,7 @@
     },
     "analytics": {
         "dsn": "https://15153cb4befe6a0ae4249f10ff87c0b6@o4506771747831808.ingest.sentry.io/4506771748945920",
-        "tracePropagationTargets": [
-            "^https:\\/\\/rapida\\.ai\\/api"
-        ]
+        "tracePropagationTargets": ["^https:\\/\\/rapida\\.ai\\/api"]
     },
     "workspace": {
         "domain": "rapida.ai",
@@ -60,7 +58,7 @@
             "documentation": "https://doc.rapida.ai",
             "source": "https://github.com/rapidaai/voice-ai",
             "support": "mailto:prashant@rapida.ai",
-            "terms": "/static/terms-and-conditions",
+            "terms": "/static/terms-conditions",
             "privacy": "/static/privacy-policy"
         },
         "defaultMode": "system",

--- a/ui/src/theme/documentation-url.ts
+++ b/ui/src/theme/documentation-url.ts
@@ -1,0 +1,20 @@
+import { useTheme } from './theme-provider';
+
+const hasProtocol = (value: string) => /^[a-z][a-z0-9+.-]*:/i.test(value);
+
+const trimEndSlash = (value: string) => value.replace(/\/+$/, '');
+
+const trimStartSlash = (value: string) => value.replace(/^\/+/, '');
+
+export const buildDocumentationUrl = (documentationRoot: string, path = '') => {
+  if (!path) return documentationRoot;
+  if (hasProtocol(path)) return path;
+  if (documentationRoot === '#') return '#';
+
+  return `${trimEndSlash(documentationRoot)}/${trimStartSlash(path)}`;
+};
+
+export const useDocumentationUrl = (path = '') => {
+  const { theme } = useTheme();
+  return buildDocumentationUrl(theme.links.documentation, path);
+};


### PR DESCRIPTION
## Summary
- Implement RFC 0014 UI-only brand and theme customization.
- Route tenant-visible logos, preview chat identity, documentation links, auth legal links, and public LLM metadata through CONFIG.theme or neutral copy.
- Add a bounded brand-literal contract check with exact-literal exceptions and focused UI coverage.

## Verification
- cd ui && yarn test:theme-contract
- cd ui && yarn check:theme-contract
- cd ui && yarn test --watchAll=false --runTestsByPath src/app/components/navigation/header/__tests__/header.test.tsx src/app/components/navigation/sidebar/__tests__/sidebar-shell.test.tsx src/app/routes/__tests__/onborading.test.tsx src/app/pages/authentication/__tests__/sign-in-sign-up.test.tsx src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx src/app/pages/assistant/view/conversations/conversation-messages.helpers.test.ts
- cd ui && yarn checkTs
- cd ui && yarn test providers --watchAll=false --runInBand
- CI=true just agent-finalize "changed paths"