### PR TITLE
test: cover authenticated telephony callbacks

### DIFF
--- a/api/assistant-api/api/talk/callback_test.go
+++ b/api/assistant-api/api/talk/callback_test.go
@@ -12,24 +12,28 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rapidaai/api/assistant-api/config"
 	callcontext "github.com/rapidaai/api/assistant-api/internal/callcontext"
 	channel_telephony "github.com/rapidaai/api/assistant-api/internal/channel/telephony"
+	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/types"
 )
 
 type callbackCallContextStore struct {
 	callContext *callcontext.CallContext
+	updates     []callcontext.CallStatusUpdate
 }
 
-func (store callbackCallContextStore) Save(context.Context, *callcontext.CallContext) (string, error) {
+func (store *callbackCallContextStore) Save(context.Context, *callcontext.CallContext) (string, error) {
 	return "", errors.New("not used")
 }
 
-func (store callbackCallContextStore) Get(context.Context, string) (*callcontext.CallContext, error) {
+func (store *callbackCallContextStore) Get(context.Context, string) (*callcontext.CallContext, error) {
 	return store.callContext, nil
 }
 
-func (store callbackCallContextStore) GetByChannelUUID(context.Context, string, uint64, string) (*callcontext.CallContext, error) {
+func (store *callbackCallContextStore) GetByChannelUUID(context.Context, string, uint64, string) (*callcontext.CallContext, error) {
 	return store.callContext, nil
 }
 
@@ -49,7 +53,7 @@ func TestUniversalCallbackDoesNotLogPersistedAuthenticationMetadata(t *testing.T
 	maliciousAuthType := "invalid-auth-type\nFORGED AUTH LOG ENTRY"
 	api := &ConversationApi{
 		logger: logger,
-		callContextStore: callbackCallContextStore{
+		callContextStore: &callbackCallContextStore{
 			callContext: &callcontext.CallContext{ContextID: maliciousContextID, AuthType: maliciousAuthType},
 		},
 		inboundDispatcher: channel_telephony.NewInboundDispatcher(channel_telephony.WithLogger(logger)),
@@ -76,16 +80,17 @@ func TestUniversalCallbackDoesNotLogPersistedAuthenticationMetadata(t *testing.T
 	}
 }
 
-func (store callbackCallContextStore) Claim(context.Context, string) (*callcontext.CallContext, error) {
+func (store *callbackCallContextStore) Claim(context.Context, string) (*callcontext.CallContext, error) {
 	return nil, errors.New("not used")
 }
 
-func (store callbackCallContextStore) UpdateField(context.Context, string, string, string) error {
+func (store *callbackCallContextStore) UpdateField(context.Context, string, string, string) error {
 	return errors.New("not used")
 }
 
-func (store callbackCallContextStore) UpdateCallStatus(context.Context, string, callcontext.CallStatusUpdate) error {
-	return errors.New("not used")
+func (store *callbackCallContextStore) UpdateCallStatus(_ context.Context, _ string, update callcontext.CallStatusUpdate) error {
+	store.updates = append(store.updates, update)
+	return nil
 }
 
 func TestCallbackByContextDoesNotLogUserProvidedContextID(t *testing.T) {
@@ -104,7 +109,7 @@ func TestCallbackByContextDoesNotLogUserProvidedContextID(t *testing.T) {
 	maliciousAuthType := "invalid-auth-type\nFORGED AUTH LOG ENTRY"
 	api := &ConversationApi{
 		logger: logger,
-		callContextStore: callbackCallContextStore{
+		callContextStore: &callbackCallContextStore{
 			callContext: &callcontext.CallContext{ContextID: maliciousContextID, AuthType: maliciousAuthType},
 		},
 	}
@@ -127,5 +132,136 @@ func TestCallbackByContextDoesNotLogUserProvidedContextID(t *testing.T) {
 	}
 	if strings.Contains(string(logData), maliciousContextID) || strings.Contains(string(logData), maliciousAuthType) || strings.Contains(string(logData), "FORGED") {
 		t.Fatalf("user-provided callback data was written to logs: %s", logData)
+	}
+}
+
+func TestCallbackByContextRestoresAuthenticationForEveryProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger(commons.EnableConsole(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	providerRequests := []struct {
+		name        string
+		method      string
+		body        string
+		contentType string
+	}{
+		{name: "twilio", method: http.MethodPost, body: "CallSid=twilio-call&CallStatus=completed", contentType: "application/x-www-form-urlencoded"},
+		{name: "exotel", method: http.MethodPost, body: "CallSid=exotel-call&Status=completed", contentType: "application/x-www-form-urlencoded"},
+		{name: "vonage", method: http.MethodGet, body: "status=completed&uuid=vonage-call&duration=1"},
+		{name: "telnyx", method: http.MethodPost, body: `{"data":{"event_type":"call.hangup","payload":{"call_control_id":"telnyx-call"}}}`, contentType: "application/json"},
+		{name: "asterisk", method: http.MethodPost, body: `{"type":"ChannelDestroyed","channel":{"id":"asterisk-call"},"cause":16,"cause_txt":"NORMAL_CLEARING"}`, contentType: "application/json"},
+		{name: "sip", method: http.MethodPost, body: `{"event":"completed","call_id":"sip-call"}`, contentType: "application/json"},
+		{name: "vobiz", method: http.MethodPost, body: "Event=Hangup&CallUUID=vobiz-call&CallStatus=completed", contentType: "application/x-www-form-urlencoded"},
+	}
+
+	projectActorType := types.ActorTypeProject.String()
+	userActorType := types.ActorTypeUser.String()
+	userID := uint64(31)
+	authContexts := []struct {
+		name       string
+		authType   types.AuthType
+		authUserID *uint64
+		actorType  *string
+		actorID    uint64
+	}{
+		{name: "project API key", authType: types.AuthTypeProject, actorType: &projectActorType, actorID: 41},
+		{name: "personal access token", authType: types.AuthTypeUser, authUserID: &userID, actorType: &userActorType, actorID: userID},
+	}
+
+	for _, authContext := range authContexts {
+		for _, providerRequest := range providerRequests {
+			t.Run(authContext.name+"/"+providerRequest.name, func(t *testing.T) {
+				store := &callbackCallContextStore{callContext: &callcontext.CallContext{
+					ContextID:      "callback-context",
+					AssistantID:    11,
+					ConversationID: 22,
+					ProjectID:      21,
+					OrganizationID: 20,
+					AuthType:       authContext.authType.String(),
+					AuthUserID:     authContext.authUserID,
+					AuthActorType:  authContext.actorType,
+					AuthActorID:    &authContext.actorID,
+					Provider:       providerRequest.name,
+					Direction:      "outbound",
+				}}
+				api := &ConversationApi{
+					cfg:              &config.AssistantConfig{},
+					logger:           logger,
+					callContextStore: store,
+					inboundDispatcher: channel_telephony.NewInboundDispatcher(
+						channel_telephony.WithConfig(&config.AssistantConfig{}),
+						channel_telephony.WithLogger(logger),
+						channel_telephony.WithTelephonyOption(channel_telephony.TelephonyOption{SIPServer: &sip_infra.Server{}}),
+					),
+				}
+
+				requestTarget := "/callback"
+				requestBody := strings.NewReader(providerRequest.body)
+				if providerRequest.method == http.MethodGet {
+					requestTarget += "?" + providerRequest.body
+					requestBody = strings.NewReader("")
+				}
+				recorder := httptest.NewRecorder()
+				ginContext, _ := gin.CreateTestContext(recorder)
+				ginContext.Request = httptest.NewRequest(providerRequest.method, requestTarget, requestBody)
+				if providerRequest.contentType != "" {
+					ginContext.Request.Header.Set("Content-Type", providerRequest.contentType)
+				}
+				ginContext.Params = gin.Params{{Key: "contextId", Value: store.callContext.ContextID}}
+
+				api.CallbackByContext(ginContext)
+
+				if recorder.Code < http.StatusOK || recorder.Code >= http.StatusMultipleChoices {
+					t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+				}
+				if len(store.updates) != 1 || store.updates[0].CallStatus != callcontext.CallStatusCompleted {
+					t.Fatalf("updates = %+v, want one completed update", store.updates)
+				}
+			})
+		}
+	}
+}
+
+func TestCallbackByContextRejectsInvalidStoredAuthenticationForEveryProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger(commons.EnableConsole(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, provider := range []string{"twilio", "exotel", "vonage", "telnyx", "asterisk", "sip", "vobiz"} {
+		t.Run(provider, func(t *testing.T) {
+			store := &callbackCallContextStore{callContext: &callcontext.CallContext{
+				ContextID:      "invalid-auth-context",
+				AssistantID:    11,
+				ConversationID: 22,
+				Provider:       provider,
+			}}
+			api := &ConversationApi{
+				logger:           logger,
+				callContextStore: store,
+				inboundDispatcher: channel_telephony.NewInboundDispatcher(
+					channel_telephony.WithConfig(&config.AssistantConfig{}),
+					channel_telephony.WithLogger(logger),
+					channel_telephony.WithTelephonyOption(channel_telephony.TelephonyOption{SIPServer: &sip_infra.Server{}}),
+				),
+			}
+			recorder := httptest.NewRecorder()
+			ginContext, _ := gin.CreateTestContext(recorder)
+			ginContext.Request = httptest.NewRequest(http.MethodPost, "/callback", nil)
+			ginContext.Params = gin.Params{{Key: "contextId", Value: store.callContext.ContextID}}
+
+			api.CallbackByContext(ginContext)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+			if len(store.updates) != 0 {
+				t.Fatalf("unexpected updates: %+v", store.updates)
+			}
+		})
 	}
 }

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -113,6 +113,87 @@ INSERT INTO user_project_roles (id,project_id,user_auth_id,role,status,created_a
 SQL
 }
 
+seed_telephony_callback_contexts() {
+  psql -v ON_ERROR_STOP=1 -h postgres -U rapida_user -d assistant_db >/dev/null <<SQL
+DELETE FROM call_contexts WHERE context_id LIKE 'ci-project-%' OR context_id LIKE 'ci-pat-%';
+INSERT INTO call_contexts (id,context_id,assistant_id,conversation_id,project_id,organization_id,auth_type,auth_user_id,auth_actor_type,auth_actor_id,provider,direction) VALUES
+  (7000001,'ci-project-twilio',1,1,1,1,'project',NULL,'project',1,'twilio','outbound'),
+  (7000002,'ci-project-exotel',1,1,1,1,'project',NULL,'project',1,'exotel','outbound'),
+  (7000003,'ci-project-vonage',1,1,1,1,'project',NULL,'project',1,'vonage','outbound'),
+  (7000004,'ci-project-telnyx',1,1,1,1,'project',NULL,'project',1,'telnyx','outbound'),
+  (7000005,'ci-project-asterisk',1,1,1,1,'project',NULL,'project',1,'asterisk','outbound'),
+  (7000006,'ci-project-sip',1,1,1,1,'project',NULL,'project',1,'sip','outbound'),
+  (7000007,'ci-project-vobiz',1,1,1,1,'project',NULL,'project',1,'vobiz','outbound'),
+  (7000008,'ci-pat-twilio',1,1,1,1,'user',1,'user',1,'twilio','outbound'),
+  (7000009,'ci-pat-exotel',1,1,1,1,'user',1,'user',1,'exotel','outbound'),
+  (7000010,'ci-pat-vonage',1,1,1,1,'user',1,'user',1,'vonage','outbound'),
+  (7000011,'ci-pat-telnyx',1,1,1,1,'user',1,'user',1,'telnyx','outbound'),
+  (7000012,'ci-pat-asterisk',1,1,1,1,'user',1,'user',1,'asterisk','outbound'),
+  (7000013,'ci-pat-sip',1,1,1,1,'user',1,'user',1,'sip','outbound'),
+  (7000014,'ci-pat-vobiz',1,1,1,1,'user',1,'user',1,'vobiz','outbound');
+SQL
+}
+
+check_telephony_callback() {
+  callback_auth=$1
+  callback_provider=$2
+  callback_method=$3
+  callback_payload=$4
+  callback_content_type=$5
+  callback_context_id="ci-$callback_auth-$callback_provider"
+  callback_body_file="$temporary_directory/$callback_context_id.body"
+  callback_url="http://assistant-api:9007/v1/talk/$callback_provider/ctx/$callback_context_id/event"
+
+  if [ "$callback_method" = 'GET' ]; then
+    callback_status=$(curl --silent --show-error --output "$callback_body_file" --write-out '%{http_code}' \
+      "$callback_url?$callback_payload")
+  else
+    callback_status=$(curl --silent --show-error --output "$callback_body_file" --write-out '%{http_code}' \
+      --request POST --header "Content-Type: $callback_content_type" --data "$callback_payload" "$callback_url")
+  fi
+
+  case "$callback_status" in
+    2??) ;;
+    *)
+      printf '%s callback with %s auth returned HTTP %s: ' "$callback_provider" "$callback_auth" "$callback_status" >&2
+      cat "$callback_body_file" >&2
+      return 1
+      ;;
+  esac
+
+  callback_call_status=$(psql -v ON_ERROR_STOP=1 -h postgres -U rapida_user -d assistant_db -Atc \
+    "SELECT call_status FROM call_contexts WHERE context_id = '$callback_context_id'")
+  if [ "$callback_call_status" != 'completed' ]; then
+    printf '%s callback with %s auth stored status %s; expected completed\n' \
+      "$callback_provider" "$callback_auth" "$callback_call_status" >&2
+    return 1
+  fi
+  printf '%s callback with %s auth passed\n' "$callback_provider" "$callback_auth"
+}
+
+run_telephony_callback_smoke() {
+  seed_telephony_callback_contexts
+
+  for callback_auth in project pat; do
+    check_telephony_callback "$callback_auth" twilio POST \
+      'CallSid=twilio-call&CallStatus=completed' 'application/x-www-form-urlencoded'
+    check_telephony_callback "$callback_auth" exotel POST \
+      'CallSid=exotel-call&Status=completed' 'application/x-www-form-urlencoded'
+    check_telephony_callback "$callback_auth" vonage GET \
+      'status=completed&uuid=vonage-call&duration=1' ''
+    check_telephony_callback "$callback_auth" telnyx POST \
+      '{"data":{"event_type":"call.hangup","payload":{"call_control_id":"telnyx-call"}}}' 'application/json'
+    check_telephony_callback "$callback_auth" asterisk POST \
+      '{"type":"ChannelDestroyed","channel":{"id":"asterisk-call"},"cause":16,"cause_txt":"NORMAL_CLEARING"}' 'application/json'
+    check_telephony_callback "$callback_auth" sip POST \
+      '{"event":"completed","call_id":"sip-call"}' 'application/json'
+    check_telephony_callback "$callback_auth" vobiz POST \
+      'Event=Hangup&CallUUID=vobiz-call&CallStatus=completed' 'application/x-www-form-urlencoded'
+  done
+
+  echo 'All authenticated telephony callback smoke tests passed'
+}
+
 run_integration_checks() {
   redis_response=$(redis-cli -h redis ping)
   [ "$redis_response" = 'PONG' ] || {
@@ -169,6 +250,9 @@ run_smoke_tests() {
 
   echo 'Running released Node SDK smoke tests with both authentication methods'
   node /workspace/sdk-smoke.js
+
+  echo 'Running telephony callback smoke tests with stored project and PAT authentication'
+  run_telephony_callback_smoke
 
   echo 'All smoke tests passed'
 }


### PR DESCRIPTION
## Summary
- add API-level callback coverage for Twilio, Exotel, Vonage, Telnyx, Asterisk, SIP, and Vobiz
- verify callback context authentication restoration for project API keys and personal access tokens
- add Docker-backed smoke coverage that invokes every provider callback and verifies persisted completion status
- verify invalid stored authentication is rejected before callback processing

## Verification
- `go test ./api/assistant-api/api/talk ./api/assistant-api/internal/channel/telephony/... -count=1`
- `just ci-smoke`
- `just agent-finalize 'api/assistant-api/api/talk/callback_test.go,tests/smoke/run.sh'`
- `just ci`
