### PR TITLE
fix: complete debugger and account branding

### DIFF
--- a/ui/src/app/components/helmet/index.test.tsx
+++ b/ui/src/app/components/helmet/index.test.tsx
@@ -7,6 +7,14 @@ import { ThemeManifest } from '@/theme/types';
 import { Helmet } from './index';
 
 const theme = developmentConfig.theme as unknown as ThemeManifest;
+const tenantTheme: ThemeManifest = {
+  ...theme,
+  id: 'tenant-voice',
+  brand: {
+    ...theme.brand,
+    name: 'Tenant Voice',
+  },
+};
 
 const ModeToggle = () => {
   const { toggleMode } = useTheme();
@@ -35,23 +43,37 @@ describe('Helmet', () => {
       .forEach(icon => icon.remove());
   });
 
-  it('keeps the configured favicon owned by ThemeProvider', async () => {
+  it('uses the configured brand in the page title', async () => {
     render(
       <HelmetProvider>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={tenantTheme}>
           <Helmet title="Dashboard" />
           <ModeToggle />
         </ThemeProvider>
       </HelmetProvider>,
     );
 
-    await waitFor(() => expect(document.title).toBe('Dashboard - Rapida AI'));
+    await waitFor(() => expect(document.title).toBe('Dashboard - Tenant Voice'));
     const icons =
       document.querySelectorAll<HTMLLinkElement>("link[rel~='icon']");
     expect(icons).toHaveLength(1);
-    expect(icons[0].getAttribute('href')).toBe(theme.brand.favicon);
+    expect(icons[0].getAttribute('href')).toBe(tenantTheme.brand.favicon);
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle mode' }));
-    await waitFor(() => expect(document.title).toBe('Dashboard - Rapida AI'));
+    await waitFor(() =>
+      expect(document.title).toBe('Dashboard - Tenant Voice'),
+    );
+  });
+
+  it('uses only the configured brand when no page title is provided', async () => {
+    render(
+      <HelmetProvider>
+        <ThemeProvider theme={tenantTheme}>
+          <Helmet />
+        </ThemeProvider>
+      </HelmetProvider>,
+    );
+
+    await waitFor(() => expect(document.title).toBe('Tenant Voice'));
   });
 });

--- a/ui/src/app/components/navigation/actionable-header/__tests__/project-switch.test.tsx
+++ b/ui/src/app/components/navigation/actionable-header/__tests__/project-switch.test.tsx
@@ -164,7 +164,7 @@ describe('Actionable header project switcher', () => {
     expect(screen.queryByLabelText('Select a Project')).not.toBeInTheDocument();
   });
 
-  it('renders resource links without branding in the account panel', () => {
+  it('renders configured account links without documentation or source', () => {
     render(
       <AuthContext.Provider value={{}}>
         <CustomerOptions />
@@ -176,14 +176,8 @@ describe('Actionable header project switcher', () => {
     expect(
       screen.queryByRole('img', { name: 'Acme Voice' }),
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Documentation')).toHaveAttribute(
-      'href',
-      mockTheme.links.documentation,
-    );
-    expect(screen.getByLabelText('Source')).toHaveAttribute(
-      'href',
-      mockTheme.links.source,
-    );
+    expect(screen.queryByLabelText('Documentation')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Source')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Support')).toHaveAttribute(
       'href',
       mockTheme.links.support,

--- a/ui/src/app/components/navigation/actionable-header/index.tsx
+++ b/ui/src/app/components/navigation/actionable-header/index.tsx
@@ -140,22 +140,6 @@ export const CustomerOptions: FC<{
           <li className="cds--switcher__item--divider">
             <span className="uppercase!">Resources</span>
           </li>
-          <SwitcherItem
-            aria-label="Documentation"
-            href={theme.links.documentation}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </SwitcherItem>
-          <SwitcherItem
-            aria-label="Source"
-            href={theme.links.source}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Source
-          </SwitcherItem>
           <SwitcherItem aria-label="Support" href={theme.links.support}>
             Support
           </SwitcherItem>

--- a/ui/src/app/pages/preview-agent/voice-agent/__tests__/preview-agent-header.test.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/__tests__/preview-agent-header.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import developmentConfig from '@/configs/config.development.json';
+import { ThemeProvider } from '@/theme/theme-provider';
+import { ThemeManifest } from '@/theme/types';
+import { PreviewAgentHeader } from '../preview-agent-header';
+
+const theme = developmentConfig.theme as unknown as ThemeManifest;
+
+const tenantTheme: ThemeManifest = {
+  ...theme,
+  id: 'tenant-voice',
+  brand: {
+    ...theme.brand,
+    name: 'Tenant Voice',
+    logos: {
+      full: {
+        light: '/tenant/full-light.svg',
+        dark: '/tenant/full-dark.svg',
+      },
+      compact: {
+        light: '/tenant/compact-light.svg',
+        dark: '/tenant/compact-dark.svg',
+      },
+    },
+  },
+  defaultMode: 'light',
+};
+
+jest.mock('@/app/components/navigation/actionable-header', () => ({
+  CustomerOptions: () => <div>Customer options</div>,
+}));
+
+describe('PreviewAgentHeader', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
+  });
+
+  it('renders the configured full logo', () => {
+    render(
+      <ThemeProvider theme={tenantTheme}>
+        <PreviewAgentHeader />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('img', { name: 'Tenant Voice' })).toHaveAttribute(
+      'src',
+      '/tenant/full-light.svg',
+    );
+    expect(screen.queryByAltText('Rapida AI')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the configured brand name without logos', () => {
+    render(
+      <ThemeProvider
+        theme={{
+          ...tenantTheme,
+          brand: {
+            ...tenantTheme.brand,
+            logos: undefined,
+          },
+        }}
+      >
+        <PreviewAgentHeader />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Tenant Voice')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/pages/preview-agent/voice-agent/preview-agent-header.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/preview-agent-header.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { BrandedLogo } from '@/app/components/brand/branded-logo';
+import { CustomerOptions } from '@/app/components/navigation/actionable-header';
+
+export const PreviewAgentHeader: FC = () => (
+  <header className="flex h-12 shrink-0 items-center justify-between border-b border-border-subtle bg-shell">
+    <div className="flex min-w-0 items-center px-4">
+      <BrandedLogo
+        variant="full"
+        className="h-6 w-auto max-w-[12rem] object-left"
+        textClassName="text-base"
+      />
+    </div>
+    <CustomerOptions showProjectSelector={false} />
+  </header>
+);

--- a/ui/src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/text/conversations/__tests__/conversation-messages.test.tsx
@@ -1,6 +1,31 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import developmentConfig from '@/configs/config.development.json';
+import { ThemeProvider } from '@/theme/theme-provider';
+import { ThemeManifest } from '@/theme/types';
 import { ConversationMessages } from '../index';
+
+const theme = developmentConfig.theme as unknown as ThemeManifest;
+
+const tenantTheme: ThemeManifest = {
+  ...theme,
+  id: 'tenant-voice',
+  brand: {
+    ...theme.brand,
+    name: 'Tenant Voice',
+    logos: {
+      full: {
+        light: '/tenant/full-light.svg',
+        dark: '/tenant/full-dark.svg',
+      },
+      compact: {
+        light: '/tenant/compact-light.svg',
+        dark: '/tenant/compact-dark.svg',
+      },
+    },
+  },
+  defaultMode: 'light',
+};
 
 jest.mock('@uiw/react-markdown-preview', () => ({
   __esModule: true,
@@ -21,27 +46,6 @@ jest.mock('@/hooks/use-credential', () => ({
 
 jest.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams()],
-}));
-
-jest.mock('@/theme/theme-provider', () => ({
-  useTheme: () => ({
-    resolvedMode: 'light',
-    theme: {
-      brand: {
-        name: 'Tenant Voice',
-        logos: {
-          full: {
-            light: '/tenant/full-light.svg',
-            dark: '/tenant/full-dark.svg',
-          },
-          compact: {
-            light: '/tenant/compact-light.svg',
-            dark: '/tenant/compact-dark.svg',
-          },
-        },
-      },
-    },
-  }),
 }));
 
 jest.mock('@rapidaai/react', () => ({
@@ -74,8 +78,23 @@ jest.mock('@rapidaai/react', () => ({
 }));
 
 describe('ConversationMessages', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
+  });
+
   it('renders assistant identity from the configured theme', () => {
-    render(<ConversationMessages vag={{} as any} />);
+    render(
+      <ThemeProvider theme={tenantTheme}>
+        <ConversationMessages vag={{} as any} />
+      </ThemeProvider>,
+    );
 
     expect(screen.getByText('Tenant Voice')).toBeInTheDocument();
     expect(screen.getByAltText('Tenant Voice')).toHaveAttribute(

--- a/ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx
+++ b/ui/src/app/pages/preview-agent/voice-agent/voice-agent.tsx
@@ -25,8 +25,9 @@ import { Tabs } from '@/app/components/carbon/tabs';
 import { Text } from '@/app/components/carbon/text';
 import { ArrowLeft } from '@carbon/icons-react';
 import { TextArea } from '@/app/components/carbon/form';
-import { CustomerOptions } from '@/app/components/navigation/actionable-header';
-import { BrandedLogo } from '@/app/components/brand/branded-logo';
+import { PreviewAgentHeader } from './preview-agent-header';
+
+export { PreviewAgentHeader } from './preview-agent-header';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -806,19 +807,6 @@ const AssistantPlaceholder: FC<{
     </div>
   );
 };
-
-export const PreviewAgentHeader: FC = () => (
-  <header className="flex h-12 shrink-0 items-center justify-between border-b border-border-subtle bg-shell">
-    <div className="flex min-w-0 items-center px-4">
-      <BrandedLogo
-        variant="full"
-        className="h-6 w-auto max-w-[12rem] object-left"
-        textClassName="text-base"
-      />
-    </div>
-    <CustomerOptions showProjectSelector={false} />
-  </header>
-);
 
 const DebuggerScrollArea: FC<{ children: React.ReactNode }> = ({
   children,


### PR DESCRIPTION
## Summary
- isolate the debugger preview header so its branding contract can be tested directly
- verify debugger header and assistant message identity through the real ThemeProvider
- remove Documentation and Source from the account panel
- keep Support, Terms, and Privacy driven by configured theme links
- verify browser page titles use `theme.brand.name` instead of a hardcoded Rapida title

## Verification
- focused debugger branding tests pass
- focused account panel test passes
- focused configured page-title tests pass
- `cd ui && yarn check:theme-contract`
- `cd ui && yarn test:theme-contract`
- `cd ui && yarn checkTs`
- `CI=true just agent-finalize "changed paths"`