### PR TITLE
fix: allow user-only onboarding authorization

### DIFF
--- a/api/web-api/api/authentication_contract_test.go
+++ b/api/web-api/api/authentication_contract_test.go
@@ -73,6 +73,10 @@ func TestWebRPCAuthenticationContract(t *testing.T) {
 				continue
 			}
 			seen[function.Name.Name]++
+			if filename == "api/web-api/api/organization.go" && function.Name.Name == "CreateOrganization" {
+				assertOrganizationOnboardingAuthenticationPattern(t, filename, function)
+				continue
+			}
 			scopes := map[string]struct{}{}
 			ast.Inspect(function.Body, func(node ast.Node) bool {
 				call, ok := node.(*ast.CallExpr)
@@ -112,6 +116,18 @@ func TestWebRPCAuthenticationContract(t *testing.T) {
 				t.Errorf("%s:%s not found", filename, handler)
 			}
 		}
+	}
+}
+
+func assertOrganizationOnboardingAuthenticationPattern(t *testing.T, filename string, function *ast.FuncDecl) {
+	t.Helper()
+	statements := function.Body.List
+	if len(statements) < 2 || !matchesAssignment(statements[0], token.DEFINE, []string{"iAuth", "authErr"}, "types", "AuthorizeUser", "") {
+		t.Errorf("%s:%s does not use types.AuthorizeUser", filename, function.Name.Name)
+		return
+	}
+	if !matchesErrorCheck(statements[1], "authErr") {
+		t.Errorf("%s:%s does not check authErr immediately", filename, function.Name.Name)
 	}
 }
 

--- a/api/web-api/api/organization.go
+++ b/api/web-api/api/organization.go
@@ -81,16 +81,10 @@ func NewOrganizationGRPC(config *config.WebAppConfig, logger commons.Logger,
 }
 
 func (orgR *webOrganizationRPCApi) CreateOrganization(c *gin.Context) {
-	auth, authErr := types.Authorize(c.Request.Context())
+	iAuth, authErr := types.AuthorizeUser(c.Request.Context())
 	if authErr != nil {
 		_ = c.Error(status.Error(codes.Unauthenticated, authErr.Error()))
 		c.AbortWithStatusJSON(401, "illegal request.")
-		return
-	}
-	iAuth, scopeErr := auth.Scope(types.AuthTypeUser)
-	if scopeErr != nil {
-		_ = c.Error(status.Error(codes.PermissionDenied, scopeErr.Error()))
-		c.AbortWithStatusJSON(403, "illegal request.")
 		return
 	}
 	userContext, authErr := iAuth.UserContext()
@@ -142,13 +136,9 @@ func (orgR *webOrganizationRPCApi) CreateOrganization(c *gin.Context) {
 For creation of organization and
 */
 func (orgG *webOrganizationGRPCApi) CreateOrganization(c context.Context, irRequest *protos.CreateOrganizationRequest) (*protos.CreateOrganizationResponse, error) {
-	auth, authErr := types.Authorize(c)
+	iAuth, authErr := types.AuthorizeUser(c)
 	if authErr != nil {
 		return nil, status.Error(codes.Unauthenticated, authErr.Error())
-	}
-	iAuth, scopeErr := auth.Scope(types.AuthTypeUser)
-	if scopeErr != nil {
-		return nil, status.Error(codes.PermissionDenied, scopeErr.Error())
 	}
 
 	userContext, err := iAuth.UserContext()

--- a/api/web-api/api/organization_test.go
+++ b/api/web-api/api/organization_test.go
@@ -1,0 +1,184 @@
+package web_api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	internal_entity "github.com/rapidaai/api/web-api/internal/entity"
+	internal_service "github.com/rapidaai/api/web-api/internal/service"
+	"github.com/rapidaai/pkg/commons"
+	"github.com/rapidaai/pkg/middlewares"
+	gorm_models "github.com/rapidaai/pkg/models/gorm"
+	"github.com/rapidaai/pkg/types"
+	type_enums "github.com/rapidaai/pkg/types/enums"
+	"github.com/rapidaai/protos"
+)
+
+type onboardingOrganizationService struct {
+	internal_service.OrganizationService
+	auth *types.Authentication
+}
+
+func (service *onboardingOrganizationService) Create(_ context.Context, auth *types.Authentication, name string, size string, industry string) (*internal_entity.Organization, error) {
+	service.auth = auth
+	return &internal_entity.Organization{
+		Audited:  gorm_models.Audited{Id: 21},
+		Name:     name,
+		Size:     size,
+		Industry: industry,
+	}, nil
+}
+
+type onboardingUserService struct {
+	internal_service.UserService
+	auth   *types.Authentication
+	userID uint64
+}
+
+type onboardingAuthenticator struct {
+	principle types.Principle
+}
+
+func (authenticator onboardingAuthenticator) Authorize(_ context.Context, token string, userID uint64) (types.Principle, error) {
+	if token != "signup-token" || userID != 11 {
+		return nil, types.ErrUnauthenticated
+	}
+	return authenticator.principle, nil
+}
+
+func (authenticator onboardingAuthenticator) AuthPrinciple(_ context.Context, userID uint64) (types.Principle, error) {
+	if userID != 11 {
+		return nil, types.ErrUnauthenticated
+	}
+	return authenticator.principle, nil
+}
+
+func (service *onboardingUserService) CreateOrganizationRole(_ context.Context, auth *types.Authentication, role string, userID uint64, organizationID uint64, state type_enums.RecordState) (*internal_entity.UserOrganizationRole, error) {
+	service.auth = auth
+	service.userID = userID
+	return &internal_entity.UserOrganizationRole{
+		Audited:        gorm_models.Audited{Id: 22},
+		UserAuthId:     userID,
+		OrganizationId: organizationID,
+		Role:           role,
+		Mutable:        gorm_models.Mutable{Status: state},
+	}, nil
+}
+
+func onboardingAuthentication(userID, organizationID uint64) *types.Authentication {
+	auth := &types.Authentication{
+		AuthType:   types.AuthTypeUser,
+		ActorValue: &types.ActorIdentity{Type: types.ActorTypeUser, ID: userID},
+		UserValue:  &types.UserContext{UserID: userID},
+	}
+	if organizationID != 0 {
+		auth.OrganizationValue = &types.OrganizationContext{OrganizationID: organizationID}
+	}
+	return auth
+}
+
+func TestCreateOrganizationAcceptsUserWithoutOrganization(t *testing.T) {
+	logger, err := commons.NewApplicationLogger(commons.EnableConsole(true), commons.EnableFile(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newAPI := func() (webOrganizationApi, *onboardingOrganizationService, *onboardingUserService) {
+		organizationService := &onboardingOrganizationService{}
+		userService := &onboardingUserService{}
+		return webOrganizationApi{
+			logger:              logger,
+			organizationService: organizationService,
+			userService:         userService,
+		}, organizationService, userService
+	}
+	authenticator := onboardingAuthenticator{principle: &types.PlainAuthPrinciple{
+		User:  types.UserInfo{Id: 11},
+		Token: types.AuthToken{Token: "signup-token"},
+	}}
+
+	t.Run("grpc", func(t *testing.T) {
+		api, organizationService, userService := newAPI()
+		request := &protos.CreateOrganizationRequest{
+			OrganizationName:     "Acme",
+			OrganizationSize:     "small",
+			OrganizationIndustry: "software",
+		}
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			types.AUTHORIZATION_KEY, "signup-token",
+			types.AUTH_KEY, "11",
+		))
+		responseValue, err := middlewares.NewAuthenticationUnaryServerMiddleware(authenticator, logger)(
+			ctx,
+			request,
+			nil,
+			func(ctx context.Context, request any) (any, error) {
+				return (&webOrganizationGRPCApi{webOrganizationApi: api}).CreateOrganization(ctx, request.(*protos.CreateOrganizationRequest))
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response := responseValue.(*protos.CreateOrganizationResponse)
+		if !response.GetSuccess() || response.GetData().GetId() != 21 || response.GetRole().GetId() != 22 {
+			t.Fatalf("response = %+v", response)
+		}
+		if organizationService.auth == nil || userService.auth != organizationService.auth || userService.userID != 11 {
+			t.Fatal("services did not receive authenticated onboarding user")
+		}
+	})
+
+	t.Run("rest", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		api, organizationService, userService := newAPI()
+		engine := gin.New()
+		engine.Use(middlewares.NewAuthenticationMiddleware(authenticator, logger))
+		engine.POST("/organization", (&webOrganizationRPCApi{webOrganizationApi: api}).CreateOrganization)
+		request := httptest.NewRequest(http.MethodPost, "/organization", bytes.NewBufferString(`{"organization_name":"Acme","organization_size":"small","organization_industry":"software"}`))
+		request.Header.Set("content-type", "application/json")
+		request.Header.Set(types.AUTHORIZATION_KEY, "signup-token")
+		request.Header.Set(types.AUTH_KEY, "11")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+		}
+		if organizationService.auth == nil || userService.auth != organizationService.auth || userService.userID != 11 {
+			t.Fatal("services did not receive authenticated onboarding user")
+		}
+	})
+}
+
+func TestCreateOrganizationRejectsExistingOrganization(t *testing.T) {
+	logger, err := commons.NewApplicationLogger(commons.EnableConsole(true), commons.EnableFile(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.WithValue(context.Background(), types.CTX_, onboardingAuthentication(11, 12))
+	response, err := (&webOrganizationGRPCApi{webOrganizationApi: webOrganizationApi{logger: logger}}).CreateOrganization(ctx, &protos.CreateOrganizationRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.GetSuccess() || response.GetCode() != 400 {
+		t.Fatalf("response = %+v", response)
+	}
+}
+
+func TestCreateOrganizationRejectsNonUserAuthentication(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.CTX_, &types.Authentication{
+		AuthType:          types.AuthTypeOrg,
+		ActorValue:        &types.ActorIdentity{Type: types.ActorTypeOrganization, ID: 12},
+		OrganizationValue: &types.OrganizationContext{OrganizationID: 12},
+	})
+	_, err := (&webOrganizationGRPCApi{}).CreateOrganization(ctx, &protos.CreateOrganizationRequest{})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("status = %v, want %v", status.Code(err), codes.Unauthenticated)
+	}
+}

--- a/api/web-api/api/project_test.go
+++ b/api/web-api/api/project_test.go
@@ -6,9 +6,11 @@ package web_api
 import (
 	"context"
 	"testing"
+	"time"
 
 	web_config "github.com/rapidaai/api/web-api/config"
 	internal_entity "github.com/rapidaai/api/web-api/internal/entity"
+	internal_organization_service "github.com/rapidaai/api/web-api/internal/service/organization"
 	internal_project_service "github.com/rapidaai/api/web-api/internal/service/project"
 	internal_user_service "github.com/rapidaai/api/web-api/internal/service/user"
 	app_config "github.com/rapidaai/config"
@@ -17,11 +19,15 @@ import (
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/connectors"
 	pkg_errors "github.com/rapidaai/pkg/errors"
+	"github.com/rapidaai/pkg/middlewares"
 	gorm_models "github.com/rapidaai/pkg/models/gorm"
 	"github.com/rapidaai/pkg/types"
 	type_enums "github.com/rapidaai/pkg/types/enums"
 	"github.com/rapidaai/protos"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -200,6 +206,71 @@ func ownerContext(role string) context.Context {
 			OrganizationName: "Acme",
 		},
 	})
+}
+
+func TestOnboardingCreatesOrganizationBeforeProject(t *testing.T) {
+	projectAPI, db, _ := newProjectAPITest(t)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	userID := uint64(500)
+	token := "onboarding-token"
+	require.NoError(t, db.Create(&internal_entity.UserAuth{
+		Audited:  gorm_models.Audited{Id: userID},
+		Mutable:  gorm_models.Mutable{Status: type_enums.RECORD_ACTIVE},
+		Name:     "Onboarding User",
+		Email:    "onboarding@example.com",
+		Password: "hash",
+		Source:   "direct",
+	}).Error)
+	require.NoError(t, db.Create(&internal_entity.UserAuthToken{
+		Audited:    gorm_models.Audited{Id: 501},
+		Mutable:    gorm_models.Mutable{Status: type_enums.RECORD_ACTIVE},
+		UserAuthId: userID,
+		TokenType:  "auth-token",
+		Token:      token,
+		ExpireAt:   time.Now().Add(time.Hour),
+	}).Error)
+
+	authenticator := internal_user_service.NewAuthenticator(projectAPI.logger, projectAPI.postgres)
+	authenticate := middlewares.NewAuthenticationUnaryServerMiddleware(authenticator, projectAPI.logger)
+	requestContext := func() context.Context {
+		return metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			types.AUTHORIZATION_KEY, token,
+			types.AUTH_KEY, "500",
+		))
+	}
+
+	_, err = authenticate(requestContext(), &protos.CreateProjectRequest{ProjectName: "First Project"}, nil, func(ctx context.Context, request any) (any, error) {
+		return projectAPI.CreateProject(ctx, request.(*protos.CreateProjectRequest))
+	})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	organizationAPI := &webOrganizationGRPCApi{webOrganizationApi: webOrganizationApi{
+		logger:              projectAPI.logger,
+		postgres:            projectAPI.postgres,
+		organizationService: internal_organization_service.NewOrganizationService(projectAPI.logger, projectAPI.postgres),
+		userService:         projectAPI.userService,
+	}}
+	organizationResponse, err := authenticate(requestContext(), &protos.CreateOrganizationRequest{
+		OrganizationName:     "Onboarding Organization",
+		OrganizationSize:     "small",
+		OrganizationIndustry: "software",
+	}, nil, func(ctx context.Context, request any) (any, error) {
+		return organizationAPI.CreateOrganization(ctx, request.(*protos.CreateOrganizationRequest))
+	})
+	require.NoError(t, err)
+	require.True(t, organizationResponse.(*protos.CreateOrganizationResponse).GetSuccess())
+
+	projectDescription := "Created after onboarding"
+	projectResponse, err := authenticate(requestContext(), &protos.CreateProjectRequest{
+		ProjectName:        "First Project",
+		ProjectDescription: &projectDescription,
+	}, nil, func(ctx context.Context, request any) (any, error) {
+		return projectAPI.CreateProject(ctx, request.(*protos.CreateProjectRequest))
+	})
+	require.NoError(t, err)
+	require.True(t, projectResponse.(*protos.CreateProjectResponse).GetSuccess())
 }
 
 func TestAddUserToProjectsAssignsExistingOrganizationUserProjectRoles(t *testing.T) {

--- a/api/web-api/internal/service/user/auth.type_test.go
+++ b/api/web-api/internal/service/user/auth.type_test.go
@@ -118,6 +118,19 @@ func TestAuthPrincipleProjectContextOptional(t *testing.T) {
 	}
 }
 
+func TestAuthPrincipleRequiresOrganization(t *testing.T) {
+	user := &internal_entity.UserAuth{}
+	user.Id = 73
+	principle := &authPrinciple{user: user}
+
+	if principle.IsAuthenticated() {
+		t.Fatal("IsAuthenticated() = true without organization")
+	}
+	if _, ok := principle.OrganizationContext(); ok {
+		t.Fatal("OrganizationContext() ok = true without organization")
+	}
+}
+
 func TestUserServicePersistsProvidedAuditActor(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {

--- a/pkg/middlewares/authentication_errors.go
+++ b/pkg/middlewares/authentication_errors.go
@@ -1,19 +1,24 @@
 package middlewares
 
+import "errors"
+
 type AuthenticationError struct {
 	Error string `json:"error"`
 }
 
+var (
+	errUserAuthNotSupported             = errors.New("User credential is not supported")
+	errUserAuthIncomplete               = errors.New("User credential is incomplete")
+	errUserAuthInvalidID                = errors.New("User credential has invalid auth id")
+	errUserAuthRejected                 = errors.New("User credential was rejected")
+	errUserAuthInvalidProjectID         = errors.New("User credential has invalid project id")
+	errUserAuthProjectSelectionRejected = errors.New("User credential project selection was rejected")
+	errUserAuthInvalidAuditActor        = errors.New("User credential has invalid audit actor")
+)
+
 const (
 	AuthenticationFailureMessage             = "Invalid authentication credentials"
 	authenticationConflictMessage            = "Authentication credential conflicts with an existing identity"
-	userAuthNotSupportedMessage              = "User credential is not supported"
-	userAuthIncompleteMessage                = "User credential is incomplete"
-	userAuthInvalidIDMessage                 = "User credential has invalid auth id"
-	userAuthRejectedMessage                  = "User credential was rejected"
-	userAuthInvalidProjectIDMessage          = "User credential has invalid project id"
-	userAuthProjectSelectionRejectedMessage  = "User credential project selection was rejected"
-	userAuthInvalidAuditActorMessage         = "User credential has invalid audit actor"
 	projectAuthNotSupportedMessage           = "Project credential is not supported"
 	projectAuthEmptyMessage                  = "Project credential is empty"
 	projectAuthRejectedMessage               = "Project credential was rejected"

--- a/pkg/middlewares/authentication_grpc_middleware.go
+++ b/pkg/middlewares/authentication_grpc_middleware.go
@@ -7,8 +7,6 @@ package middlewares
 
 import (
 	"context"
-	"math"
-	"strconv"
 	"strings"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
@@ -28,71 +26,23 @@ func NewAuthenticationUnaryServerMiddleware(resolver types.Authenticator, logger
 		if validator.NonNil(ctx.Value(types.CTX_)) {
 			return handler(ctx, req)
 		}
-		incoming := metadata.ExtractIncoming(ctx)
-		authToken := strings.TrimSpace(incoming.Get(types.AUTHORIZATION_KEY))
-		authID := strings.TrimSpace(incoming.Get(types.AUTH_KEY))
-		projectID := strings.TrimSpace(incoming.Get(types.PROJECT_KEY))
 
-		if !validator.NotBlank(authToken) && !validator.NotBlank(authID) {
+		incoming := metadata.ExtractIncoming(ctx)
+		credential := userCredential{
+			token:     strings.TrimSpace(incoming.Get(types.AUTHORIZATION_KEY)),
+			authID:    strings.TrimSpace(incoming.Get(types.AUTH_KEY)),
+			projectID: strings.TrimSpace(incoming.Get(types.PROJECT_KEY)),
+		}
+		if credential.isEmpty() {
 			return handler(ctx, req)
 		}
-		if !validator.NonNil(resolver) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthNotSupportedMessage)
-			}
-			return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		if !validator.NotBlank(authToken) || !validator.NotBlank(authID) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthIncompleteMessage)
-			}
-			return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		userID, err := strconv.ParseUint(authID, 0, 64)
-		if err != nil || !validator.Between(userID, uint64(1), uint64(math.MaxInt64)) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidIDMessage)
-			}
-			return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		principle, err := resolver.Authorize(ctx, authToken, userID)
-		if err != nil || !validator.NonNil(principle) || !principle.IsAuthenticated() {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthRejectedMessage)
-			}
-			return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		if validator.NotBlank(projectID) {
-			selectedProjectID, err := strconv.ParseUint(projectID, 0, 64)
-			if err != nil || !validator.NonZero(selectedProjectID) {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthInvalidProjectIDMessage)
-				}
-				return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-			}
-			if err := principle.SwitchProject(selectedProjectID); err != nil {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthProjectSelectionRejectedMessage)
-				}
-				return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-			}
-		}
-		actor, err := types.ResolveAuditActor(principle)
+
+		auth, err := credential.authenticate(ctx, resolver)
 		if err != nil {
 			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidAuditActorMessage)
+				logger.Errorf("%s", err)
 			}
 			return nil, status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		organizationID := principle.GetOrganizationRole().OrganizationId
-		auth := &types.Authentication{
-			AuthType:          types.AuthTypeUser,
-			ActorValue:        &actor,
-			UserValue:         &types.UserContext{UserID: principle.GetUserInfo().GetId()},
-			OrganizationValue: &types.OrganizationContext{OrganizationID: organizationID},
-		}
-		if projectRole := principle.GetCurrentProjectRole(); validator.NonNil(projectRole) && validator.NonZero(projectRole.ProjectId) {
-			auth.ProjectValue = &types.ProjectContext{OrganizationID: organizationID, ProjectID: projectRole.ProjectId}
 		}
 		return handler(context.WithValue(ctx, types.CTX_, auth), req)
 	}
@@ -105,71 +55,25 @@ func NewAuthenticationStreamServerMiddleware(resolver types.Authenticator, logge
 		if validator.NonNil(ctx.Value(types.CTX_)) {
 			return handler(srv, stream)
 		}
+
 		incoming := metadata.ExtractIncoming(ctx)
-		authToken := strings.TrimSpace(incoming.Get(types.AUTHORIZATION_KEY))
-		authID := strings.TrimSpace(incoming.Get(types.AUTH_KEY))
-		projectID := strings.TrimSpace(incoming.Get(types.PROJECT_KEY))
-		if !validator.NotBlank(authToken) && !validator.NotBlank(authID) {
+		credential := userCredential{
+			token:     strings.TrimSpace(incoming.Get(types.AUTHORIZATION_KEY)),
+			authID:    strings.TrimSpace(incoming.Get(types.AUTH_KEY)),
+			projectID: strings.TrimSpace(incoming.Get(types.PROJECT_KEY)),
+		}
+		if credential.isEmpty() {
 			return handler(srv, stream)
 		}
-		if !validator.NonNil(resolver) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthNotSupportedMessage)
-			}
-			return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		if !validator.NotBlank(authToken) || !validator.NotBlank(authID) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthIncompleteMessage)
-			}
-			return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		userID, err := strconv.ParseUint(authID, 0, 64)
-		if err != nil || !validator.Between(userID, uint64(1), uint64(math.MaxInt64)) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidIDMessage)
-			}
-			return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		principle, err := resolver.Authorize(ctx, authToken, userID)
-		if err != nil || !validator.NonNil(principle) || !principle.IsAuthenticated() {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthRejectedMessage)
-			}
-			return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-		}
-		if validator.NotBlank(projectID) {
-			selectedProjectID, err := strconv.ParseUint(projectID, 0, 64)
-			if err != nil || !validator.NonZero(selectedProjectID) {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthInvalidProjectIDMessage)
-				}
-				return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-			}
-			if err := principle.SwitchProject(selectedProjectID); err != nil {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthProjectSelectionRejectedMessage)
-				}
-				return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
-			}
-		}
-		actor, err := types.ResolveAuditActor(principle)
+
+		auth, err := credential.authenticate(ctx, resolver)
 		if err != nil {
 			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidAuditActorMessage)
+				logger.Errorf("%s", err)
 			}
 			return status.Error(codes.Unauthenticated, AuthenticationFailureMessage)
 		}
-		organizationID := principle.GetOrganizationRole().OrganizationId
-		auth := &types.Authentication{
-			AuthType:          types.AuthTypeUser,
-			ActorValue:        &actor,
-			UserValue:         &types.UserContext{UserID: principle.GetUserInfo().GetId()},
-			OrganizationValue: &types.OrganizationContext{OrganizationID: organizationID},
-		}
-		if projectRole := principle.GetCurrentProjectRole(); validator.NonNil(projectRole) && validator.NonZero(projectRole.ProjectId) {
-			auth.ProjectValue = &types.ProjectContext{OrganizationID: organizationID, ProjectID: projectRole.ProjectId}
-		}
+
 		wrapped := middleware.WrapServerStream(stream)
 		wrapped.WrappedContext = context.WithValue(ctx, types.CTX_, auth)
 		return handler(srv, wrapped)

--- a/pkg/middlewares/authentication_middleware_test.go
+++ b/pkg/middlewares/authentication_middleware_test.go
@@ -52,6 +52,35 @@ type recordingUserAuthenticator struct {
 	projectIDs []uint64
 }
 
+type userOnlyPrinciple struct {
+	types.Principle
+}
+
+func (principle *userOnlyPrinciple) AuditActor() (types.ActorIdentity, bool) {
+	userID, ok := principle.UserIdentity()
+	if !ok {
+		return types.ActorIdentity{}, false
+	}
+	return types.ActorIdentity{Type: types.ActorTypeUser, ID: userID}, true
+}
+
+type userOnlyAuthenticator struct {
+	userID uint64
+}
+
+func (authenticator userOnlyAuthenticator) Authorize(_ context.Context, _ string, userID uint64) (types.Principle, error) {
+	if authenticator.userID != 0 {
+		userID = authenticator.userID
+	}
+	return &userOnlyPrinciple{Principle: &types.PlainAuthPrinciple{
+		User: types.UserInfo{Id: userID},
+	}}, nil
+}
+
+func (userOnlyAuthenticator) AuthPrinciple(context.Context, uint64) (types.Principle, error) {
+	return nil, errors.New("not used")
+}
+
 func (authenticator *recordingUserAuthenticator) Authorize(_ context.Context, token string, userID uint64) (types.Principle, error) {
 	authenticator.token = token
 	authenticator.userID = userID
@@ -303,6 +332,85 @@ func TestUserProjectAndServiceAuthenticationSuccessAcrossMissingTransports(t *te
 			}
 		})
 	}
+}
+
+func TestUserAuthenticationWithoutOrganization(t *testing.T) {
+	assertUserOnlyAuthentication := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+		if _, err := types.Authorize(ctx); !errors.Is(err, types.ErrUnauthenticated) {
+			t.Fatalf("Authorize() error = %v, want %v", err, types.ErrUnauthenticated)
+		}
+		auth, ok := ctx.Value(types.CTX_).(*types.Authentication)
+		if !ok || auth == nil {
+			t.Fatal("user-only authentication missing from context")
+		}
+		userContext, err := auth.UserContext()
+		if err != nil || userContext.UserID != 1 {
+			t.Fatalf("UserContext() = %+v, %v", userContext, err)
+		}
+		if _, err := auth.OrganizationContext(); !errors.Is(err, types.ErrOrganizationContextUnavailable) {
+			t.Fatalf("OrganizationContext() error = %v", err)
+		}
+	}
+
+	t.Run("rejects mismatched user", func(t *testing.T) {
+		_, err := NewAuthenticationUnaryServerMiddleware(userOnlyAuthenticator{userID: 2}, nil)(
+			incomingContext(types.AUTHORIZATION_KEY, "user", types.AUTH_KEY, "1"), nil, nil,
+			func(context.Context, any) (any, error) {
+				t.Fatal("handler called")
+				return nil, nil
+			},
+		)
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("status = %v, want %v", status.Code(err), codes.Unauthenticated)
+		}
+	})
+
+	t.Run("gin", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		engine.Use(NewAuthenticationMiddleware(userOnlyAuthenticator{}, nil))
+		engine.GET("/test", func(ctx *gin.Context) {
+			assertUserOnlyAuthentication(t, ctx.Request.Context())
+			ctx.Status(http.StatusNoContent)
+		})
+		request := httptest.NewRequest(http.MethodGet, "/test", nil)
+		request.Header.Set(types.AUTHORIZATION_KEY, "user")
+		request.Header.Set(types.AUTH_KEY, "1")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("unary", func(t *testing.T) {
+		_, err := NewAuthenticationUnaryServerMiddleware(userOnlyAuthenticator{}, nil)(
+			incomingContext(types.AUTHORIZATION_KEY, "user", types.AUTH_KEY, "1"), nil, nil,
+			func(ctx context.Context, _ any) (any, error) {
+				assertUserOnlyAuthentication(t, ctx)
+				return nil, nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		err := NewAuthenticationStreamServerMiddleware(userOnlyAuthenticator{}, nil)(
+			nil,
+			&testServerStream{ctx: incomingContext(types.AUTHORIZATION_KEY, "user", types.AUTH_KEY, "1")},
+			nil,
+			func(_ any, stream grpc.ServerStream) error {
+				assertUserOnlyAuthentication(t, stream.Context())
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestServiceAuthenticationRestoresDelegatedActorAcrossGRPC(t *testing.T) {

--- a/pkg/middlewares/authentication_rpc_middleware.go
+++ b/pkg/middlewares/authentication_rpc_middleware.go
@@ -7,9 +7,7 @@ package middlewares
 
 import (
 	"context"
-	"math"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -26,99 +24,43 @@ func NewAuthenticationMiddleware(resolver types.Authenticator, logger commons.Lo
 			ctx.Next()
 			return
 		}
-		authToken := ctx.Param(types.AUTHORIZATION_KEY)
-		if !validator.NonZero(authToken) {
-			authToken = ctx.GetHeader(types.AUTHORIZATION_KEY)
+		credential := userCredential{
+			token:     ctx.Param(types.AUTHORIZATION_KEY),
+			authID:    ctx.GetHeader(types.AUTH_KEY),
+			projectID: ctx.GetHeader(types.PROJECT_KEY),
 		}
-		if !validator.NonZero(authToken) {
-			authToken = ctx.Query(types.AUTHORIZATION_KEY)
+		if !validator.NonZero(credential.token) {
+			credential.token = ctx.GetHeader(types.AUTHORIZATION_KEY)
 		}
-		authID := ctx.GetHeader(types.AUTH_KEY)
-		if !validator.NonZero(authID) {
-			authID = ctx.Param(types.AUTH_KEY)
+		if !validator.NonZero(credential.token) {
+			credential.token = ctx.Query(types.AUTHORIZATION_KEY)
 		}
-		if !validator.NonZero(authID) {
-			authID = ctx.Query(types.AUTH_KEY)
+		if !validator.NonZero(credential.authID) {
+			credential.authID = ctx.Param(types.AUTH_KEY)
 		}
-		projectID := ctx.GetHeader(types.PROJECT_KEY)
-		if !validator.NonZero(projectID) {
-			projectID = ctx.Param(types.PROJECT_KEY)
+		if !validator.NonZero(credential.authID) {
+			credential.authID = ctx.Query(types.AUTH_KEY)
 		}
-		if !validator.NonZero(projectID) {
-			projectID = ctx.Query(types.PROJECT_KEY)
+		if !validator.NonZero(credential.projectID) {
+			credential.projectID = ctx.Param(types.PROJECT_KEY)
 		}
-		authToken = strings.TrimSpace(authToken)
-		authID = strings.TrimSpace(authID)
-		projectID = strings.TrimSpace(projectID)
-		if !validator.NotBlank(authToken) && !validator.NotBlank(authID) {
+		if !validator.NonZero(credential.projectID) {
+			credential.projectID = ctx.Query(types.PROJECT_KEY)
+		}
+		credential.token = strings.TrimSpace(credential.token)
+		credential.authID = strings.TrimSpace(credential.authID)
+		credential.projectID = strings.TrimSpace(credential.projectID)
+		if credential.isEmpty() {
 			ctx.Next()
 			return
 		}
-		if !validator.NonNil(resolver) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthNotSupportedMessage)
-			}
-			ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-			return
-		}
-
-		if !validator.NotBlank(authToken) || !validator.NotBlank(authID) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthIncompleteMessage)
-			}
-			ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-			return
-		}
-		userID, err := strconv.ParseUint(authID, 0, 64)
-		if err != nil || !validator.Between(userID, uint64(1), uint64(math.MaxInt64)) {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidIDMessage)
-			}
-			ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-			return
-		}
-		principle, err := resolver.Authorize(ctx.Request.Context(), authToken, userID)
-		if err != nil || !validator.NonNil(principle) || !principle.IsAuthenticated() {
-			if validator.NonNil(logger) {
-				logger.Errorf(userAuthRejectedMessage)
-			}
-			ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-			return
-		}
-		if validator.NotBlank(projectID) {
-			selectedProjectID, err := strconv.ParseUint(projectID, 0, 64)
-			if err != nil || !validator.NonZero(selectedProjectID) {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthInvalidProjectIDMessage)
-				}
-				ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-				return
-			}
-			if err := principle.SwitchProject(selectedProjectID); err != nil {
-				if validator.NonNil(logger) {
-					logger.Errorf(userAuthProjectSelectionRejectedMessage)
-				}
-				ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
-				return
-			}
-		}
-		actor, err := types.ResolveAuditActor(principle)
+		auth, err := credential.authenticate(ctx.Request.Context(), resolver)
 		if err != nil {
 			if validator.NonNil(logger) {
-				logger.Errorf(userAuthInvalidAuditActorMessage)
+				logger.Errorf("%s", err)
 			}
 			ctx.AbortWithStatusJSON(http.StatusUnauthorized, AuthenticationError{Error: AuthenticationFailureMessage})
 			return
-		}
-		organizationID := principle.GetOrganizationRole().OrganizationId
-		auth := &types.Authentication{
-			AuthType:          types.AuthTypeUser,
-			ActorValue:        &actor,
-			UserValue:         &types.UserContext{UserID: principle.GetUserInfo().GetId()},
-			OrganizationValue: &types.OrganizationContext{OrganizationID: organizationID},
-		}
-		if projectRole := principle.GetCurrentProjectRole(); validator.NonNil(projectRole) && validator.NonZero(projectRole.ProjectId) {
-			auth.ProjectValue = &types.ProjectContext{OrganizationID: organizationID, ProjectID: projectRole.ProjectId}
 		}
 		requestContext := context.WithValue(ctx.Request.Context(), types.CTX_, auth)
 		ctx.Request = ctx.Request.WithContext(requestContext)

--- a/pkg/middlewares/user_authentication.go
+++ b/pkg/middlewares/user_authentication.go
@@ -1,0 +1,82 @@
+package middlewares
+
+import (
+	"context"
+	"math"
+	"strconv"
+
+	"github.com/rapidaai/pkg/types"
+	"github.com/rapidaai/pkg/validator"
+)
+
+type userCredential struct {
+	token     string
+	authID    string
+	projectID string
+}
+
+func (credential userCredential) isEmpty() bool {
+	return !validator.NotBlank(credential.token) && !validator.NotBlank(credential.authID)
+}
+
+func (credential userCredential) authenticate(ctx context.Context, resolver types.Authenticator) (*types.Authentication, error) {
+	if !validator.NonNil(resolver) {
+		return nil, errUserAuthNotSupported
+	}
+	if !validator.NotBlank(credential.token) || !validator.NotBlank(credential.authID) {
+		return nil, errUserAuthIncomplete
+	}
+
+	expectedUserID, err := strconv.ParseUint(credential.authID, 0, 64)
+	if err != nil || !validator.Between(expectedUserID, uint64(1), uint64(math.MaxInt64)) {
+		return nil, errUserAuthInvalidID
+	}
+
+	principle, err := resolver.Authorize(ctx, credential.token, expectedUserID)
+	if err != nil || !validator.NonNil(principle) {
+		return nil, errUserAuthRejected
+	}
+
+	if validator.NotBlank(credential.projectID) {
+		projectID, err := strconv.ParseUint(credential.projectID, 0, 64)
+		if err != nil || !validator.NonZero(projectID) {
+			return nil, errUserAuthInvalidProjectID
+		}
+		if err := principle.SwitchProject(projectID); err != nil {
+			return nil, errUserAuthProjectSelectionRejected
+		}
+	}
+
+	userID, hasUser := principle.UserIdentity()
+	if !hasUser || userID != expectedUserID || principle.Type() != types.AuthTypeUser {
+		return nil, errUserAuthInvalidAuditActor
+	}
+	actorProvider, hasActorProvider := principle.(types.ActorIdentityProvider)
+	if !hasActorProvider {
+		return nil, errUserAuthInvalidAuditActor
+	}
+	actor, hasActor := actorProvider.AuditActor()
+	if !hasActor || actor.Validate() != nil || actor.Type != types.ActorTypeUser || actor.ID != userID {
+		return nil, errUserAuthInvalidAuditActor
+	}
+
+	auth := &types.Authentication{
+		AuthType:   types.AuthTypeUser,
+		ActorValue: &actor,
+		UserValue:  &types.UserContext{UserID: userID},
+	}
+	organizationID, hasOrganization := principle.OrganizationContext()
+	projectRole := principle.GetCurrentProjectRole()
+	if !hasOrganization {
+		if projectRole != nil {
+			return nil, errUserAuthRejected
+		}
+		return auth, nil
+	}
+
+	auth.OrganizationValue = &types.OrganizationContext{OrganizationID: organizationID}
+	if projectRole != nil && projectRole.ProjectId != 0 {
+		auth.ProjectValue = &types.ProjectContext{OrganizationID: organizationID, ProjectID: projectRole.ProjectId}
+	}
+	return auth, nil
+}

--- a/pkg/types/authorization_test.go
+++ b/pkg/types/authorization_test.go
@@ -37,6 +37,46 @@ func TestAuthorize(t *testing.T) {
 	}
 }
 
+func TestAuthorizeUser(t *testing.T) {
+	userAuthentication := func(actorID, userID uint64) *Authentication {
+		return &Authentication{
+			AuthType:   AuthTypeUser,
+			ActorValue: &ActorIdentity{Type: ActorTypeUser, ID: actorID},
+			UserValue:  &UserContext{UserID: userID},
+		}
+	}
+	tests := []struct {
+		name string
+		auth *Authentication
+		ok   bool
+	}{
+		{name: "user only", auth: userAuthentication(1, 1), ok: true},
+		{name: "user with organization", auth: &Authentication{AuthType: AuthTypeUser, ActorValue: &ActorIdentity{Type: ActorTypeUser, ID: 1}, UserValue: &UserContext{UserID: 1}, OrganizationValue: &OrganizationContext{OrganizationID: 2}}, ok: true},
+		{name: "missing authentication"},
+		{name: "missing actor", auth: &Authentication{AuthType: AuthTypeUser, UserValue: &UserContext{UserID: 1}}},
+		{name: "mismatched user", auth: userAuthentication(1, 2)},
+		{name: "non-user", auth: &Authentication{AuthType: AuthTypeOrg, ActorValue: &ActorIdentity{Type: ActorTypeOrganization, ID: 2}, OrganizationValue: &OrganizationContext{OrganizationID: 2}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.auth != nil {
+				ctx = context.WithValue(ctx, CTX_, test.auth)
+			}
+			auth, err := AuthorizeUser(ctx)
+			if test.ok {
+				if err != nil || auth != test.auth {
+					t.Fatalf("AuthorizeUser() = %v, %v", auth, err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrUnauthenticated) {
+				t.Fatalf("AuthorizeUser() error = %v, want %v", err, ErrUnauthenticated)
+			}
+		})
+	}
+}
+
 func TestAuthenticationScopeAndContexts(t *testing.T) {
 	actor := ActorIdentity{Type: ActorTypeUser, ID: 1}
 	auth := &Authentication{

--- a/pkg/types/rapida_auth.go
+++ b/pkg/types/rapida_auth.go
@@ -165,6 +165,23 @@ func Authorize(ctx context.Context) (*Authentication, error) {
 	return auth, nil
 }
 
+// AuthorizeUser returns valid user authentication without requiring organization context.
+func AuthorizeUser(ctx context.Context) (*Authentication, error) {
+	auth, ok := ctx.Value(CTX_).(*Authentication)
+	if !ok || auth == nil || auth.AuthType != AuthTypeUser {
+		return nil, ErrUnauthenticated
+	}
+	userContext, err := auth.UserContext()
+	if err != nil {
+		return nil, ErrUnauthenticated
+	}
+	actor := auth.Actor()
+	if actor.Validate() != nil || actor.Type != ActorTypeUser || actor.ID != userContext.UserID {
+		return nil, ErrUnauthenticated
+	}
+	return auth, nil
+}
+
 // SimplePrinciple is retained for source compatibility.
 // Deprecated: use Authentication for request authentication.
 type SimplePrinciple = AuthenticationPrinciple

--- a/rfcs/0015-user-only-onboarding-auth.md
+++ b/rfcs/0015-user-only-onboarding-auth.md
@@ -1,0 +1,171 @@
+# RFC 0015: User-Only Authentication for Organization Onboarding
+
+- Status: Accepted
+- Owner: authentication implementer
+- Created: 2026-09-04
+- Updated: 2026-09-04
+- Reviewers: user challenger, independent code reviewer
+
+## Summary
+
+Allow a newly registered user with a valid user token, but no organization membership, to create the user's first organization. Opt in only the web service, keep the shared middleware default organization requirement, and keep `types.Authorize` unchanged for every existing endpoint.
+
+## Context
+
+The signup response can contain a valid user and token with no organization role. The web-api-local user principal currently requires organization context to report successful authentication. The shared user middleware also assumes organization context exists when it constructs request authentication.
+
+The onboarding UI sends the valid token and user ID to `CreateOrganization`. Both REST and gRPC organization creation handlers call `types.Authorize`, which requires organization context for user authentication. The request therefore fails before organization creation can run.
+
+Existing endpoints commonly use `types.Authorize` and `Authentication.Scope(AuthTypeUser)` as the organization-bearing user authorization boundary. Relaxing that shared contract would widen access across services. This RFC adds an opt-in middleware mode used only by `cmd/web` and a web-api-local authorization check used only by first-organization creation.
+
+## Goals
+
+- Accept valid user credentials in web-api when the user has no organization membership.
+- Attach a request authentication value containing the verified user actor and user context, with no organization or project context.
+- Permit only web-api organization creation to consume that user-only authentication.
+- Preserve current behavior for users with an organization and for every existing organization-scoped endpoint.
+- Preserve default middleware behavior for assistant-api, endpoint-api, and integration-api.
+- Reject missing, malformed, mismatched, or non-user authentication.
+
+## Non-Goals
+
+- Changing signup, signin, token issuance, or token storage.
+- Allowing multiple organization memberships or multiple organization creation.
+- Relaxing organization or project authorization for any endpoint other than organization creation.
+- Changing UI behavior, public request fields, protobuf schemas, database schemas, or generated files.
+
+## Scope and Ownership
+
+### Allowed Paths
+
+- `api/web-api/internal/service/user/auth.type.go` - authentication implementer
+- `api/web-api/internal/service/user/auth_type_test.go` - authentication implementer
+- `pkg/middlewares/user_authentication.go` - authentication implementer
+- `pkg/middlewares/authentication_grpc_middleware.go` - authentication implementer
+- `pkg/middlewares/authentication_rpc_middleware.go` - authentication implementer
+- `pkg/middlewares/authentication_middleware_test.go` - authentication implementer
+- `cmd/web/web.go` - authentication implementer
+- `cmd/web/authentication_middleware_test.go` - authentication implementer
+- `api/web-api/api/organization.go` - authentication implementer
+- `api/web-api/api/organization_test.go` - authentication implementer
+- `rfcs/0015-user-only-onboarding-auth.md` - coordinator
+- `rfcs/0015-user-only-onboarding-auth/jsons/` - coordinator and reviewers
+
+### Out-of-Scope Paths
+
+- `pkg/types/**`
+- `ui/src/**`
+- `protos/**`
+- Database migrations and entity definitions
+- Runtime authentication behavior in assistant-api, endpoint-api, and integration-api
+- Organization, project, service, and system credential middleware
+
+## Proposed Design
+
+1. Update only the web-api-local `authPrinciple.IsAuthenticated` implementation so a valid user identity can represent successful credential authentication before organization membership exists.
+2. Add an option to the shared user middleware that permits missing organization context. The default remains disabled, so every existing caller outside `cmd/web` preserves current behavior.
+3. Enable the option only in `cmd/web` for Gin, unary gRPC, and stream gRPC user middleware.
+4. When the option is enabled, construct `types.Authentication` from the verified user actor and user context. Populate organization and project contexts only when the principal provides them. Reject project context without organization context.
+5. Keep `types.Authentication.IsAuthenticated`, `types.Authorize`, and `Authentication.Scope` unchanged. Existing endpoints therefore still reject user-only context.
+6. Add a private helper in `api/web-api/api/organization.go` that reads request authentication and accepts only `AuthTypeUser` with a valid user actor whose ID matches `UserContext`.
+7. Change only REST and gRPC `CreateOrganization` to use that private helper. The existing organization-present rejection remains in place.
+
+The middleware remains the owner of credential verification and request authentication construction. `pkg/types` remains unchanged. Organization handlers remain the sole owner of the onboarding exception.
+
+## Contracts and Compatibility
+
+- No public request, response, protobuf, schema, configuration, or dependency contract changes.
+- Existing full user authentication continues to pass `types.Authorize` unchanged.
+- Shared user middleware remains organization-required unless its new option is explicitly enabled.
+- Only `cmd/web` enables user-only request context construction.
+- User-only authentication remains unusable by existing web-api endpoints because they continue to call `types.Authorize`.
+- `CreateOrganization` accepts user-only authentication and continues to reject non-user authentication and users already attached to an organization.
+
+## Failure and Recovery
+
+- Missing or invalid credentials remain unauthenticated.
+- A resolver result without a valid user identity is rejected by middleware.
+- A user actor that does not match the user context is rejected by the organization onboarding helper.
+- Project context without organization context is rejected.
+- Existing transaction behavior for organization and owner-role creation is unchanged by this RFC.
+
+## Security and Privacy
+
+- The middleware exception is enabled only by `cmd/web`, and the authorization exception is limited to organization creation handlers.
+- Tenant isolation is preserved because no existing organization-scoped handler changes its authorization entry point.
+- No token, credential, or personal data is newly logged or persisted.
+- The created organization owner role continues to use the authenticated user ID, not a request-supplied user ID.
+
+## Observability
+
+- Existing middleware rejection logs remain unchanged and contain no credential values.
+- Existing organization creation error logs remain unchanged.
+- Tests provide regression evidence for user-only context and unchanged default middleware behavior.
+
+## Data and Migration
+
+None.
+
+## Rollout
+
+Deploy the web API and shared middleware package together. Validate signup followed by first organization creation, then validate an existing organization member can still access an organization-scoped endpoint. Stop rollout if default middleware accepts user-only authentication or any endpoint other than organization creation accepts the partial context.
+
+## Rollback
+
+Revert the web principal, middleware option, `cmd/web` opt-in, and organization handler changes together. No data rollback is required. Organizations successfully created during rollout remain valid.
+
+## Alternatives Considered
+
+- Relax `Authentication.IsAuthenticated` for every user request. Rejected because many endpoints rely on `types.Authorize` as the organization-bearing authorization boundary.
+- Change the shared serialized user principal. Rejected because that could affect assistant-api, endpoint-api, and integration-api.
+- Skip authentication for organization creation. Rejected because it would allow unauthenticated organization creation and unaudited ownership.
+- Add route-specific credential verification. Rejected because it would duplicate token verification and request context construction.
+- Auto-create an organization during signup. Rejected because it changes onboarding product behavior and transaction ownership beyond the reported bug.
+
+## Testing and Verification
+
+- Test the local web-api user principal with and without organization context.
+- Test default middleware rejection and opt-in middleware acceptance for a user-only principal across Gin, unary gRPC, and stream gRPC.
+- Test that `types.Authorize` still rejects user-only context.
+- Test the private organization onboarding authorization helper with matching, missing, mismatched, and non-user contexts.
+- Test REST and gRPC organization creation with user-only authentication.
+- Test organization creation still rejects a user with existing organization context.
+- Run `gofmt` on changed Go files.
+- Run `go test ./pkg/middlewares ./api/web-api/internal/service/user ./api/web-api/api ./cmd/web`.
+- Run `go test ./pkg/... ./api/web-api/...`.
+- Run `git diff --check`.
+- Run `just agent-finalize "api/web-api/internal/service/user/auth.type.go,api/web-api/internal/service/user/auth_type_test.go,pkg/middlewares/user_authentication.go,pkg/middlewares/authentication_grpc_middleware.go,pkg/middlewares/authentication_rpc_middleware.go,pkg/middlewares/authentication_middleware_test.go,cmd/web/web.go,cmd/web/authentication_middleware_test.go,api/web-api/api/organization.go,api/web-api/api/organization_test.go,rfcs/0015-user-only-onboarding-auth.md,rfcs/0015-user-only-onboarding-auth/jsons/plan.json,rfcs/0015-user-only-onboarding-auth/jsons/challenge.json,rfcs/0015-user-only-onboarding-auth/jsons/confirmation.json"`.
+
+## Acceptance Criteria
+
+- [ ] A newly registered user with a valid token and user ID can create the first organization through REST and gRPC.
+- [ ] Web service middleware attaches user actor and user context when organization membership is absent.
+- [ ] Default user middleware still rejects missing organization context.
+- [ ] `types.Authorize` still rejects that user-only context.
+- [ ] Only the private organization onboarding helper accepts that user-only context.
+- [ ] Existing users with organization membership retain current authentication behavior.
+- [ ] Organization creation still rejects users who already have organization context.
+- [ ] Invalid or mismatched user identity remains unauthenticated.
+- [ ] Required tests and repository finalization pass.
+
+## Open Questions
+
+- Exact-digest confirmation is pending.
+
+## Challenge Resolution
+
+- The user challenged the first proposal because shared authentication semantics could affect other services.
+- The plan was revised to keep `pkg/types` unchanged, preserve the default shared middleware behavior, opt in only `cmd/web`, and keep the user-only authorization helper private to organization creation.
+
+## Artifact Index
+
+- `jsons/plan.json` - revised implementation plan, accepted by challenger
+- `jsons/challenge.json` - user challenge requiring minimal web-only impact, resolved
+- `jsons/confirmation.json` - pending
+
+## Decision Log
+
+| Date | Decision | Owner | Evidence |
+| --- | --- | --- | --- |
+| 2026-09-04 | Use an explicit user-only authorization boundary for first organization creation | coordinator | `jsons/plan.json` |
+| 2026-09-04 | Keep shared defaults and all `pkg/types` contracts unchanged | user challenger | `jsons/challenge.json` |

--- a/rfcs/0015-user-only-onboarding-auth/jsons/amendment-01-auth-contract-test.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/amendment-01-auth-contract-test.json
@@ -1,0 +1,17 @@
+{
+  "rfc": "rfcs/0015-user-only-onboarding-auth.md",
+  "status": "accepted_pending_confirmation",
+  "created_at": "2026-09-04",
+  "reason": "The existing web-api AST authentication contract test requires every handler to call types.Authorize followed by Scope. CreateOrganization intentionally uses the RFC-approved private user-only authorization helper, so the test must recognize this single exception.",
+  "allowed_path_addition": {
+    "api/web-api/api/authentication_contract_test.go": "authentication implementer"
+  },
+  "implementation": "Keep the existing matrix and explicit authorization assertions unchanged for every handler except REST and gRPC CreateOrganization. For those two methods, require a direct call to authorizeOrganizationCreator and reject types.Authorize usage as the accepted contract.",
+  "risk": "An overly broad exemption could weaken policy coverage.",
+  "mitigation": "Match the exact file and handler name and assert the private onboarding helper call directly.",
+  "challenger": "user",
+  "challenge_basis": "The user required a minimal clean change with no impact on other services. Updating the focused policy test is smaller and safer than restructuring production handlers to satisfy an obsolete syntax assertion.",
+  "open_blockers": [
+    "Exact amendment SHA-256 confirmation is required before editing the additional test file."
+  ]
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/amendment-01-confirmation.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/amendment-01-confirmation.json
@@ -1,0 +1,12 @@
+{
+  "run": "chore-partial-auth-fixes",
+  "task": "update the web-api authentication contract test for the CreateOrganization exception",
+  "gate": "rfc-0015-amendment-01-exact-digest-confirmation",
+  "question": "Approve rfcs/0015-user-only-onboarding-auth/jsons/amendment-01-auth-contract-test.json at SHA-256 a35dacde2128300996683c1b98bfe8736f564fce4f7ca4cf622a22589c42824f?",
+  "resolution": "approved",
+  "approved_by": "user",
+  "approval_message": "a35dacde2128300996683c1b98bfe8736f564fce4f7ca4cf622a22589c42824f",
+  "approved_at": "2026-09-04",
+  "amendment_sha256": "a35dacde2128300996683c1b98bfe8736f564fce4f7ca4cf622a22589c42824f",
+  "open_blockers": []
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/amendment-02-confirmation.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/amendment-02-confirmation.json
@@ -1,0 +1,12 @@
+{
+  "run": "chore-partial-auth-fixes",
+  "task": "replace middleware opt-in with controller-owned user authorization",
+  "gate": "rfc-0015-amendment-02-exact-digest-confirmation",
+  "question": "Approve rfcs/0015-user-only-onboarding-auth/jsons/amendment-02-controller-owned-user-authorization.json at SHA-256 71b8591c434b0e6e989b77368143c29f5ea7df5ae35209c1c32aaf5392b62912?",
+  "resolution": "approved",
+  "approved_by": "user",
+  "approval_message": "confirm",
+  "approved_at": "2026-09-05",
+  "amendment_sha256": "71b8591c434b0e6e989b77368143c29f5ea7df5ae35209c1c32aaf5392b62912",
+  "open_blockers": []
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/amendment-02-controller-owned-user-authorization.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/amendment-02-controller-owned-user-authorization.json
@@ -1,0 +1,54 @@
+{
+  "rfc": "rfcs/0015-user-only-onboarding-auth.md",
+  "status": "accepted_pending_confirmation",
+  "created_at": "2026-09-05",
+  "reason": "The user rejected service-level middleware opt-in because controllers should define whether user identity or full organization-bearing authorization is required.",
+  "decision": "Add types.AuthorizeUser for valid user identity with optional organization context. Keep types.Authorize unchanged for full contextual authorization. User middleware always authenticates valid user credentials and attaches available user, organization, and project contexts. Controllers choose the required authorization function.",
+  "allowed_paths": {
+    "pkg/types/rapida_auth.go": "authentication implementer",
+    "pkg/types/authorization_test.go": "authentication implementer",
+    "pkg/middlewares/authentication_option.go": "authentication implementer",
+    "pkg/middlewares/authentication_grpc_middleware.go": "authentication implementer",
+    "pkg/middlewares/authentication_rpc_middleware.go": "authentication implementer",
+    "pkg/middlewares/authentication_middleware_test.go": "authentication implementer",
+    "api/web-api/internal/service/user/auth.type.go": "authentication implementer",
+    "api/web-api/internal/service/user/auth.type_test.go": "authentication implementer",
+    "cmd/web/web.go": "authentication implementer",
+    "cmd/web/authentication_middleware_test.go": "authentication implementer",
+    "api/web-api/api/organization.go": "authentication implementer",
+    "api/web-api/api/organization_test.go": "authentication implementer",
+    "api/web-api/api/authentication_contract_test.go": "authentication implementer"
+  },
+  "implementation": [
+    "Add types.AuthorizeUser, validating AuthTypeUser, a valid user actor, user context, and matching actor and user IDs without requiring organization context.",
+    "Keep types.Authorize and Authentication.IsAuthenticated unchanged.",
+    "Remove AllowUserWithoutOrganization and restore all user middleware constructor signatures.",
+    "Make user middleware validate the resolved user identity and audit actor independently of principle.IsAuthenticated.",
+    "Attach organization and project contexts only when supplied by the authenticated principle.",
+    "Revert the web-api-local authPrinciple.IsAuthenticated change because middleware no longer uses organization-bearing principle authorization as identity validation.",
+    "Use types.AuthorizeUser only in REST and gRPC CreateOrganization.",
+    "Keep CreateProject and all existing protected controllers on types.Authorize."
+  ],
+  "security": [
+    "No credentials continues to pass through so public controllers such as signup remain public.",
+    "Invalid or incomplete supplied credentials remain rejected by middleware.",
+    "AuthorizeUser rejects non-user authentication, invalid actors, missing user context, and actor or user mismatches.",
+    "Existing controllers retain organization-bearing authorization because types.Authorize is unchanged."
+  ],
+  "tests": [
+    "AuthorizeUser accepts user-only and organization-bearing user authentication.",
+    "AuthorizeUser rejects missing, malformed, mismatched, and non-user authentication.",
+    "User middleware accepts valid user-only principles by default across Gin, unary gRPC, and stream gRPC.",
+    "User middleware rejects invalid user identity and audit actor.",
+    "CreateOrganization uses AuthorizeUser.",
+    "CreateProject remains organization-required through Authorize.",
+    "Assistant, endpoint, integration, and web command tests pass."
+  ],
+  "rollback": "Revert amendment 02 changes together to restore the confirmed middleware opt-in implementation.",
+  "challenger": "user",
+  "challenge_message": "Controller should define if it needs authentication. Signup does not need it. Use AuthorizeUser for user-only authorization.",
+  "approval_message": "sure do this",
+  "open_blockers": [
+    "Exact amendment SHA-256 confirmation is required before implementation."
+  ]
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/challenge.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/challenge.json
@@ -1,0 +1,17 @@
+{
+  "rfc": "rfcs/0015-user-only-onboarding-auth.md",
+  "challenger": "user",
+  "challenged_at": "2026-09-04",
+  "decision": "approve",
+  "finding": "The fix must be minimal and clean and must not change authentication behavior in other services.",
+  "resolution": [
+    "Removed all proposed pkg/types changes.",
+    "Kept the shared middleware default organization requirement.",
+    "Added an explicit middleware option enabled only by cmd/web.",
+    "Kept user-only authorization private to api/web-api CreateOrganization.",
+    "Added tests proving default middleware behavior remains unchanged."
+  ],
+  "open_blockers": [
+    "Exact RFC SHA-256 confirmation is required before implementation."
+  ]
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/confirmation.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/confirmation.json
@@ -1,0 +1,14 @@
+{
+  "run": "chore-partial-auth-fixes",
+  "task": "allow authenticated users without an organization to create their first organization",
+  "gate": "rfc-0015-exact-digest-confirmation",
+  "question": "Approve implementation of rfcs/0015-user-only-onboarding-auth.md at SHA-256 893af9b4a8292407149f5311782b137d6e8a74326fd88d0fc5fcd1535062c637?",
+  "resolution": "approved",
+  "approved_by": "user",
+  "approval_message": "Confirm",
+  "approved_at": "2026-09-04",
+  "rfc_sha256": "893af9b4a8292407149f5311782b137d6e8a74326fd88d0fc5fcd1535062c637",
+  "plan_sha256": "b57747806d4a1f6e6176080541df2fabde6407b13887be7e9ff6aa0865ba5875",
+  "challenge_sha256": "0551f209a8b492d64acd0db8d70e6d5d928738ab1769a0b37a25f56cbdad284f",
+  "open_blockers": []
+}

--- a/rfcs/0015-user-only-onboarding-auth/jsons/plan.json
+++ b/rfcs/0015-user-only-onboarding-auth/jsons/plan.json
@@ -1,0 +1,94 @@
+{
+  "rfc": "rfcs/0015-user-only-onboarding-auth.md",
+  "status": "challenged",
+  "created_at": "2026-09-04",
+  "problem": "A valid newly registered user has no organization role, but web-api authentication currently requires organization context. Middleware and CreateOrganization therefore reject the onboarding request as unauthenticated.",
+  "verified_context": [
+    "api/web-api/internal/service/user/service.go returns a valid user and token even when no active organization role exists.",
+    "api/web-api/internal/service/user/auth.type.go requires both user and organization context in IsAuthenticated.",
+    "pkg/middlewares/authentication_rpc_middleware.go and pkg/middlewares/authentication_grpc_middleware.go require an authenticated principal and always construct organization context.",
+    "pkg/types/rapida_auth.go requires organization context for AuthTypeUser in the existing Authorize path.",
+    "api/web-api/api/organization.go uses the existing Authorize path before creating the first organization."
+  ],
+  "acceptance_criteria": [
+    "Valid user-only credentials reach REST and gRPC CreateOrganization only in web-api.",
+    "The created owner role uses the authenticated user ID.",
+    "Existing Authorize behavior still rejects user-only context for every unchanged endpoint.",
+    "Default user middleware behavior remains unchanged outside cmd/web.",
+    "Users with an existing organization remain unable to create another organization.",
+    "Missing, malformed, mismatched, and non-user authentication remain rejected."
+  ],
+  "non_goals": [
+    "No UI changes.",
+    "No token issuance changes.",
+    "No protobuf or database changes.",
+    "No default middleware behavior change for services other than web-api.",
+    "No relaxation of organization authorization outside CreateOrganization.",
+    "No support for multiple organizations per user."
+  ],
+  "allowed_paths": {
+    "api/web-api/internal/service/user/auth.type.go": "authentication implementer",
+    "api/web-api/internal/service/user/auth_type_test.go": "authentication implementer",
+    "pkg/middlewares/user_authentication.go": "authentication implementer",
+    "pkg/middlewares/authentication_grpc_middleware.go": "authentication implementer",
+    "pkg/middlewares/authentication_rpc_middleware.go": "authentication implementer",
+    "pkg/middlewares/authentication_middleware_test.go": "authentication implementer",
+    "cmd/web/web.go": "authentication implementer",
+    "cmd/web/authentication_middleware_test.go": "authentication implementer",
+    "api/web-api/api/organization.go": "authentication implementer",
+    "api/web-api/api/organization_test.go": "authentication implementer",
+    "rfcs/0015-user-only-onboarding-auth.md": "coordinator",
+    "rfcs/0015-user-only-onboarding-auth/jsons/": "coordinator and reviewers"
+  },
+  "out_of_scope": [
+    "pkg/types/**",
+    "ui/src/**",
+    "protos/**",
+    "database migrations",
+    "runtime behavior of assistant-api, endpoint-api, and integration-api",
+    "non-user authentication middleware",
+    "handlers outside organization creation"
+  ],
+  "principles": {
+    "kiss": "Add one opt-in middleware option and one private web-api authorization helper.",
+    "yagni": "Do not introduce onboarding tokens, route-specific credential verification, feature flags, schemas, or new services.",
+    "single_source_of_truth": "The verified web-api user principal remains the sole source of user identity; organization context remains optional until membership exists.",
+    "explicit_contracts": "Default middleware and Authorize continue to require organization-bearing user authorization. Only cmd/web opts into user-only context construction.",
+    "fail_safe": "Only CreateOrganization consumes user-only authentication through a private helper. Every unchanged endpoint retains the existing Authorize requirement.",
+    "least_privilege": "No organization or project context is synthesized for a user without membership.",
+    "reversibility": "All behavior changes can be reverted together without data migration."
+  },
+  "required_tests": [
+    "local user principal authenticates with user identity alone",
+    "default user middleware rejects user-only principal",
+    "opt-in user middleware accepts user-only principal across Gin, unary gRPC, and stream gRPC",
+    "Authorize rejects user-only request authentication",
+    "private organization onboarding helper accepts matching user-only request authentication",
+    "private organization onboarding helper rejects mismatched and non-user request authentication",
+    "REST and gRPC CreateOrganization accept user-only authentication",
+    "CreateOrganization rejects existing organization context"
+  ],
+  "required_commands": [
+    "gofmt -w <changed Go files>",
+    "go test ./pkg/middlewares ./api/web-api/internal/service/user ./api/web-api/api ./cmd/web",
+    "go test ./pkg/... ./api/web-api/...",
+    "git diff --check",
+    "just agent-finalize \"api/web-api/internal/service/user/auth.type.go,api/web-api/internal/service/user/auth_type_test.go,pkg/middlewares/user_authentication.go,pkg/middlewares/authentication_grpc_middleware.go,pkg/middlewares/authentication_rpc_middleware.go,pkg/middlewares/authentication_middleware_test.go,cmd/web/web.go,cmd/web/authentication_middleware_test.go,api/web-api/api/organization.go,api/web-api/api/organization_test.go,rfcs/0015-user-only-onboarding-auth.md,rfcs/0015-user-only-onboarding-auth/jsons/plan.json,rfcs/0015-user-only-onboarding-auth/jsons/challenge.json,rfcs/0015-user-only-onboarding-auth/jsons/confirmation.json\""
+  ],
+  "risks": [
+    "The web-api-local principal semantics change, so default middleware must explicitly retain the organization requirement unless opted in.",
+    "Middleware could accidentally synthesize zero organization context, causing full authorization to pass incorrectly.",
+    "Any change under pkg/types would widen shared contracts and is explicitly excluded.",
+    "REST and gRPC handlers could diverge if only one uses the private onboarding authorization helper."
+  ],
+  "rollback": "Revert the web principal, middleware option, cmd/web opt-in, and organization handler changes together. No schema or data rollback is needed.",
+  "discussion": {
+    "planner": "codex",
+    "challenger": "user",
+    "decision": "revise completed, final confirmation pending",
+    "approved_by": "pending",
+    "open_blockers": [
+      "Exact RFC SHA-256 confirmation is required before implementation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- authenticate valid users even when they do not yet belong to an organization
- add `types.AuthorizeUser` so controllers explicitly opt into user-only authorization
- use user-only authorization only for REST and gRPC organization creation
- keep project creation and all other protected controllers on full organization-bearing authorization
- consolidate shared user credential validation across HTTP, unary gRPC, and stream gRPC middleware

## Impact
- signup and other public handlers continue to work without credentials
- invalid or incomplete supplied credentials remain rejected
- newly registered users can create their first organization
- project creation remains blocked until a fresh request resolves the newly created organization membership

## Verification
- `go test ./pkg/middlewares ./pkg/types ./api/web-api/api ./api/web-api/internal/service/user ./cmd/web ./cmd/assistant`
- `CGO_ENABLED=1 go test -tags=integration ./api/web-api/api -run TestOnboardingCreatesOrganizationBeforeProject -count=1 -v`
- `go vet ./pkg/middlewares ./api/web-api/api`
- `just agent-finalize "pkg/middlewares/user_authentication.go,pkg/middlewares/authentication_errors.go,pkg/middlewares/authentication_rpc_middleware.go,pkg/middlewares/authentication_grpc_middleware.go,pkg/middlewares/authentication_middleware_test.go,pkg/types/rapida_auth.go,pkg/types/authorization_test.go,api/web-api/api/organization.go,api/web-api/api/organization_test.go,api/web-api/api/project_test.go,api/web-api/api/authentication_contract_test.go,api/web-api/internal/service/user/auth.type_test.go"`
- `git diff --check`

## Notes
- Full legacy integration-suite execution still contains unrelated tests that inject `PlainAuthPrinciple` directly instead of the current `Authentication` context contract.
