### PR TITLE
fix: record failed callback conversation status

### DIFF
--- a/.github/workflows/reusable-end-to-end-ci.yml
+++ b/.github/workflows/reusable-end-to-end-ci.yml
@@ -98,3 +98,45 @@ jobs:
           path: smoke-diagnostics
           if-no-files-found: error
           retention-days: 7
+
+  telephony-callbacks:
+    name: Telephony Callback Integration
+    needs: smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      COMPOSE_PROJECT_NAME: rapida-telephony-callbacks-${{ github.run_id }}-${{ github.run_attempt }}
+      CI_STACK_AUTH_TOKEN: ci-telephony-callbacks-${{ github.run_id }}-${{ github.run_attempt }}
+      CI_STACK_PROJECT_API_KEY: ci-telephony-callbacks-project-${{ github.run_id }}-${{ github.run_attempt }}
+      CI_STACK_CACHE_SCOPE: end-to-end-${{ github.run_id }}-${{ github.run_attempt }}
+      CI_STACK_DIAGNOSTICS_DIR: ${{ github.workspace }}/telephony-callback-diagnostics
+      CI_STACK_REPORTS_DIR: ${{ github.workspace }}/telephony-callback-reports
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Set up Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
+        with:
+          just-version: "1.58.0"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        with:
+          name: rapida-telephony-callbacks-${{ github.run_id }}-${{ github.run_attempt }}
+          driver: docker-container
+          install: true
+
+      - name: Run telephony callback integration tests
+        run: just ci-telephony-callbacks
+
+      - name: Upload telephony callback diagnostics
+        if: failure() && hashFiles('telephony-callback-diagnostics/**') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: telephony-callback-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: telephony-callback-diagnostics
+          if-no-files-found: error
+          retention-days: 7

--- a/api/assistant-api/api/talk/callback.go
+++ b/api/assistant-api/api/talk/callback.go
@@ -135,7 +135,7 @@ func (cApi *ConversationApi) UnviersalCallback(c *gin.Context) {
 				ConversationID: cc.ConversationID,
 			},
 			observability.RecordMetric{
-				Metrics: observability.CallStatusMetric(observability.MetricCallStatusFailed, statusInfo.Error.Reason),
+				Metrics: failedCallbackMetrics(statusInfo.Error.Reason),
 			})
 		if validator.NotBlank(statusInfo.Error.Reason) {
 			observer.Record(c,
@@ -355,7 +355,7 @@ func (cApi *ConversationApi) CallbackByContext(c *gin.Context) {
 				ConversationID: cc.ConversationID,
 			},
 			observability.RecordMetric{
-				Metrics: observability.CallStatusMetric(observability.MetricCallStatusFailed, statusInfo.Error.Reason),
+				Metrics: failedCallbackMetrics(statusInfo.Error.Reason),
 			})
 		if validator.NotBlank(statusInfo.Error.Reason) {
 			observer.Record(c, observability.ConversationScope{
@@ -456,4 +456,13 @@ func (cApi *ConversationApi) CallbackByContext(c *gin.Context) {
 		cApi.logger.Warnf("failed to close callback observability recorder: %v", err)
 	}
 	c.Status(http.StatusCreated)
+}
+
+func failedCallbackMetrics(reason string) []*protos.Metric {
+	metrics := observability.CallStatusMetric(observability.MetricCallStatusFailed, reason)
+	return append(metrics, &protos.Metric{
+		Name:        observability.MetricConversationStatus,
+		Value:       observability.MetricCallStatusFailed,
+		Description: reason,
+	})
 }

--- a/api/assistant-api/api/talk/callback.go
+++ b/api/assistant-api/api/talk/callback.go
@@ -135,7 +135,11 @@ func (cApi *ConversationApi) UnviersalCallback(c *gin.Context) {
 				ConversationID: cc.ConversationID,
 			},
 			observability.RecordMetric{
-				Metrics: failedCallbackMetrics(statusInfo.Error.Reason),
+				Metrics: append(observability.CallStatusMetric(observability.MetricCallStatusFailed, statusInfo.Error.Reason), &protos.Metric{
+					Name:        observability.MetricConversationStatus,
+					Value:       observability.MetricCallStatusFailed,
+					Description: statusInfo.Error.Reason,
+				}),
 			})
 		if validator.NotBlank(statusInfo.Error.Reason) {
 			observer.Record(c,
@@ -355,7 +359,11 @@ func (cApi *ConversationApi) CallbackByContext(c *gin.Context) {
 				ConversationID: cc.ConversationID,
 			},
 			observability.RecordMetric{
-				Metrics: failedCallbackMetrics(statusInfo.Error.Reason),
+				Metrics: append(observability.CallStatusMetric(observability.MetricCallStatusFailed, statusInfo.Error.Reason), &protos.Metric{
+					Name:        observability.MetricConversationStatus,
+					Value:       observability.MetricCallStatusFailed,
+					Description: statusInfo.Error.Reason,
+				}),
 			})
 		if validator.NotBlank(statusInfo.Error.Reason) {
 			observer.Record(c, observability.ConversationScope{
@@ -456,13 +464,4 @@ func (cApi *ConversationApi) CallbackByContext(c *gin.Context) {
 		cApi.logger.Warnf("failed to close callback observability recorder: %v", err)
 	}
 	c.Status(http.StatusCreated)
-}
-
-func failedCallbackMetrics(reason string) []*protos.Metric {
-	metrics := observability.CallStatusMetric(observability.MetricCallStatusFailed, reason)
-	return append(metrics, &protos.Metric{
-		Name:        observability.MetricConversationStatus,
-		Value:       observability.MetricCallStatusFailed,
-		Description: reason,
-	})
 }

--- a/api/assistant-api/api/talk/callback_test.go
+++ b/api/assistant-api/api/talk/callback_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rapidaai/api/assistant-api/config"
 	callcontext "github.com/rapidaai/api/assistant-api/internal/callcontext"
 	channel_telephony "github.com/rapidaai/api/assistant-api/internal/channel/telephony"
+	"github.com/rapidaai/api/assistant-api/internal/observability"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
@@ -263,5 +264,28 @@ func TestCallbackByContextRejectsInvalidStoredAuthenticationForEveryProvider(t *
 				t.Fatalf("unexpected updates: %+v", store.updates)
 			}
 		})
+	}
+}
+
+func TestFailedCallbackMetricsIncludesCallAndConversationStatus(t *testing.T) {
+	metrics := failedCallbackMetrics("busy")
+	if len(metrics) != 2 {
+		t.Fatalf("metric count = %d, want 2", len(metrics))
+	}
+
+	values := make(map[string]string, len(metrics))
+	descriptions := make(map[string]string, len(metrics))
+	for _, metric := range metrics {
+		values[metric.GetName()] = metric.GetValue()
+		descriptions[metric.GetName()] = metric.GetDescription()
+	}
+
+	for _, name := range []string{observability.MetricCallStatus, observability.MetricConversationStatus} {
+		if values[name] != observability.MetricCallStatusFailed {
+			t.Errorf("metric %q = %q, want %q", name, values[name], observability.MetricCallStatusFailed)
+		}
+		if descriptions[name] != "busy" {
+			t.Errorf("metric %q description = %q, want busy", name, descriptions[name])
+		}
 	}
 }

--- a/api/assistant-api/api/talk/callback_test.go
+++ b/api/assistant-api/api/talk/callback_test.go
@@ -311,11 +311,6 @@ func TestCallbackByContextRejectsInvalidStoredAuthenticationForEveryProvider(t *
 	}
 }
 
-func TestFailedCallbackMetricsIncludesCallAndConversationStatus(t *testing.T) {
-	metrics := failedCallbackMetrics("busy")
-	assertFailedStatusMetrics(t, metrics, "busy")
-}
-
 func TestFailedCallbacksPersistCallAndConversationStatus(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logger, err := commons.NewApplicationLogger(commons.EnableConsole(false))

--- a/api/assistant-api/api/talk/callback_test.go
+++ b/api/assistant-api/api/talk/callback_test.go
@@ -9,21 +9,65 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rapidaai/api/assistant-api/config"
 	callcontext "github.com/rapidaai/api/assistant-api/internal/callcontext"
 	channel_telephony "github.com/rapidaai/api/assistant-api/internal/channel/telephony"
+	internal_conversation_entity "github.com/rapidaai/api/assistant-api/internal/entity/conversations"
 	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_services "github.com/rapidaai/api/assistant-api/internal/services"
 	sip_infra "github.com/rapidaai/api/assistant-api/sip/infra"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/types"
+	"github.com/rapidaai/protos"
 )
 
 type callbackCallContextStore struct {
 	callContext *callcontext.CallContext
 	updates     []callcontext.CallStatusUpdate
+}
+
+type callbackConversationServiceStub struct {
+	internal_services.AssistantConversationService
+
+	mu             sync.Mutex
+	metrics        []*protos.Metric
+	metricRecorded chan struct{}
+	metricOnce     sync.Once
+}
+
+func (service *callbackConversationServiceStub) CreateOrUpdateConversationMetrics(
+	_ context.Context,
+	_ *types.Authentication,
+	_ uint64,
+	_ uint64,
+	metrics []*protos.Metric,
+) ([]*internal_conversation_entity.AssistantConversationMetric, error) {
+	service.mu.Lock()
+	service.metrics = append(service.metrics, metrics...)
+	service.mu.Unlock()
+	service.metricOnce.Do(func() { close(service.metricRecorded) })
+	return nil, nil
+}
+
+func (service *callbackConversationServiceStub) CreateOrUpdateConversationMetadata(
+	context.Context,
+	*types.Authentication,
+	uint64,
+	uint64,
+	[]*protos.Metadata,
+) ([]*internal_conversation_entity.AssistantConversationMetadata, error) {
+	return nil, nil
+}
+
+func (service *callbackConversationServiceStub) recordedMetrics() []*protos.Metric {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	return append([]*protos.Metric(nil), service.metrics...)
 }
 
 func (store *callbackCallContextStore) Save(context.Context, *callcontext.CallContext) (string, error) {
@@ -269,6 +313,94 @@ func TestCallbackByContextRejectsInvalidStoredAuthenticationForEveryProvider(t *
 
 func TestFailedCallbackMetricsIncludesCallAndConversationStatus(t *testing.T) {
 	metrics := failedCallbackMetrics("busy")
+	assertFailedStatusMetrics(t, metrics, "busy")
+}
+
+func TestFailedCallbacksPersistCallAndConversationStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger, err := commons.NewApplicationLogger(commons.EnableConsole(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		target string
+		params gin.Params
+		invoke func(*ConversationApi, *gin.Context)
+	}{
+		{
+			name:   "context callback",
+			target: "/callback",
+			params: gin.Params{{Key: "contextId", Value: "callback-context"}},
+			invoke: (*ConversationApi).CallbackByContext,
+		},
+		{
+			name:   "catch-all callback",
+			target: "/callback?CallSid=twilio-call&CallStatus=busy",
+			params: gin.Params{{Key: "telephony", Value: "twilio"}, {Key: "assistantId", Value: "11"}},
+			invoke: (*ConversationApi).UnviersalCallback,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actorType := types.ActorTypeProject.String()
+			actorID := uint64(41)
+			store := &callbackCallContextStore{callContext: &callcontext.CallContext{
+				ContextID:      "callback-context",
+				AssistantID:    11,
+				ConversationID: 22,
+				ProjectID:      21,
+				OrganizationID: 20,
+				AuthType:       types.AuthTypeProject.String(),
+				AuthActorType:  &actorType,
+				AuthActorID:    &actorID,
+				Provider:       "twilio",
+				Direction:      "outbound",
+			}}
+			conversationService := &callbackConversationServiceStub{metricRecorded: make(chan struct{})}
+			api := &ConversationApi{
+				cfg:                          &config.AssistantConfig{},
+				logger:                       logger,
+				callContextStore:             store,
+				assistantConversationService: conversationService,
+				inboundDispatcher: channel_telephony.NewInboundDispatcher(
+					channel_telephony.WithConfig(&config.AssistantConfig{}),
+					channel_telephony.WithLogger(logger),
+				),
+			}
+
+			requestBody := strings.NewReader("CallSid=twilio-call&CallStatus=busy")
+			if test.name == "catch-all callback" {
+				requestBody = strings.NewReader("")
+			}
+			recorder := httptest.NewRecorder()
+			ginContext, _ := gin.CreateTestContext(recorder)
+			ginContext.Request = httptest.NewRequest(http.MethodPost, test.target, requestBody)
+			ginContext.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			ginContext.Params = test.params
+
+			test.invoke(api, ginContext)
+
+			if recorder.Code < http.StatusOK || recorder.Code >= http.StatusMultipleChoices {
+				t.Fatalf("status = %d, want 2xx", recorder.Code)
+			}
+			if len(store.updates) != 1 || store.updates[0].CallStatus != callcontext.CallStatusFailed {
+				t.Fatalf("updates = %+v, want one failed update", store.updates)
+			}
+			select {
+			case <-conversationService.metricRecorded:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for callback metrics")
+			}
+			assertFailedStatusMetrics(t, conversationService.recordedMetrics(), "busy")
+		})
+	}
+}
+
+func assertFailedStatusMetrics(t *testing.T, metrics []*protos.Metric, reason string) {
+	t.Helper()
 	if len(metrics) != 2 {
 		t.Fatalf("metric count = %d, want 2", len(metrics))
 	}
@@ -284,8 +416,8 @@ func TestFailedCallbackMetricsIncludesCallAndConversationStatus(t *testing.T) {
 		if values[name] != observability.MetricCallStatusFailed {
 			t.Errorf("metric %q = %q, want %q", name, values[name], observability.MetricCallStatusFailed)
 		}
-		if descriptions[name] != "busy" {
-			t.Errorf("metric %q description = %q, want busy", name, descriptions[name])
+		if descriptions[name] != reason {
+			t.Errorf("metric %q description = %q, want %q", name, descriptions[name], reason)
 		}
 	}
 }

--- a/just/ci-stack.sh
+++ b/just/ci-stack.sh
@@ -3,9 +3,9 @@ set -Eeuo pipefail
 
 bash just/require-docker.sh
 
-mode=${1:?usage: ci-stack.sh <build|integration|smoke>}
+mode=${1:?usage: ci-stack.sh <build|integration|smoke|telephony-callbacks>}
 case "$mode" in
-  build | integration | smoke) ;;
+  build | integration | smoke | telephony-callbacks) ;;
   *)
     printf 'unsupported CI stack mode: %s\n' "$mode" >&2
     exit 2
@@ -56,7 +56,8 @@ chmod 0777 "$CI_STACK_REPORTS_DIR"
 
 "${compose[@]}" config --quiet
 bash -n tests/smoke/run.sh
-bash just/shellcheck.sh tests/smoke/run.sh
+bash -n tests/integration/telephony/*/run.sh
+bash just/shellcheck.sh tests/smoke/run.sh tests/integration/telephony/*/run.sh
 ./bin/check-go-version-consistency
 ./docker/assistant-api/scripts/verify-native-deps.sh docker/assistant-api/native-deps.lock
 bash just/ci-python.sh openapi/scripts/generate_assistant_postman_collection.py --check

--- a/just/ci.just
+++ b/just/ci.just
@@ -1,7 +1,7 @@
 go_ci_packages := "./api/web-api/... ./api/integration-api/... ./api/endpoint-api/... ./pkg/... ./cmd/web/... ./cmd/integration/... ./cmd/endpoint/... ./config/..."
 
 # Run every required CI stage locally in production order.
-ci: ci-doctor ci-basics ci-docker ci-single-service ci-integration ci-smoke
+ci: ci-doctor ci-basics ci-docker ci-single-service ci-integration ci-smoke ci-telephony-callbacks
 
 # Run repository, Go, UI, and contract checks.
 ci-basics: ci-check ci-repository ci-go ci-ui ci-contracts
@@ -129,3 +129,7 @@ ci-integration:
 # Build every service and run REST and SDK smoke tests with all supported authentication methods.
 ci-smoke:
     bash just/ci-stack.sh smoke
+
+# Run provider callback integration tests against the complete service stack.
+ci-telephony-callbacks:
+    bash just/ci-stack.sh telephony-callbacks

--- a/tests/integration/telephony/asterisk-callback/run.sh
+++ b/tests/integration/telephony/asterisk-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" asterisk

--- a/tests/integration/telephony/callbacks/run.sh
+++ b/tests/integration/telephony/callbacks/run.sh
@@ -85,7 +85,8 @@ send_post_callback() {
   content_type=$3
   payload=$4
   response_file="$temporary_directory/$context_id.response"
-  http_status=$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+  http_status=$(curl --silent --show-error --connect-timeout 2 --max-time 10 \
+    --output "$response_file" --write-out '%{http_code}' \
     --request POST --header "Content-Type: $content_type" --data-binary "$payload" \
     "$assistant_api_url/v1/talk/$provider/ctx/$context_id/event")
 
@@ -97,7 +98,8 @@ send_get_callback() {
   context_id=$2
   query_string=$3
   response_file="$temporary_directory/$context_id.response"
-  http_status=$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+  http_status=$(curl --silent --show-error --connect-timeout 2 --max-time 10 \
+    --output "$response_file" --write-out '%{http_code}' \
     "$assistant_api_url/v1/talk/$provider/ctx/$context_id/event?$query_string")
 
   assert_callback_accepted "$provider" "$http_status" "$response_file"

--- a/tests/integration/telephony/callbacks/run.sh
+++ b/tests/integration/telephony/callbacks/run.sh
@@ -1,0 +1,257 @@
+#!/bin/sh
+set -eu
+
+readonly assistant_api_url="${ASSISTANT_API_URL:-http://assistant-api:9007}"
+readonly postgres_host="${POSTGRES_HOST:-postgres}"
+readonly postgres_user="${POSTGRES_USER:-rapida_user}"
+readonly postgres_database="${POSTGRES_DATABASE:-assistant_db}"
+readonly requested_provider="${1:-all}"
+readonly conversation_ids='7100001,7100002,7100003,7100004,7100005,7100006,7100007,7100008'
+
+temporary_directory=$(mktemp -d)
+failures=0
+
+query() {
+  psql -v ON_ERROR_STOP=1 -h "$postgres_host" -U "$postgres_user" -d "$postgres_database" -Atc "$1"
+}
+
+cleanup() {
+  query "DELETE FROM assistant_conversation_metadata WHERE assistant_conversation_id IN ($conversation_ids)" >/dev/null || true
+  query "DELETE FROM assistant_conversation_metrics WHERE assistant_conversation_id IN ($conversation_ids)" >/dev/null || true
+  query "DELETE FROM call_contexts WHERE conversation_id IN ($conversation_ids)" >/dev/null || true
+  query "DELETE FROM assistant_conversations WHERE id IN ($conversation_ids)" >/dev/null || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT HUP INT TERM
+
+wait_for_value() {
+  description=$1
+  sql=$2
+  expected=$3
+  attempts=10
+  actual=''
+
+  while [ "$attempts" -gt 0 ]; do
+    actual=$(query "$sql")
+    if [ "$actual" = "$expected" ]; then
+      printf '%s passed\n' "$description"
+      return
+    fi
+    attempts=$((attempts - 1))
+    sleep 1
+  done
+
+  printf '%s failed: got %s, expected %s\n' "$description" "${actual:-<missing>}" "$expected" >&2
+  return 1
+}
+
+seed_callback_contexts() {
+  query "
+DELETE FROM assistant_conversation_metadata WHERE assistant_conversation_id IN ($conversation_ids);
+DELETE FROM assistant_conversation_metrics WHERE assistant_conversation_id IN ($conversation_ids);
+DELETE FROM call_contexts WHERE conversation_id IN ($conversation_ids);
+DELETE FROM assistant_conversations WHERE id IN ($conversation_ids);
+INSERT INTO assistant_conversations (
+  id, identifier, assistant_id, assistant_provider_model_id, name,
+  project_id, organization_id, source, created_by, status, direction,
+  created_actor_type, created_actor_id
+) VALUES
+  (7100001, 'ci-callback-twilio', 1, 1, 'Twilio callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100002, 'ci-callback-exotel-busy', 1, 1, 'Exotel busy callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100003, 'ci-callback-exotel-no-answer', 1, 1, 'Exotel no-answer callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100004, 'ci-callback-vonage', 1, 1, 'Vonage callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100005, 'ci-callback-telnyx', 1, 1, 'Telnyx callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100006, 'ci-callback-asterisk', 1, 1, 'Asterisk callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100007, 'ci-callback-sip', 1, 1, 'SIP callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100008, 'ci-callback-vobiz', 1, 1, 'Vobiz callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1);
+INSERT INTO call_contexts (
+  id, context_id, assistant_id, conversation_id, project_id, organization_id,
+  auth_type, auth_actor_type, auth_actor_id, provider, direction
+) VALUES
+  (7100001, 'ci-callback-twilio', 1, 7100001, 1, 1, 'project', 'project', 1, 'twilio', 'outbound'),
+  (7100002, 'ci-callback-exotel-busy', 1, 7100002, 1, 1, 'project', 'project', 1, 'exotel', 'outbound'),
+  (7100003, 'ci-callback-exotel-no-answer', 1, 7100003, 1, 1, 'project', 'project', 1, 'exotel', 'outbound'),
+  (7100004, 'ci-callback-vonage', 1, 7100004, 1, 1, 'project', 'project', 1, 'vonage', 'outbound'),
+  (7100005, 'ci-callback-telnyx', 1, 7100005, 1, 1, 'project', 'project', 1, 'telnyx', 'outbound'),
+  (7100006, 'ci-callback-asterisk', 1, 7100006, 1, 1, 'project', 'project', 1, 'asterisk', 'outbound'),
+  (7100007, 'ci-callback-sip', 1, 7100007, 1, 1, 'project', 'project', 1, 'sip', 'outbound'),
+  (7100008, 'ci-callback-vobiz', 1, 7100008, 1, 1, 'project', 'project', 1, 'vobiz', 'outbound');
+" >/dev/null
+}
+
+send_post_callback() {
+  provider=$1
+  context_id=$2
+  content_type=$3
+  payload=$4
+  response_file="$temporary_directory/$context_id.response"
+  http_status=$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+    --request POST --header "Content-Type: $content_type" --data-binary "$payload" \
+    "$assistant_api_url/v1/talk/$provider/ctx/$context_id/event")
+
+  assert_callback_accepted "$provider" "$http_status" "$response_file"
+}
+
+send_get_callback() {
+  provider=$1
+  context_id=$2
+  query_string=$3
+  response_file="$temporary_directory/$context_id.response"
+  http_status=$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+    "$assistant_api_url/v1/talk/$provider/ctx/$context_id/event?$query_string")
+
+  assert_callback_accepted "$provider" "$http_status" "$response_file"
+}
+
+assert_callback_accepted() {
+  provider=$1
+  http_status=$2
+  response_file=$3
+
+  if [ "$http_status" != '201' ]; then
+    printf '%s callback returned HTTP %s: ' "$provider" "$http_status" >&2
+    cat "$response_file" >&2
+    return 1
+  fi
+  printf '%s callback accepted\n' "$provider"
+}
+
+send_exotel_callback() {
+  context_id=$1
+  boundary=$2
+  call_sid=$3
+  provider_status=$4
+  updated_at=$5
+  payload_file="$temporary_directory/$context_id.multipart"
+
+  printf '%s\r\n' \
+    "--$boundary" \
+    'Content-Disposition: form-data; name="CallSid"' \
+    '' \
+    "$call_sid" \
+    "--$boundary" \
+    'Content-Disposition: form-data; name="Status"' \
+    '' \
+    "$provider_status" \
+    "--$boundary" \
+    'Content-Disposition: form-data; name="DateUpdated"' \
+    '' \
+    "$updated_at" \
+    "--$boundary--" \
+    '' > "$payload_file"
+
+  send_post_callback exotel "$context_id" "multipart/form-data; boundary=$boundary" "@$payload_file"
+}
+
+assert_failed_callback() {
+  provider=$1
+  context_id=$2
+  conversation_id=$3
+  expected_reason=$4
+  raw_marker=$5
+
+  wait_for_value "$provider call context status" \
+    "SELECT call_status FROM call_contexts WHERE context_id = '$context_id'" \
+    'failed' || return 1
+  wait_for_value "$provider provider disconnect reason" \
+    "SELECT disconnect_reason FROM call_contexts WHERE context_id = '$context_id'" \
+    "$expected_reason" || return 1
+  wait_for_value "$provider call.status metric" \
+    "SELECT value FROM assistant_conversation_metrics WHERE assistant_conversation_id = $conversation_id AND name = 'call.status'" \
+    'FAILED' || return 1
+  wait_for_value "$provider disconnect type metadata" \
+    "SELECT value FROM assistant_conversation_metadata WHERE assistant_conversation_id = $conversation_id AND key = 'disconnect_reason'" \
+    'DISCONNECTION_TYPE_ERROR' || return 1
+  wait_for_value "$provider raw disconnect metadata" \
+    "SELECT CASE WHEN position('$raw_marker' in value) > 0 THEN 'present' ELSE 'missing' END FROM assistant_conversation_metadata WHERE assistant_conversation_id = $conversation_id AND key = 'disconnect_raw_reason'" \
+    'present' || return 1
+  wait_for_value "$provider conversation status metric" \
+    "SELECT value FROM assistant_conversation_metrics WHERE assistant_conversation_id = $conversation_id AND name = 'status'" \
+    'FAILED'
+}
+
+run_twilio() {
+  send_post_callback twilio 'ci-callback-twilio' 'application/x-www-form-urlencoded' \
+    'CallSid=CAf64ab88f90f35581dcb16e60f875ea4a&CallStatus=busy' || return 1
+  assert_failed_callback twilio 'ci-callback-twilio' 7100001 'busy' 'CallStatus=busy'
+}
+
+run_exotel() {
+  exotel_failures=0
+  send_exotel_callback 'ci-callback-exotel-busy' 'form-data-boundary-mga7whnq347kygeh' \
+    'ad5af740ea0d4c9cf816ce81c4e51a93' 'busy' '2026-09-03 20:57:43' || return 1
+  send_exotel_callback 'ci-callback-exotel-no-answer' 'form-data-boundary-0qvisod6e1zig9oq' \
+    '0cfbf52a7747404d311a085f0ed81a93' 'no-answer' '2026-09-03 17:56:22' || return 1
+
+  assert_failed_callback 'exotel busy' 'ci-callback-exotel-busy' 7100002 'busy' 'busy' || exotel_failures=$((exotel_failures + 1))
+  assert_failed_callback 'exotel no-answer' 'ci-callback-exotel-no-answer' 7100003 'no-answer' 'no-answer' || exotel_failures=$((exotel_failures + 1))
+  [ "$exotel_failures" -eq 0 ]
+}
+
+run_vonage() {
+  send_get_callback vonage 'ci-callback-vonage' \
+    'status=busy&uuid=vonage-call&duration=0' || return 1
+  assert_failed_callback vonage 'ci-callback-vonage' 7100004 'busy' 'status=busy'
+}
+
+run_telnyx() {
+  send_post_callback telnyx 'ci-callback-telnyx' 'application/json' \
+    '{"data":{"event_type":"call.hangup","payload":{"call_control_id":"telnyx-call","hangup_cause":"no_answer","duration":0}}}' || return 1
+  assert_failed_callback telnyx 'ci-callback-telnyx' 7100005 'no_answer' 'hangup_cause'
+}
+
+run_asterisk() {
+  send_post_callback asterisk 'ci-callback-asterisk' 'application/json' \
+    '{"type":"ChannelDestroyed","channel":{"id":"asterisk-call"},"cause":17,"cause_txt":"USER_BUSY"}' || return 1
+  assert_failed_callback asterisk 'ci-callback-asterisk' 7100006 'USER_BUSY' 'USER_BUSY'
+}
+
+run_sip() {
+  send_post_callback sip 'ci-callback-sip' 'application/json' \
+    '{"event":"failed","call_id":"sip-call","reason":"no_answer"}' || return 1
+  assert_failed_callback sip 'ci-callback-sip' 7100007 'no_answer' 'no_answer'
+}
+
+run_vobiz() {
+  send_post_callback vobiz 'ci-callback-vobiz' 'application/x-www-form-urlencoded' \
+    'Event=Hangup&CallUUID=vobiz-call&CallStatus=busy' || return 1
+  assert_failed_callback vobiz 'ci-callback-vobiz' 7100008 'busy' 'CallStatus=busy'
+}
+
+run_and_record() {
+  if ! "$1"; then
+    failures=$((failures + 1))
+  fi
+}
+
+seed_callback_contexts
+
+case "$requested_provider" in
+  all)
+    run_and_record run_twilio
+    run_and_record run_exotel
+    run_and_record run_vonage
+    run_and_record run_telnyx
+    run_and_record run_asterisk
+    run_and_record run_sip
+    run_and_record run_vobiz
+    ;;
+  twilio) run_and_record run_twilio ;;
+  exotel) run_and_record run_exotel ;;
+  vonage) run_and_record run_vonage ;;
+  telnyx) run_and_record run_telnyx ;;
+  asterisk) run_and_record run_asterisk ;;
+  sip) run_and_record run_sip ;;
+  vobiz) run_and_record run_vobiz ;;
+  *)
+    printf 'unsupported telephony callback provider: %s\n' "$requested_provider" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s telephony callback provider test(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+echo 'Telephony callback integration tests passed'

--- a/tests/integration/telephony/callbacks/run.sh
+++ b/tests/integration/telephony/callbacks/run.sh
@@ -53,17 +53,17 @@ DELETE FROM call_contexts WHERE conversation_id IN ($conversation_ids);
 DELETE FROM assistant_conversations WHERE id IN ($conversation_ids);
 INSERT INTO assistant_conversations (
   id, identifier, assistant_id, assistant_provider_model_id, name,
-  project_id, organization_id, source, created_by, status, direction,
+  project_id, organization_id, source, status, direction,
   created_actor_type, created_actor_id
 ) VALUES
-  (7100001, 'ci-callback-twilio', 1, 1, 'Twilio callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100002, 'ci-callback-exotel-busy', 1, 1, 'Exotel busy callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100003, 'ci-callback-exotel-no-answer', 1, 1, 'Exotel no-answer callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100004, 'ci-callback-vonage', 1, 1, 'Vonage callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100005, 'ci-callback-telnyx', 1, 1, 'Telnyx callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100006, 'ci-callback-asterisk', 1, 1, 'Asterisk callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100007, 'ci-callback-sip', 1, 1, 'SIP callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1),
-  (7100008, 'ci-callback-vobiz', 1, 1, 'Vobiz callback integration', 1, 1, 'TELEPHONY', 1, 'ACTIVE', 'OUTBOUND', 'project', 1);
+  (7100001, 'ci-callback-twilio', 1, 1, 'Twilio callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100002, 'ci-callback-exotel-busy', 1, 1, 'Exotel busy callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100003, 'ci-callback-exotel-no-answer', 1, 1, 'Exotel no-answer callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100004, 'ci-callback-vonage', 1, 1, 'Vonage callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100005, 'ci-callback-telnyx', 1, 1, 'Telnyx callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100006, 'ci-callback-asterisk', 1, 1, 'Asterisk callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100007, 'ci-callback-sip', 1, 1, 'SIP callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1),
+  (7100008, 'ci-callback-vobiz', 1, 1, 'Vobiz callback integration', 1, 1, 'TELEPHONY', 'ACTIVE', 'OUTBOUND', 'project', 1);
 INSERT INTO call_contexts (
   id, context_id, assistant_id, conversation_id, project_id, organization_id,
   auth_type, auth_actor_type, auth_actor_id, provider, direction

--- a/tests/integration/telephony/exotel-callback/run.sh
+++ b/tests/integration/telephony/exotel-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" exotel

--- a/tests/integration/telephony/sip-callback/run.sh
+++ b/tests/integration/telephony/sip-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" sip

--- a/tests/integration/telephony/telnyx-callback/run.sh
+++ b/tests/integration/telephony/telnyx-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" telnyx

--- a/tests/integration/telephony/twilio-callback/run.sh
+++ b/tests/integration/telephony/twilio-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" twilio

--- a/tests/integration/telephony/vobiz-callback/run.sh
+++ b/tests/integration/telephony/vobiz-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" vobiz

--- a/tests/integration/telephony/vonage-callback/run.sh
+++ b/tests/integration/telephony/vonage-callback/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(cd "$(dirname "$0")" && pwd)
+exec "$script_directory/../callbacks/run.sh" vonage

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -9,9 +9,11 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 COPY tests/smoke/run.sh /usr/local/bin/run-ci-tests
 COPY tests/smoke/sdk-smoke.js /workspace/sdk-smoke.js
+COPY tests/integration/telephony /workspace/tests/integration/telephony
 COPY openapi/postman/assistant-api/assistant-api.smoke.postman_collection.json /workspace/openapi/postman/assistant-api/assistant-api.smoke.postman_collection.json
 
 RUN chmod 0755 /usr/local/bin/run-ci-tests && \
+    find /workspace/tests/integration/telephony -name run.sh -exec chmod 0755 {} + && \
     mkdir -p /reports && \
     chown node:node /reports
 

--- a/tests/smoke/Dockerfile.dockerignore
+++ b/tests/smoke/Dockerfile.dockerignore
@@ -4,6 +4,9 @@
 !tests/smoke/package.json
 !tests/smoke/package-lock.json
 !tests/smoke/run.sh
+!tests/integration/
+!tests/integration/telephony/
+!tests/integration/telephony/**
 !openapi/
 !openapi/postman/
 !openapi/postman/assistant-api/

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -264,6 +264,9 @@ case "$mode" in
   smoke)
     run_smoke_tests
     ;;
+  telephony-callbacks)
+    /workspace/tests/integration/telephony/callbacks/run.sh
+    ;;
   *)
     printf 'unsupported test mode: %s\n' "$mode" >&2
     exit 2


### PR DESCRIPTION
## Summary

- record `status=FAILED` alongside `call.status=FAILED` for failed telephony callbacks
- apply the metric contract to both context-based and catch-all callback routes
- add live-stack callback integration coverage for Twilio, Exotel, Vonage, Telnyx, Asterisk, SIP, and Vobiz
- run the telephony callback integration lane after smoke tests in end-to-end CI

## Verification

- `go test -count=1 ./api/assistant-api/api/talk`
- `go test -count=1 ./api/assistant-api/internal/channel/telephony/... ./api/assistant-api/internal/adapters/internal/...`
- `bash just/shellcheck.sh tests/smoke/run.sh tests/integration/telephony/*/run.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/reusable-end-to-end-ci.yml`
- `just agent-finalize "api/assistant-api/api/talk/callback.go,api/assistant-api/api/talk/callback_test.go,.github/workflows/reusable-end-to-end-ci.yml,just/ci-stack.sh,just/ci.just,tests/smoke/Dockerfile,tests/smoke/Dockerfile.dockerignore,tests/smoke/run.sh,tests/integration/telephony/callbacks/run.sh,tests/integration/telephony/exotel-callback/run.sh,tests/integration/telephony/twilio-callback/run.sh,tests/integration/telephony/vonage-callback/run.sh,tests/integration/telephony/telnyx-callback/run.sh,tests/integration/telephony/asterisk-callback/run.sh,tests/integration/telephony/sip-callback/run.sh,tests/integration/telephony/vobiz-callback/run.sh"`

## Local limitation

- `just ci-telephony-callbacks` was not executed locally because the Docker daemon was unavailable. The new workflow job runs this lane after smoke tests.