### PR TITLE
fix: cartesia stt websocket protocol

### DIFF
--- a/api/assistant-api/internal/transformer/cartesia/cartesia.go
+++ b/api/assistant-api/internal/transformer/cartesia/cartesia.go
@@ -110,7 +110,7 @@ func (co *cartesiaOption) GetSpeechToTextConnectionString() string {
 	params.Add("encoding", co.GetEncoding())
 	params.Add("sample_rate", "16000")
 
-	model := "ink-whisper"
+	model := "ink-2"
 	if configuredModel, err := co.mdlOpts.GetString(internal_options.ListenOptionModel); err == nil {
 		model = configuredModel
 	}

--- a/api/assistant-api/internal/transformer/cartesia/cartesia.go
+++ b/api/assistant-api/internal/transformer/cartesia/cartesia.go
@@ -8,6 +8,7 @@ package internal_transformer_cartesia
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -20,10 +21,11 @@ import (
 )
 
 const (
-	URL                  = "wss://api.cartesia.ai/stt/websocket"
-	CARTESIA_API_VERSION = "2024-06-10"
-	RECONNECT_DELAY      = 5 * time.Second
-	WRITE_TIME_OUT       = 10 * time.Second
+	URL                      = "wss://api.cartesia.ai/stt/websocket"
+	CARTESIA_API_VERSION     = "2024-06-10"
+	CARTESIA_STT_API_VERSION = "2026-03-01"
+	RECONNECT_DELAY          = 5 * time.Second
+	WRITE_TIME_OUT           = 10 * time.Second
 )
 
 func (co *cartesiaOption) GetEncoding() string {
@@ -105,21 +107,29 @@ func (co *cartesiaOption) GetTextToSpeechInput(
 
 func (co *cartesiaOption) GetSpeechToTextConnectionString() string {
 	params := url.Values{}
-	params.Add("api_key", co.key)
-	params.Add("cartesia_version", CARTESIA_API_VERSION)
 	params.Add("encoding", co.GetEncoding())
 	params.Add("sample_rate", "16000")
+
+	model := "ink-whisper"
+	if configuredModel, err := co.mdlOpts.GetString(internal_options.ListenOptionModel); err == nil {
+		model = configuredModel
+	}
+	params.Add("model", model)
+
 	// Check and add language
 	if language, err := co.mdlOpts.GetString(internal_options.ListenOptionLanguage); err == nil {
 		params.Add("language", language)
 	}
 
-	// Check and add model
-	if model, err := co.mdlOpts.GetString(internal_options.ListenOptionModel); err == nil {
-		params.Add("model", model)
-	}
 	// Construct the final URL
 	return fmt.Sprintf("%s?%s", URL, params.Encode())
+}
+
+func (co *cartesiaOption) GetSpeechToTextHeader() http.Header {
+	header := http.Header{}
+	header.Set("X-API-Key", co.key)
+	header.Set("Cartesia-Version", CARTESIA_STT_API_VERSION)
+	return header
 }
 
 func (co *cartesiaOption) GetTextToSpeechConnectionString() string {

--- a/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
+++ b/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
@@ -1,12 +1,20 @@
 package internal_transformer_cartesia
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
 	"github.com/rapidaai/pkg/commons"
 	"github.com/rapidaai/pkg/utils"
 	"github.com/rapidaai/protos"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -109,9 +117,10 @@ func TestGetSpeechToTextConnectionString_Default(t *testing.T) {
 	opt, _ := NewCartesiaOption(newTestLogger(), cred, utils.Option{})
 	connStr := opt.GetSpeechToTextConnectionString()
 	assert.Contains(t, connStr, "wss://api.cartesia.ai/stt/websocket?")
-	assert.Contains(t, connStr, "api_key=my-key")
-	assert.Contains(t, connStr, "cartesia_version="+CARTESIA_API_VERSION)
+	assert.NotContains(t, connStr, "api_key=")
+	assert.NotContains(t, connStr, "cartesia_version=")
 	assert.Contains(t, connStr, "encoding=pcm_s16le")
+	assert.Contains(t, connStr, "model=ink-whisper")
 	assert.Contains(t, connStr, "sample_rate=16000")
 }
 
@@ -127,6 +136,90 @@ func TestGetSpeechToTextConnectionString_WithLanguageAndModel(t *testing.T) {
 	assert.Contains(t, connStr, "model=nova-2")
 	assert.Contains(t, connStr, "encoding=pcm_s16le")
 	assert.Contains(t, connStr, "sample_rate=16000")
+}
+
+func TestGetSpeechToTextHeader(t *testing.T) {
+	cred := newVaultCredential(map[string]interface{}{"key": "my-key"})
+	opt, _ := NewCartesiaOption(newTestLogger(), cred, utils.Option{})
+
+	header := opt.GetSpeechToTextHeader()
+
+	assert.Equal(t, "my-key", header.Get("X-API-Key"))
+	assert.Equal(t, CARTESIA_STT_API_VERSION, header.Get("Cartesia-Version"))
+}
+
+func TestCartesiaSpeechToTextTransform_ContextAndFinalize(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	messages := make(chan struct {
+		messageType int
+		payload     string
+	}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		for i := 0; i < 2; i++ {
+			messageType, payload, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			messages <- struct {
+				messageType int
+				payload     string
+			}{messageType: messageType, payload: string(payload)}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	stt := &cartesiaSpeechToText{
+		connection: conn,
+		logger:     newTestLogger(),
+		onPacket:   func(pkt ...internal_type.Packet) error { return nil },
+	}
+
+	require.NoError(t, stt.Transform(context.Background(), internal_type.SpeechToTextStartPacket{
+		ContextID: "ctx-start",
+	}))
+	require.NoError(t, stt.Transform(context.Background(), internal_type.SpeechToTextAudioPacket{
+		ContextID: "ctx-audio",
+		Audio:     []byte{1, 2, 3, 4},
+	}))
+	require.NoError(t, stt.Transform(context.Background(), internal_type.SpeechToTextEndPacket{
+		ContextID: "ctx-end",
+	}))
+
+	readMessage := func(label string) struct {
+		messageType int
+		payload     string
+	} {
+		select {
+		case message := <-messages:
+			return message
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s message", label)
+			return struct {
+				messageType int
+				payload     string
+			}{}
+		}
+	}
+
+	audioMessage := readMessage("audio")
+	assert.Equal(t, websocket.BinaryMessage, audioMessage.messageType)
+	assert.Equal(t, string([]byte{1, 2, 3, 4}), audioMessage.payload)
+
+	finalizeMessage := readMessage("finalize")
+	assert.Equal(t, websocket.TextMessage, finalizeMessage.messageType)
+	assert.Equal(t, "finalize", finalizeMessage.payload)
+	assert.Equal(t, "ctx-end", stt.contextId)
 }
 
 func TestGetTextToSpeechConnectionString(t *testing.T) {

--- a/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
+++ b/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
@@ -222,6 +222,162 @@ func TestCartesiaSpeechToTextTransform_ContextAndFinalize(t *testing.T) {
 	assert.Equal(t, "ctx-end", stt.contextId)
 }
 
+func TestCartesiaSpeechToTextTransform_FinalizeFailureEmitsError(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	packets := make(chan internal_type.Packet, 8)
+	stt := &cartesiaSpeechToText{
+		connection: conn,
+		logger:     newTestLogger(),
+		onPacket: func(pkt ...internal_type.Packet) error {
+			for _, p := range pkt {
+				packets <- p
+			}
+			return nil
+		},
+	}
+
+	err = stt.Transform(context.Background(), internal_type.SpeechToTextEndPacket{ContextID: "ctx-end"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "finalize failed")
+	sttErr := waitForCartesiaSpeechToTextError(t, packets)
+	assert.Equal(t, "ctx-end", sttErr.ContextID)
+	assert.Contains(t, sttErr.Error.Error(), "finalize failed")
+}
+
+func TestCartesiaSpeechToTextReadLoop_InvalidMessageEmitsErrorAndClosesConnection(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("{not-json"))
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	packets := make(chan internal_type.Packet, 8)
+	stt := &cartesiaSpeechToText{
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		connection: conn,
+		contextId:  "ctx-json",
+		logger:     newTestLogger(),
+		onPacket: func(pkt ...internal_type.Packet) error {
+			for _, p := range pkt {
+				packets <- p
+			}
+			return nil
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stt.readLoop(conn)
+	}()
+
+	sttErr := waitForCartesiaSpeechToTextError(t, packets)
+	assert.Equal(t, "ctx-json", sttErr.ContextID)
+	assert.Contains(t, sttErr.Error.Error(), "invalid message")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for read loop to stop")
+	}
+
+	stt.mu.Lock()
+	currentConn := stt.connection
+	stt.mu.Unlock()
+	assert.Nil(t, currentConn)
+}
+
+func TestCartesiaSpeechToTextClose_ClosesConnectionAndCancelsContext(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	serverReadErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _, err = conn.ReadMessage()
+		serverReadErr <- err
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stt := &cartesiaSpeechToText{
+		ctx:            ctx,
+		ctxCancel:      cancel,
+		connection:     conn,
+		contextId:      "ctx-close",
+		sttConnectedAt: time.Now(),
+		logger:         newTestLogger(),
+		onPacket:       func(pkt ...internal_type.Packet) error { return nil },
+	}
+
+	require.NoError(t, stt.Close(context.Background()))
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for context cancellation")
+	}
+
+	select {
+	case err := <-serverReadErr:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server read to stop")
+	}
+}
+
+func waitForCartesiaSpeechToTextError(t *testing.T, packets <-chan internal_type.Packet) internal_type.SpeechToTextErrorPacket {
+	t.Helper()
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case packet := <-packets:
+			if sttErr, ok := packet.(internal_type.SpeechToTextErrorPacket); ok {
+				return sttErr
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for SpeechToTextErrorPacket")
+		}
+	}
+}
+
 func TestGetTextToSpeechConnectionString(t *testing.T) {
 	cred := newVaultCredential(map[string]interface{}{"key": "my-key"})
 	opt, _ := NewCartesiaOption(newTestLogger(), cred, utils.Option{})

--- a/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
+++ b/api/assistant-api/internal/transformer/cartesia/cartesia_test.go
@@ -120,7 +120,7 @@ func TestGetSpeechToTextConnectionString_Default(t *testing.T) {
 	assert.NotContains(t, connStr, "api_key=")
 	assert.NotContains(t, connStr, "cartesia_version=")
 	assert.Contains(t, connStr, "encoding=pcm_s16le")
-	assert.Contains(t, connStr, "model=ink-whisper")
+	assert.Contains(t, connStr, "model=ink-2")
 	assert.Contains(t, connStr, "sample_rate=16000")
 }
 

--- a/api/assistant-api/internal/transformer/cartesia/internal/type.go
+++ b/api/assistant-api/internal/transformer/cartesia/internal/type.go
@@ -55,5 +55,7 @@ type SpeechToTextOutput struct {
 	Text      string           `json:"text"`
 	Duration  float64          `json:"duration"`
 	Language  string           `json:"language"`
+	Title     string           `json:"title"`
+	Message   string           `json:"message"`
 	Words     []TranscriptWord `json:"words"`
 }

--- a/api/assistant-api/internal/transformer/cartesia/stt.go
+++ b/api/assistant-api/internal/transformer/cartesia/stt.go
@@ -127,7 +127,7 @@ func NewSpeechToText(opts ...Option) (internal_type.SpeechToTextTransformer, err
 
 func (cst *cartesiaSpeechToText) Initialize() error {
 	start := time.Now()
-	conn, _, err := websocket.DefaultDialer.Dial(cst.GetSpeechToTextConnectionString(), nil)
+	conn, _, err := websocket.DefaultDialer.Dial(cst.GetSpeechToTextConnectionString(), cst.GetSpeechToTextHeader())
 	if err != nil {
 		cst.logger.Errorf("cartesia-stt: failed to connect to Cartesia WebSocket: %v", err)
 		cst.onPacket(internal_type.ObservabilityLogRecordPacket{
@@ -231,12 +231,67 @@ func (cst *cartesiaSpeechToText) readLoop(conn *websocket.Conn) {
 		}
 
 		var resp cartesia_internal.SpeechToTextOutput
-		if err := json.Unmarshal(msg, &resp); err != nil || resp.Text == "" {
+		if err := json.Unmarshal(msg, &resp); err != nil {
 			continue
 		}
 		cst.mu.Lock()
 		ctxID := cst.contextId
 		cst.mu.Unlock()
+
+		switch resp.Type {
+		case "transcript":
+		case "flush_done", "done":
+			continue
+		case "error":
+			message := resp.Message
+			if message == "" {
+				message = resp.Title
+			}
+			if message == "" {
+				message = "unknown Cartesia STT error"
+			}
+			cst.onPacket(
+				internal_type.ObservabilityMetricRecordPacket{
+					ContextID: ctxID,
+					Scope:     internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.RecordMetric{
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricSTTError,
+							Value:       "1",
+							Description: "Cartesia STT server error",
+						}},
+						Attributes: observability.Attributes{"provider": cst.Name()},
+					},
+				},
+				internal_type.SpeechToTextErrorPacket{
+					ContextID: ctxID,
+					Error:     fmt.Errorf("cartesia-stt: %s", message),
+					Type:      internal_type.STTNetworkTimeout,
+				},
+				internal_type.ObservabilityLogRecordPacket{
+					ContextID: ctxID,
+					Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+					Record: observability.RecordLog{
+						Level:   observability.LevelError,
+						Message: "cartesia-stt: server error",
+						Attributes: observability.Attributes{
+							"component": observability.ComponentSTT.String(),
+							"provider":  cst.Name(),
+							"error":     observability.AttributeValue(message),
+						},
+						OccurredAt: time.Now(),
+					},
+				},
+			)
+			continue
+		default:
+			if resp.Text == "" {
+				continue
+			}
+		}
+		if resp.Text == "" {
+			continue
+		}
 
 		if !resp.IsFinal {
 			cst.onPacket(
@@ -317,13 +372,58 @@ func (cst *cartesiaSpeechToText) Transform(ctx context.Context, in internal_type
 		return nil
 	case internal_type.SpeechToTextStartPacket:
 		cst.mu.Lock()
+		if pkt.ContextID != "" {
+			cst.contextId = pkt.ContextID
+		}
 		if cst.startedAt.IsZero() {
 			cst.startedAt = time.Now()
 		}
 		cst.mu.Unlock()
 		return nil
+	case internal_type.SpeechToTextEndPacket:
+		cst.mu.Lock()
+		if pkt.ContextID != "" {
+			cst.contextId = pkt.ContextID
+		}
+		conn := cst.connection
+		contextID := cst.contextId
+		cst.mu.Unlock()
+
+		if conn == nil {
+			return fmt.Errorf("cartesia-stt: connection not initialized")
+		}
+
+		cst.writeMu.Lock()
+		err := conn.WriteMessage(websocket.TextMessage, []byte("finalize"))
+		cst.writeMu.Unlock()
+		if err != nil {
+			cst.logger.Errorf("cartesia-stt: finalize failed: %v", err)
+			cst.onPacket(
+				internal_type.ObservabilityMetricRecordPacket{
+					ContextID: contextID,
+					Scope:     internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.RecordMetric{
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricSTTError,
+							Value:       "1",
+							Description: "Cartesia STT finalize failure",
+						}},
+						Attributes: observability.Attributes{"provider": cst.Name()},
+					},
+				},
+				internal_type.SpeechToTextErrorPacket{
+					ContextID: contextID,
+					Error:     fmt.Errorf("cartesia-stt: finalize failed: %w", err),
+					Type:      internal_type.STTNetworkTimeout,
+				})
+			return fmt.Errorf("cartesia-stt: finalize failed: %w", err)
+		}
+		return nil
 	case internal_type.SpeechToTextAudioPacket:
 		cst.mu.Lock()
+		if pkt.ContextID != "" {
+			cst.contextId = pkt.ContextID
+		}
 		if cst.startedAt.IsZero() {
 			cst.startedAt = time.Now()
 		}
@@ -341,6 +441,18 @@ func (cst *cartesiaSpeechToText) Transform(ctx context.Context, in internal_type
 		if err != nil {
 			cst.logger.Errorf("cartesia-stt: error sending audio: %v", err)
 			cst.onPacket(
+				internal_type.ObservabilityMetricRecordPacket{
+					ContextID: contextID,
+					Scope:     internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.RecordMetric{
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricSTTError,
+							Value:       "1",
+							Description: "Cartesia STT send failure",
+						}},
+						Attributes: observability.Attributes{"provider": cst.Name()},
+					},
+				},
 				internal_type.SpeechToTextErrorPacket{
 					ContextID: contextID,
 					Error:     fmt.Errorf("cartesia-stt: send failed: %w", err),
@@ -370,18 +482,25 @@ func (cst *cartesiaSpeechToText) Transform(ctx context.Context, in internal_type
 }
 
 func (cst *cartesiaSpeechToText) Close(ctx context.Context) error {
-	cst.ctxCancel()
 	cst.mu.Lock()
 	ctxID := cst.contextId
 	connectedAt := cst.sttConnectedAt
 	cst.sttConnectedAt = time.Time{}
 
+	var conn *websocket.Conn
 	if cst.connection != nil {
-		conn := cst.connection
-		cst.connection = nil // mark before Close so readLoop sees intentional
-		conn.Close()
+		conn = cst.connection
+		cst.connection = nil
 	}
 	cst.mu.Unlock()
+
+	if conn != nil {
+		cst.writeMu.Lock()
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("close"))
+		cst.writeMu.Unlock()
+		_ = conn.Close()
+	}
+	cst.ctxCancel()
 
 	if !connectedAt.IsZero() {
 		duration := time.Since(connectedAt)

--- a/api/assistant-api/internal/transformer/cartesia/stt.go
+++ b/api/assistant-api/internal/transformer/cartesia/stt.go
@@ -232,7 +232,49 @@ func (cst *cartesiaSpeechToText) readLoop(conn *websocket.Conn) {
 
 		var resp cartesia_internal.SpeechToTextOutput
 		if err := json.Unmarshal(msg, &resp); err != nil {
-			continue
+			cst.mu.Lock()
+			if cst.connection == conn {
+				cst.connection = nil
+			}
+			ctxID := cst.contextId
+			cst.mu.Unlock()
+
+			cst.logger.Errorf("cartesia-stt: invalid message: %v", err)
+			cst.onPacket(
+				internal_type.ObservabilityMetricRecordPacket{
+					ContextID: ctxID,
+					Scope:     internal_type.ObservabilityRecordScopeConversation,
+					Record: observability.RecordMetric{
+						Metrics: []*protos.Metric{{
+							Name:        observability.MetricSTTError,
+							Value:       "1",
+							Description: "Cartesia STT protocol error",
+						}},
+						Attributes: observability.Attributes{"provider": cst.Name()},
+					},
+				},
+				internal_type.SpeechToTextErrorPacket{
+					ContextID: ctxID,
+					Error:     fmt.Errorf("cartesia-stt: invalid message: %w", err),
+					Type:      internal_type.STTNetworkTimeout,
+				},
+				internal_type.ObservabilityLogRecordPacket{
+					ContextID: ctxID,
+					Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+					Record: observability.RecordLog{
+						Level:   observability.LevelError,
+						Message: "cartesia-stt: invalid message",
+						Attributes: observability.Attributes{
+							"component": observability.ComponentSTT.String(),
+							"provider":  cst.Name(),
+							"error":     observability.AttributeValue(err.Error()),
+						},
+						OccurredAt: time.Now(),
+					},
+				},
+			)
+			_ = conn.Close()
+			return
 		}
 		cst.mu.Lock()
 		ctxID := cst.contextId
@@ -495,9 +537,6 @@ func (cst *cartesiaSpeechToText) Close(ctx context.Context) error {
 	cst.mu.Unlock()
 
 	if conn != nil {
-		cst.writeMu.Lock()
-		_ = conn.WriteMessage(websocket.TextMessage, []byte("close"))
-		cst.writeMu.Unlock()
 		_ = conn.Close()
 	}
 	cst.ctxCancel()

--- a/ui/src/providers/__tests__/provider-stt-comparison.test.ts
+++ b/ui/src/providers/__tests__/provider-stt-comparison.test.ts
@@ -381,17 +381,37 @@ describe('Cartesia STT — config vs original', () => {
 
   it('produces the same default keys and values', () => {
     const result = getDefaultsFromConfig(config, 'stt', [], 'cartesia');
-    expect(findMeta(result, 'listen.model')).toBe('ink-whisper');
+    expect(findMeta(result, 'listen.model')).toBe('ink-2');
     expect(findMeta(result, 'listen.language')).toBe('en');
   });
 
   it('validates: valid options returns undefined', () => {
     const opts = [
       cred(),
-      createMetadata('listen.model', 'ink-whisper'),
+      createMetadata('listen.model', 'ink-2'),
       createMetadata('listen.language', 'en'),
     ];
     expect(validateFromConfig(config, 'stt', 'cartesia', opts)).toBeUndefined();
+  });
+
+  it('validates: preview model languages return undefined', () => {
+    const opts = [
+      cred(),
+      createMetadata('listen.model', 'ink-preview'),
+      createMetadata('listen.language', 'hi'),
+    ];
+    expect(validateFromConfig(config, 'stt', 'cartesia', opts)).toBeUndefined();
+  });
+
+  it('validates: stable model rejects preview-only languages', () => {
+    const opts = [
+      cred(),
+      createMetadata('listen.model', 'ink-2'),
+      createMetadata('listen.language', 'hi'),
+    ];
+    expect(validateFromConfig(config, 'stt', 'cartesia', opts)).toBe(
+      'Please provide valid cartesia language options for speech to text.',
+    );
   });
 });
 

--- a/ui/src/providers/cartesia/languages-ink-2.json
+++ b/ui/src/providers/cartesia/languages-ink-2.json
@@ -1,0 +1,6 @@
+[
+  {
+    "code": "en",
+    "name": "English"
+  }
+]

--- a/ui/src/providers/cartesia/languages-ink-preview.json
+++ b/ui/src/providers/cartesia/languages-ink-preview.json
@@ -1,0 +1,22 @@
+[
+  {
+    "code": "en",
+    "name": "English"
+  },
+  {
+    "code": "fr",
+    "name": "French"
+  },
+  {
+    "code": "hi",
+    "name": "Hindi"
+  },
+  {
+    "code": "ja",
+    "name": "Japanese"
+  },
+  {
+    "code": "es",
+    "name": "Spanish"
+  }
+]

--- a/ui/src/providers/cartesia/speech-to-text-models.json
+++ b/ui/src/providers/cartesia/speech-to-text-models.json
@@ -1,7 +1,10 @@
 [
   {
-    "name": "ink-whisper",
-    "id": "ink-whisper",
+    "name": "ink-2",
+    "id": "ink-2",
+    "releaseDate": "May 22, 2026",
+    "languages": ["en"],
+    "status": "Stable",
     "config": {
       "parameters": [
         {
@@ -10,7 +13,28 @@
           "type": "dropdown",
           "required": true,
           "default": "en",
-          "data": "languages.json",
+          "data": "languages-ink-2.json",
+          "valueField": "code",
+          "errorMessage": "Please provide valid cartesia language options for speech to text."
+        }
+      ]
+    }
+  },
+  {
+    "name": "ink-preview",
+    "id": "ink-preview",
+    "releaseDate": "September 4, 2026",
+    "languages": ["en", "fr", "hi", "ja", "es"],
+    "status": "Preview",
+    "config": {
+      "parameters": [
+        {
+          "key": "listen.language",
+          "label": "Language",
+          "type": "dropdown",
+          "required": true,
+          "default": "en",
+          "data": "languages-ink-preview.json",
           "valueField": "code",
           "errorMessage": "Please provide valid cartesia language options for speech to text."
         }

--- a/ui/src/providers/cartesia/stt.json
+++ b/ui/src/providers/cartesia/stt.json
@@ -6,7 +6,7 @@
       "label": "Model",
       "type": "dropdown",
       "required": true,
-      "default": "ink-whisper",
+      "default": "ink-2",
       "data": "speech-to-text-models.json",
       "valueField": "id",
       "errorMessage": "Please provide valid cartesia model for speech to text."


### PR DESCRIPTION
## Summary
- send Cartesia STT authentication and API version through websocket headers
- use the current STT protocol controls for finalize and close messages
- handle Cartesia STT transcript, done, flush_done, and error events explicitly
- cover URL/header generation and finalize behavior with tests

## Verification
- go test ./api/assistant-api/internal/transformer/cartesia -count=1
- just agent-finalize "api/assistant-api/internal/transformer/cartesia"