### PR TITLE
fix: preserve speech across tool calls and results

### DIFF
--- a/api/assistant-api/internal/adapters/internal/dispatch_handler.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler.go
@@ -1755,7 +1755,6 @@ func (h requestorDispatchHandler) HandleLLMToolCall(ctx context.Context, p inter
 
 	if msg, ok := p.Arguments["message"]; ok && msg != "" {
 		h.r.OnPacket(ctx,
-			internal_type.TextToSpeechInterruptPacket{ContextID: p.ContextID},
 			internal_type.InjectMessagePacket{ContextID: p.ContextID, Text: msg})
 	}
 
@@ -1904,7 +1903,6 @@ func (h requestorDispatchHandler) HandleLLMToolResult(ctx context.Context, p int
 
 	h.r.OnPacket(
 		ctx,
-		internal_type.TextToSpeechInterruptPacket{ContextID: p.ContextID},
 		internal_type.StartIdleTimeoutPacket{ContextID: p.ContextID},
 		internal_type.ObservabilityEventRecordPacket{
 			ContextID: p.ContextID,

--- a/api/assistant-api/internal/adapters/internal/dispatch_handler_tool_test.go
+++ b/api/assistant-api/internal/adapters/internal/dispatch_handler_tool_test.go
@@ -1,0 +1,142 @@
+package adapter_internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	adapter_lifecycle "github.com/rapidaai/api/assistant-api/internal/adapters/lifecycle"
+	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
+	"github.com/rapidaai/protos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type toolDispatchTestExecutor struct {
+	packets chan internal_type.Packet
+	err     error
+}
+
+func (*toolDispatchTestExecutor) Name() string {
+	return "tool-dispatch-test"
+}
+
+func (executor *toolDispatchTestExecutor) Execute(_ context.Context, _ internal_type.Communication, packet internal_type.Packet) error {
+	executor.packets <- packet
+	return executor.err
+}
+
+func (*toolDispatchTestExecutor) Close(context.Context) error {
+	return nil
+}
+
+func TestHandleLLMToolCall_DoesNotInterruptSpeech(test *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		arguments map[string]string
+	}{
+		{name: "progress message", arguments: map[string]string{"message": "Let me send an OTP now."}},
+		{name: "no message"},
+		{name: "empty message", arguments: map[string]string{"message": ""}},
+	} {
+		test.Run(testCase.name, func(test *testing.T) {
+			requestor := newInterruptionTestRequestor("")
+			executor := &toolDispatchTestExecutor{packets: make(chan internal_type.Packet, 1)}
+			requestor.assistantExecutor = executor
+			handler := requestorDispatchHandler{r: requestor}
+			packet := internal_type.LLMToolCallPacket{
+				ContextID: "ctx-active",
+				ToolID:    "otp-tool",
+				Name:      "send_otp",
+				Arguments: testCase.arguments,
+			}
+
+			handler.HandleLLMToolCall(context.Background(), packet)
+
+			assert.Empty(test, drainControlPackets(requestor))
+			assert.Equal(test, adapter_lifecycle.MessageStateAssistantSpeaking, requestor.messageLifecycle.State())
+			if message := testCase.arguments["message"]; message != "" {
+				assert.Equal(test, []internal_type.Packet{
+					internal_type.InjectMessagePacket{ContextID: packet.ContextID, Text: message},
+				}, drainEgressPackets(requestor))
+			} else {
+				assert.Empty(test, drainEgressPackets(requestor))
+			}
+
+			streamer := requestor.streamer.(*streamTestStreamer)
+			require.Len(test, streamer.sent, 1)
+			call, ok := streamer.sent[0].(*protos.ConversationToolCall)
+			require.True(test, ok)
+			assert.Equal(test, packet.ContextID, call.Id)
+			assert.Equal(test, packet.ToolID, call.ToolId)
+			assert.Equal(test, packet.Name, call.Name)
+			assert.Equal(test, packet.Arguments, call.Args)
+			select {
+			case executed := <-executor.packets:
+				assert.Equal(test, packet, executed)
+			case <-time.After(time.Second):
+				test.Fatal("tool call was not forwarded to the assistant executor")
+			}
+		})
+	}
+}
+
+func TestHandleLLMToolResult_DoesNotInterruptSpeech(test *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		result map[string]string
+		err    error
+	}{
+		{name: "success", result: map[string]string{"status": "sent"}},
+		{name: "tool failure", result: map[string]string{"error": "OTP delivery failed"}},
+		{name: "empty result"},
+		{name: "executor failure", err: errors.New("tool result processing failed")},
+	} {
+		test.Run(testCase.name, func(test *testing.T) {
+			requestor := newInterruptionTestRequestor("")
+			executor := &toolDispatchTestExecutor{
+				packets: make(chan internal_type.Packet, 1),
+				err:     testCase.err,
+			}
+			requestor.assistantExecutor = executor
+			handler := requestorDispatchHandler{r: requestor}
+			packet := internal_type.LLMToolResultPacket{
+				ContextID: "ctx-active",
+				ToolID:    "otp-tool",
+				Name:      "send_otp",
+				Result:    testCase.result,
+			}
+
+			handler.HandleLLMToolResult(context.Background(), packet)
+
+			assert.Empty(test, drainControlPackets(requestor))
+			assert.Equal(test, adapter_lifecycle.MessageStateAssistantSpeaking, requestor.messageLifecycle.State())
+			assert.Equal(test, []internal_type.Packet{
+				internal_type.StartIdleTimeoutPacket{ContextID: packet.ContextID},
+			}, drainEgressPackets(requestor))
+			assert.Empty(test, requestor.streamer.(*streamTestStreamer).sent)
+			select {
+			case executed := <-executor.packets:
+				assert.Equal(test, packet, executed)
+			case <-time.After(time.Second):
+				test.Fatal("tool result was not forwarded to the assistant executor")
+			}
+			if testCase.err != nil {
+				require.Eventually(test, func() bool {
+					for _, emitted := range drainBackgroundPackets(requestor) {
+						log, ok := emitted.(internal_type.ObservabilityLogRecordPacket)
+						if ok && log.Record.Level == observability.LevelError {
+							assert.Equal(test, packet.ContextID, log.ContextID)
+							assert.Equal(test, packet.ToolID, log.Record.Attributes["tool_id"])
+							assert.Equal(test, testCase.err.Error(), log.Record.Attributes["error"])
+							return true
+						}
+					}
+					return false
+				}, time.Second, time.Millisecond)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Workflow tier: Standard.
- Remove the two tool-triggered `TextToSpeechInterruptPacket` emissions: before injecting a tool message and when processing an ordinary tool result.
- Prevent tool activity from explicitly cancelling active synthesis when the user has not interrupted.
- Add regression coverage for progress messages, missing/empty messages, successful/failed/empty tool results, executor forwarding, and executor failure reporting.

## Approved Plan

- Acceptance criteria: tool calls/results do not enqueue a TTS interrupt; message injection, tool notifications, executor forwarding, failure reporting, and genuine user barge-in remain intact.
- In scope: `api/assistant-api/internal/adapters/internal/dispatch_handler.go` and `api/assistant-api/internal/adapters/internal/dispatch_handler_tool_test.go`.
- Out of scope: `LLMDone`, Cartesia/provider internals, playback sequencing, and end-call timing. Premature hangup is a separate deferred fix.
- Ownership: the existing requestor dispatch handler remains responsible for tool packet handling. This hotfix adds no new production state or owner.
- Rollback or disablement: revert this commit to restore the two tool-triggered interrupt emissions.

## RFC Confirmation

N/A: Standard change. The user approved the two-emission removal and explicitly deferred the end-call fix.

## Principles

- KISS / smallest complete solution: exactly two production-line deletions, plus focused tests.
- YAGNI / rejected speculation: no queue redesign, new configuration, sleeps, provider changes, or changes to `LLMDone`.
- Single source of truth and ownership: interruption policy remains in the shared adapter.
- Contracts and compatibility: no public API or packet schema changes. This shared behavior change affects all TTS providers, not only Cartesia.
- Failure safety and cleanup: tool-result failure reporting is covered; genuine user interruption paths are unchanged and their focused tests pass.
- Security and least privilege: no changes to credentials, permissions, or external dependencies. See the approved security-check exception below.
- Observability: tool lifecycle events and error logs remain unchanged; these two tool paths no longer generate misleading TTS interruption events.

## Testing

Passed:

```sh
go test ./api/assistant-api/internal/adapters/internal -run 'TestHandleLLMTool|TestHandleInterruptionDetected_(VADTriggerUsesVADOnly|WordTriggerUsesWordOnly)' -count=1
just agent-finalize "api/assistant-api/internal/adapters/internal/dispatch_handler.go,api/assistant-api/internal/adapters/internal/dispatch_handler_tool_test.go"
git diff --check
```

- The regression tests first failed on the original interrupt emissions and passed after the two deletions.
- `agent-finalize` passed the changed-test coverage check and full adapter package tests. It was rerun before commit and passed again.
- Formatting, applicable hygiene/secret checks, dependency checks, commit-message validation, pre-push go vet, and CI binary builds passed.
- No live Cartesia or telephony playback test was performed. Complete playback across tool responses still requires live validation.

### Approved security-check exception

The user explicitly approved skipping **only `go-security-scan`** for this hotfix and documenting the findings here. No other applicable hook was bypassed.

- The hook forces `CGO_ENABLED=0`, which cannot type-check the adapter's native audio dependencies (RNNoise, LiveKit, Azure Speech, and FireRed VAD).
- Running the same scan with CGO enabled succeeds in loading those dependencies but reports two existing G115 findings:
  - `dispatch_handler.go:1280`: conversion of `IdleTimeout` from `uint64` to `time.Duration`.
  - `dispatch_handler.go:2997`: conversion of `MaxSessionDuration` from `uint64` to `time.Duration`.
- Both conversions are untouched by this hotfix. Git blame attributes them to existing commits `d760bd226` and `4fc5a4471` respectively.
- These findings and the hook's CGO setup remain unresolved; this PR does not claim a clean security scan.

Manual scan command:

```sh
CGO_ENABLED=1 golangci-lint run --allow-serial-runners --timeout=5m --build-tags=nocgo --enable-only gosec ./api/assistant-api/internal/adapters/internal
```

## Independent Code Review

- Reviewer: pending; must not be an implementation author.
- Review report or Orca task: pending.
- Decision: pending. Do not merge until independent review is complete.
- Critical findings: not independently assessed.
- Major findings: not independently assessed.
- Unresolved follow-ups: the two pre-existing G115 findings, CGO-disabled security-hook compatibility, live playback verification, and the separately deferred end-call timing issue.

## Checklist

- [x] The selected workflow tier matches `DEVELOPMENT_PROCESS.md`.
- Governed RFC and confirmation gates: N/A.
- [x] I kept the change focused.
- [x] I updated tests where needed.
- [x] Scoped validation and applicable non-exempt hooks passed; the security exception is documented above.
- [ ] An independent code reviewer approved the complete diff.
- [ ] Critical and major review findings are resolved.
- [x] Rollback and operational impact are documented.
- [x] I did not commit secrets or generated noise.