### PR TITLE
fix: recover stalled Pipecat turns with activity-aware timeout

### DIFF
--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/constant.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/constant.go
@@ -20,10 +20,12 @@ const (
 	optPctFallbackTimeout  = internal_options.MicrophoneEOSOptionFallbackTimeout
 	optPctModelPath        = internal_options.MicrophoneEOSOptionPipecatModelPath
 
-	// The transcript safety budget and Smart Turn silence limit run independently after VAD stop.
+	// The transcript safety budget and received-audio silence limit run independently after VAD stop.
 	defaultPctThreshold       = 0.85
 	defaultPctExtendedTimeout = 4000.0
 	defaultPctFallbackTimeout = 1000.0
+	// Match Pipecat's controller watchdog when stopped turns receive no further transcription activity.
+	defaultPctTurnStopTimeout = 5 * time.Second
 
 	maxAudioSamples        = whisperMaxSamples
 	preSpeechAudioSamples  = whisperSampleRate / 2

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/error.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/error.go
@@ -19,6 +19,7 @@ var (
 	errPipecatDetectorSetOptimization       = errors.New("pipecat_detector: set optimization")
 	errPipecatDetectorCreateSession         = errors.New("pipecat_detector: create session")
 	errPipecatDetectorCreateMemoryInfo      = errors.New("pipecat_detector: create memory info")
+	errPipecatDetectorCreateRunOptions      = errors.New("pipecat_detector: create run options")
 	errPipecatDetectorCreateInputTensor     = errors.New("pipecat_detector: create input tensor")
 	errPipecatDetectorRunInference          = errors.New("pipecat_detector: run inference")
 	errPipecatDetectorGetOutputData         = errors.New("pipecat_detector: get output data")

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/infer_darwin.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/infer_darwin.go
@@ -18,12 +18,9 @@ import (
 	"unsafe"
 )
 
-// infer runs ONNX inference on mel spectrogram features.
-// Input: flat float32 slice of shape [1, 80, 800].
-// Output: sigmoid probability of turn completion.
-//
-// darwin: uses C.longlong for int64 tensor dimensions.
-func (pd *PipecatDetector) infer(features []float32) (float64, error) {
+// inferWithRunOptions runs ONNX on [1, 80, 800] mel features and returns the probability.
+// Darwin uses C.longlong for int64 tensor dimensions.
+func (pd *PipecatDetector) inferWithRunOptions(features []float32, runOptions *C.OrtRunOptions) (float64, error) {
 	// --- Input tensor: input_features [1, 80, 800] ---
 	var featValue *C.OrtValue
 	featDims := []C.longlong{1, whisperNMels, whisperMaxFrames}
@@ -43,9 +40,12 @@ func (pd *PipecatDetector) infer(features []float32) (float64, error) {
 	inputNames := []*C.char{pd.cStrings["input_features"]}
 	outputNames := []*C.char{pd.cStrings["logits"]}
 
-	status = C.PctOrtApiRun(pd.api, pd.session, nil,
+	status = C.PctOrtApiRun(pd.api, pd.session, runOptions,
 		&inputNames[0], &inputs[0], C.size_t(len(inputNames)),
 		&outputNames[0], C.size_t(len(outputNames)), &outputs[0])
+	if outputs[0] != nil {
+		defer C.PctOrtApiReleaseValue(pd.api, outputs[0])
+	}
 	defer C.PctOrtApiReleaseStatus(pd.api, status)
 	if status != nil {
 		return 0, fmt.Errorf("%w: %s", errPipecatDetectorRunInference, C.GoString(C.PctOrtApiGetErrorMessage(pd.api, status)))
@@ -56,11 +56,9 @@ func (pd *PipecatDetector) infer(features []float32) (float64, error) {
 	status = C.PctOrtApiGetTensorMutableData(pd.api, outputs[0], &probPtr)
 	defer C.PctOrtApiReleaseStatus(pd.api, status)
 	if status != nil {
-		C.PctOrtApiReleaseValue(pd.api, outputs[0])
 		return 0, fmt.Errorf("%w: %s", errPipecatDetectorGetOutputData, C.GoString(C.PctOrtApiGetErrorMessage(pd.api, status)))
 	}
 
 	prob := float64(*(*float32)(probPtr))
-	C.PctOrtApiReleaseValue(pd.api, outputs[0])
 	return prob, nil
 }

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/infer_linux.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/infer_linux.go
@@ -18,12 +18,9 @@ import (
 	"unsafe"
 )
 
-// infer runs ONNX inference on mel spectrogram features.
-// Input: flat float32 slice of shape [1, 80, 800].
-// Output: sigmoid probability of turn completion.
-//
-// linux/other: uses C.long for int64 tensor dimensions.
-func (pd *PipecatDetector) infer(features []float32) (float64, error) {
+// inferWithRunOptions runs ONNX on [1, 80, 800] mel features and returns the probability.
+// Linux uses C.long for int64 tensor dimensions.
+func (pd *PipecatDetector) inferWithRunOptions(features []float32, runOptions *C.OrtRunOptions) (float64, error) {
 	// --- Input tensor: input_features [1, 80, 800] ---
 	var featValue *C.OrtValue
 	featDims := []C.long{1, whisperNMels, whisperMaxFrames}
@@ -43,9 +40,12 @@ func (pd *PipecatDetector) infer(features []float32) (float64, error) {
 	inputNames := []*C.char{pd.cStrings["input_features"]}
 	outputNames := []*C.char{pd.cStrings["logits"]}
 
-	status = C.PctOrtApiRun(pd.api, pd.session, nil,
+	status = C.PctOrtApiRun(pd.api, pd.session, runOptions,
 		&inputNames[0], &inputs[0], C.size_t(len(inputNames)),
 		&outputNames[0], C.size_t(len(outputNames)), &outputs[0])
+	if outputs[0] != nil {
+		defer C.PctOrtApiReleaseValue(pd.api, outputs[0])
+	}
 	defer C.PctOrtApiReleaseStatus(pd.api, status)
 	if status != nil {
 		return 0, fmt.Errorf("%w: %s", errPipecatDetectorRunInference, C.GoString(C.PctOrtApiGetErrorMessage(pd.api, status)))
@@ -56,11 +56,9 @@ func (pd *PipecatDetector) infer(features []float32) (float64, error) {
 	status = C.PctOrtApiGetTensorMutableData(pd.api, outputs[0], &probPtr)
 	defer C.PctOrtApiReleaseStatus(pd.api, status)
 	if status != nil {
-		C.PctOrtApiReleaseValue(pd.api, outputs[0])
 		return 0, fmt.Errorf("%w: %s", errPipecatDetectorGetOutputData, C.GoString(C.PctOrtApiGetErrorMessage(pd.api, status)))
 	}
 
 	prob := float64(*(*float32)(probPtr))
-	C.PctOrtApiReleaseValue(pd.api, outputs[0])
 	return prob, nil
 }

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/ort_bridge.c
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/ort_bridge.c
@@ -28,6 +28,10 @@ OrtStatus* PctOrtApiCreateTensorWithDataAsOrtValue(const OrtApi *api, const OrtM
     const int64_t *s, size_t sl, ONNXTensorElementDataType dt, OrtValue **v) { return api->CreateTensorWithDataAsOrtValue(mi, d, dl, s, sl, dt, v); }
 void PctOrtApiReleaseValue(const OrtApi *api, OrtValue *v) { api->ReleaseValue(v); }
 
+OrtStatus* PctOrtApiCreateRunOptions(const OrtApi *api, OrtRunOptions **opts) { return api->CreateRunOptions(opts); }
+OrtStatus* PctOrtApiRunOptionsSetTerminate(const OrtApi *api, OrtRunOptions *opts) { return api->RunOptionsSetTerminate(opts); }
+void PctOrtApiReleaseRunOptions(const OrtApi *api, OrtRunOptions *opts) { api->ReleaseRunOptions(opts); }
+
 OrtStatus* PctOrtApiRun(const OrtApi *api, OrtSession *s, const OrtRunOptions *ro,
     const char *const *in, const OrtValue *const *iv, size_t il,
     const char *const *on, size_t ol, OrtValue **ov) { return api->Run(s, ro, in, iv, il, on, ol, ov); }

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/ort_bridge.h
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/ort_bridge.h
@@ -37,6 +37,10 @@ OrtStatus* PctOrtApiCreateTensorWithDataAsOrtValue(const OrtApi *api, const OrtM
     const int64_t *shape, size_t shape_len, ONNXTensorElementDataType data_type, OrtValue **value);
 void PctOrtApiReleaseValue(const OrtApi *api, OrtValue *value);
 
+OrtStatus* PctOrtApiCreateRunOptions(const OrtApi *api, OrtRunOptions **opts);
+OrtStatus* PctOrtApiRunOptionsSetTerminate(const OrtApi *api, OrtRunOptions *opts);
+void PctOrtApiReleaseRunOptions(const OrtApi *api, OrtRunOptions *opts);
+
 OrtStatus* PctOrtApiRun(const OrtApi *api, OrtSession *session, const OrtRunOptions *run_options,
     const char *const *input_names, const OrtValue *const *inputs, size_t inputs_len,
     const char *const *output_names, size_t output_names_len, OrtValue **outputs);

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech.go
@@ -8,6 +8,7 @@ package internal_pipecat
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -54,11 +55,12 @@ type endOfSpeechState struct {
 	turnState          turnState
 	vadRevision        uint64
 	transcriptDeadline time.Time
+	turnStopDeadline   time.Time
 	silenceSamples     uint64
 }
 
 type turnPredictor interface {
-	Predict([]float32) (float64, error)
+	PredictContext(context.Context, []float32) (float64, error)
 }
 
 type pipecatEndOfSpeech struct {
@@ -72,6 +74,7 @@ type pipecatEndOfSpeech struct {
 	threshold       float64
 	extendedTimeout time.Duration
 	fallbackTimeout time.Duration
+	turnStopTimeout time.Duration
 
 	audioBuffer       []float32
 	audioStartSample  uint64
@@ -88,9 +91,10 @@ type pipecatEndOfSpeech struct {
 	stopCh    chan struct{}
 	closeOnce sync.Once
 
-	mu           sync.RWMutex
-	state        *endOfSpeechState
-	eosStartedAt time.Time
+	mu               sync.RWMutex
+	state            *endOfSpeechState
+	eosStartedAt     time.Time
+	cancelPrediction context.CancelFunc
 }
 
 type options struct {
@@ -174,6 +178,7 @@ func New(opts ...Option) (internal_type.EndOfSpeechExecutor, error) {
 		threshold:       defaultPctThreshold,
 		extendedTimeout: time.Duration(defaultPctExtendedTimeout) * time.Millisecond,
 		fallbackTimeout: time.Duration(defaultPctFallbackTimeout) * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		audioBuffer:     make([]float32, 0, maxAudioSamples),
 		commandCh:       make(chan workerCommand, 32),
 		stopCh:          make(chan struct{}),
@@ -301,10 +306,15 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 		endOfSpeech.mu.Lock()
 		switch packet.Event {
 		case internal_type.InterruptionEventStart:
+			if endOfSpeech.cancelPrediction != nil {
+				endOfSpeech.cancelPrediction()
+				endOfSpeech.cancelPrediction = nil
+			}
 			endOfSpeech.state.vadState = vadStateSpeaking
 			endOfSpeech.state.turnState = turnStatePending
 			endOfSpeech.state.confidence = 0
 			endOfSpeech.state.transcriptDeadline = time.Time{}
+			endOfSpeech.state.turnStopDeadline = time.Time{}
 			endOfSpeech.state.silenceSamples = 0
 			endOfSpeech.state.vadRevision++
 			endOfSpeech.state.segment.Revision++
@@ -333,6 +343,7 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 			endOfSpeech.state.vadRevision++
 			endOfSpeech.state.segment.Revision++
 			vadRevision := endOfSpeech.state.vadRevision
+			endOfSpeech.state.turnStopDeadline = time.Now().Add(endOfSpeech.turnStopTimeout)
 			if endOfSpeech.state.transcript == transcriptStateUserText {
 				endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision}
 				endOfSpeech.state.transcript = transcriptStateIdle
@@ -349,9 +360,26 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 					-time.Duration(vadStopSamples) * pipecatAudioSampleDuration,
 				)
 			}
+			// Transcription can extend turn recovery without extending the native inference budget.
+			predictionDeadline := endOfSpeech.state.turnStopDeadline
+			if endOfSpeech.state.transcriptDeadline.After(predictionDeadline) {
+				predictionDeadline = endOfSpeech.state.transcriptDeadline
+			}
+			predictionContext, cancelPrediction := context.WithDeadline(ctx, predictionDeadline)
+			endOfSpeech.cancelPrediction = cancelPrediction
+			command := workerCommand{
+				ctx:      ctx,
+				segment:  endOfSpeech.state.segment,
+				deadline: endOfSpeech.state.transcriptDeadline,
+			}
+			command.segment.Text = command.segment.FinalText
 			endOfSpeech.mu.Unlock()
-			probability, predictionErr := endOfSpeech.predictEOU()
-			if predictionErr != nil {
+			if command.segment.Text != "" {
+				endOfSpeech.enqueueCommand(command)
+			}
+			probability, predictionErr := endOfSpeech.predictEOU(predictionContext)
+			cancelPrediction()
+			if predictionErr != nil && !errors.Is(predictionErr, context.Canceled) && !errors.Is(predictionErr, context.DeadlineExceeded) {
 				// Packet dispatchers may discard Execute errors, so report inference failures here as well.
 				_ = endOfSpeech.onPacket(ctx, internal_type.ObservabilityLogRecordPacket{
 					ContextID: packet.ContextID,
@@ -373,6 +401,7 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 				endOfSpeech.mu.Unlock()
 				return nil
 			}
+			endOfSpeech.cancelPrediction = nil
 			endOfSpeech.state.confidence = probability
 			if endOfSpeech.state.turnState != turnStateComplete {
 				if predictionErr == nil && probability > endOfSpeech.threshold {
@@ -381,10 +410,6 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 					endOfSpeech.state.turnState = turnStateIncomplete
 				}
 			}
-			if endOfSpeech.state.turnState == turnStateIncomplete {
-				endOfSpeech.mu.Unlock()
-				return predictionErr
-			}
 			if endOfSpeech.state.turnState == turnStateComplete {
 				endOfSpeech.audioBuffer = endOfSpeech.audioBuffer[:0]
 				endOfSpeech.audioStartSample = endOfSpeech.audioNextSample
@@ -392,7 +417,7 @@ func (endOfSpeech *pipecatEndOfSpeech) Execute(ctx context.Context, packet inter
 				endOfSpeech.audioGeneration++
 				endOfSpeech.hasPredictedResult = false
 			}
-			command := workerCommand{
+			command = workerCommand{
 				ctx:        ctx,
 				segment:    endOfSpeech.state.segment,
 				confidence: endOfSpeech.state.confidence,
@@ -418,6 +443,10 @@ func (endOfSpeech *pipecatEndOfSpeech) handleUserTextPacket(ctx context.Context,
 	}
 
 	endOfSpeech.mu.Lock()
+	if endOfSpeech.cancelPrediction != nil {
+		endOfSpeech.cancelPrediction()
+		endOfSpeech.cancelPrediction = nil
+	}
 	segment := speechSegment{
 		Revision:  endOfSpeech.state.segment.Revision + 1,
 		ContextID: packet.ContextId(),
@@ -462,10 +491,13 @@ func (endOfSpeech *pipecatEndOfSpeech) handleUserTextPacket(ctx context.Context,
 }
 
 func (endOfSpeech *pipecatEndOfSpeech) handleSpeechToTextPacket(ctx context.Context, packet internal_type.SpeechToTextPacket) error {
-	if packet.Script == "" {
+	if strings.TrimSpace(packet.Script) == "" {
 		return nil
 	}
 	endOfSpeech.mu.Lock()
+	if endOfSpeech.state.vadState == vadStateEnded {
+		endOfSpeech.state.turnStopDeadline = time.Now().Add(endOfSpeech.turnStopTimeout)
+	}
 	if endOfSpeech.state.transcript == transcriptStateUserText {
 		endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision}
 		endOfSpeech.state.started = false
@@ -511,7 +543,7 @@ func (endOfSpeech *pipecatEndOfSpeech) handleSpeechToTextPacket(ctx context.Cont
 			}
 			shouldSchedule = true
 		case vadStateEnded:
-			shouldSchedule = endOfSpeech.state.turnState == turnStateComplete
+			shouldSchedule = true
 		}
 	}
 	command.deadline = endOfSpeech.state.transcriptDeadline
@@ -581,7 +613,10 @@ func (endOfSpeech *pipecatEndOfSpeech) appendAudio(pcm16 []byte) {
 	endOfSpeech.mu.Unlock()
 }
 
-func (endOfSpeech *pipecatEndOfSpeech) predictEOU() (float64, error) {
+func (endOfSpeech *pipecatEndOfSpeech) predictEOU(ctx context.Context) (float64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	endOfSpeech.mu.RLock()
 	generation := endOfSpeech.audioGeneration
 	if endOfSpeech.hasPredictedResult && endOfSpeech.predictedGeneration == generation {
@@ -617,12 +652,15 @@ func (endOfSpeech *pipecatEndOfSpeech) predictEOU() (float64, error) {
 
 	endOfSpeech.predictorMu.Lock()
 	defer endOfSpeech.predictorMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 
 	if endOfSpeech.predictor == nil {
 		return 0, errPipecatDetectorNil
 	}
 
-	probability, err := endOfSpeech.predictor.Predict(audio)
+	probability, err := endOfSpeech.predictor.PredictContext(ctx, audio)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %w", errPipecatDetectorRunInference, err)
 	}
@@ -684,6 +722,10 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 		timerArmedAt = time.Time{}
 	}
 	resetState := func() {
+		if endOfSpeech.cancelPrediction != nil {
+			endOfSpeech.cancelPrediction()
+			endOfSpeech.cancelPrediction = nil
+		}
 		endOfSpeech.state.segment = speechSegment{Revision: endOfSpeech.state.segment.Revision + 1}
 		endOfSpeech.state.confidence = 0
 		endOfSpeech.state.started = false
@@ -692,6 +734,7 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 		endOfSpeech.state.turnState = turnStatePending
 		endOfSpeech.state.vadRevision++
 		endOfSpeech.state.transcriptDeadline = time.Time{}
+		endOfSpeech.state.turnStopDeadline = time.Time{}
 		endOfSpeech.state.silenceSamples = 0
 		endOfSpeech.audioBuffer = endOfSpeech.audioBuffer[:0]
 		endOfSpeech.audioStartSample = endOfSpeech.audioNextSample
@@ -723,6 +766,11 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 				endOfSpeech.mu.Unlock()
 				continue
 			}
+			// The inactivity watchdog only recovers turns that model or audio completion has not released.
+			if endOfSpeech.state.vadState == vadStateEnded && endOfSpeech.state.turnState != turnStateComplete &&
+				command.deadline.Before(endOfSpeech.state.turnStopDeadline) {
+				command.deadline = endOfSpeech.state.turnStopDeadline
+			}
 			currentCommand = command
 			stopTimer()
 			timerArmedAt = time.Now()
@@ -742,17 +790,36 @@ func (endOfSpeech *pipecatEndOfSpeech) worker() {
 				endOfSpeech.mu.Unlock()
 				continue
 			}
-			if endOfSpeech.state.vadState == vadStateEnded &&
-				endOfSpeech.state.turnState != turnStateComplete {
+			if endOfSpeech.state.vadState == vadStateEnded && endOfSpeech.state.turnState != turnStateComplete &&
+				(endOfSpeech.state.turnStopDeadline.IsZero() ||
+					time.Now().Before(endOfSpeech.state.turnStopDeadline)) {
 				stopTimer()
 				endOfSpeech.mu.Unlock()
 				continue
 			}
+			turnStopDeadlineExpired := endOfSpeech.state.vadState == vadStateEnded && endOfSpeech.state.turnState != turnStateComplete
 			command := currentCommand
+			command.confidence = endOfSpeech.state.confidence
 			armedAt := timerArmedAt
 			stopTimer()
 			resetState()
 			endOfSpeech.mu.Unlock()
+			if turnStopDeadlineExpired {
+				_ = endOfSpeech.onPacket(command.ctx, internal_type.ObservabilityLogRecordPacket{
+					ContextID: command.segment.ContextID,
+					Scope:     internal_type.ObservabilityRecordScopeUserMessage,
+					Record: observability.RecordLog{
+						Level:      observability.LevelInfo,
+						Message:    "Pipecat inactivity watchdog released committed text without a complete prediction",
+						OccurredAt: time.Now(),
+						Attributes: observability.Attributes{
+							"component":  observability.ComponentEOS.String(),
+							"provider":   endOfSpeech.Name(),
+							"confidence": fmt.Sprintf("%.4f", command.confidence),
+						},
+					},
+				})
+			}
 			endOfSpeech.emitEndOfSpeech(command, armedAt)
 		}
 	}
@@ -827,6 +894,12 @@ func (endOfSpeech *pipecatEndOfSpeech) Close(ctx context.Context) error {
 
 	endOfSpeech.closeOnce.Do(func() {
 		endOfSpeech.mu.Lock()
+		if endOfSpeech.cancelPrediction != nil {
+			endOfSpeech.cancelPrediction()
+			endOfSpeech.cancelPrediction = nil
+		}
+		endOfSpeech.state.vadRevision++
+		endOfSpeech.state.segment.Revision++
 		eosStartedAt := endOfSpeech.eosStartedAt
 		endOfSpeech.eosStartedAt = time.Time{}
 		endOfSpeech.mu.Unlock()

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_activity_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_activity_test.go
@@ -1,0 +1,361 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package internal_pipecat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type activityCompletion struct {
+	packet internal_type.EndOfSpeechPacket
+	at     time.Time
+}
+
+func TestEOS_TranscriptActivityPostponesTurnStopRecovery(t *testing.T) {
+	for _, testCase := range []struct {
+		name            string
+		firstFinal      bool
+		secondChunk     string
+		wantSpeech      string
+		fallbackTimeout float64
+	}{
+		{name: "interim update", secondChunk: "there", wantSpeech: "hello there", fallbackTimeout: 80},
+		{name: "final update", firstFinal: true, secondChunk: "friend", wantSpeech: "hello there friend", fallbackTimeout: 80},
+		{name: "longer transcript safety", secondChunk: "there", wantSpeech: "hello there", fallbackTimeout: 2200},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			completed := make(chan activityCompletion, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(_ context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- activityCompletion{packet: packet, at: time.Now()}
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": testCase.fallbackTimeout,
+				"microphone.eos.extended_timeout": 200.0,
+			}), func([]float32) (float64, error) { return 0.1, nil })
+			endOfSpeech.turnStopTimeout = 800 * time.Millisecond
+			defer closeTestEndOfSpeech(endOfSpeech)
+
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello", true)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			endOfSpeech.mu.RLock()
+			initialDeadline := endOfSpeech.state.turnStopDeadline
+			transcriptDeadline := endOfSpeech.state.transcriptDeadline
+			endOfSpeech.mu.RUnlock()
+
+			select {
+			case result := <-completed:
+				t.Fatalf("incomplete turn completed before transcript activity: %+v", result.packet)
+			case <-time.After(time.Until(initialDeadline.Add(-400 * time.Millisecond))):
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("there", testCase.firstFinal)))
+			endOfSpeech.mu.RLock()
+			activityDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.True(t, activityDeadline.After(initialDeadline), "text activity must extend recovery")
+
+			select {
+			case result := <-completed:
+				t.Fatalf("transcript activity did not postpone the original watchdog: %+v", result.packet)
+			case <-time.After(time.Until(initialDeadline.Add(100 * time.Millisecond))):
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput(testCase.secondChunk, true)))
+			endOfSpeech.mu.RLock()
+			finalDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.True(t, finalDeadline.After(activityDeadline), "later committed text must extend recovery again")
+
+			select {
+			case result := <-completed:
+				t.Fatalf("turn completed before the latest inactivity deadline: %+v", result.packet)
+			case <-time.After(time.Until(finalDeadline.Add(-400 * time.Millisecond))):
+			}
+			for _, script := range []string{"", " \t\n "} {
+				for _, final := range []bool{false, true} {
+					require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput(script, final)))
+				}
+			}
+			endOfSpeech.mu.RLock()
+			deadlineAfterBlanks := endOfSpeech.state.turnStopDeadline
+			transcriptDeadlineAfterBlanks := endOfSpeech.state.transcriptDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.Equal(t, finalDeadline, deadlineAfterBlanks, "blank STT must not extend inactivity")
+			assert.Equal(t, transcriptDeadline, transcriptDeadlineAfterBlanks, "blank STT must not change transcript safety")
+			recoveryDeadline := finalDeadline
+			if transcriptDeadline.After(recoveryDeadline) {
+				recoveryDeadline = transcriptDeadline
+			}
+			select {
+			case result := <-completed:
+				assert.Equal(t, testCase.wantSpeech, result.packet.Speech)
+				assert.False(t, result.at.Before(finalDeadline), "recovery must wait for inactivity after the last final")
+				assert.False(t, result.at.Before(transcriptDeadline), "recovery must also wait for transcript safety")
+			case <-time.After(time.Until(recoveryDeadline.Add(time.Second))):
+				t.Fatal("committed text did not complete after transcript inactivity")
+			}
+			select {
+			case result := <-completed:
+				t.Fatalf("turn completed twice: %+v", result.packet)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestEOS_CompleteTurnActivityKeepsTranscriptDeadline(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		probability   float64
+		audioComplete bool
+	}{
+		{name: "model complete", probability: 0.9},
+		{name: "audio silence complete", probability: 0.1, audioComplete: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			completed := make(chan activityCompletion, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(_ context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- activityCompletion{packet: packet, at: time.Now()}
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 600.0,
+				"microphone.eos.extended_timeout": 200.0,
+			}), func([]float32) (float64, error) { return testCase.probability, nil })
+			endOfSpeech.turnStopTimeout = 3 * time.Second
+			defer closeTestEndOfSpeech(endOfSpeech)
+
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello", true)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			endOfSpeech.mu.RLock()
+			transcriptDeadline := endOfSpeech.state.transcriptDeadline
+			initialTurnStopDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+
+			for index, final := range []bool{false, true} {
+				updateAt := transcriptDeadline.Add(time.Duration(index-2) * 200 * time.Millisecond)
+				select {
+				case result := <-completed:
+					t.Fatalf("turn completed before transcript safety elapsed: %+v", result.packet)
+				case <-time.After(time.Until(updateAt)):
+				}
+				require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("there", final)))
+			}
+			endOfSpeech.mu.RLock()
+			deadlineAfterActivity := endOfSpeech.state.transcriptDeadline
+			turnStopDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.Equal(t, transcriptDeadline, deadlineAfterActivity)
+			assert.True(t, turnStopDeadline.After(initialTurnStopDeadline))
+			if testCase.audioComplete {
+				require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{
+					Audio: make([]byte, 6400),
+				}))
+			}
+
+			select {
+			case result := <-completed:
+				assert.Equal(t, "hello there", result.packet.Speech)
+				assert.False(t, result.at.Before(transcriptDeadline), "COMPLETE must retain transcript safety")
+				assert.True(t, result.at.Before(turnStopDeadline), "COMPLETE must not wait for recovery")
+			case <-time.After(time.Until(transcriptDeadline.Add(time.Second))):
+				t.Fatal("COMPLETE was delayed by the transcript inactivity watchdog")
+			}
+		})
+	}
+}
+
+func TestEOS_TranscriptActivityDoesNotExtendPredictionCancellation(t *testing.T) {
+	for _, testCase := range []struct {
+		name            string
+		fallbackTimeout float64
+	}{
+		{name: "watchdog sets prediction budget", fallbackTimeout: 80},
+		{name: "transcript safety sets prediction budget", fallbackTimeout: 1200},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			completed := make(chan activityCompletion, 4)
+			predictionStarted := make(chan time.Time, 1)
+			predictionCanceled := make(chan struct {
+				at  time.Time
+				err error
+			}, 1)
+			predictionReturned := make(chan error, 1)
+			predictionDone := make(chan struct{})
+			endOfSpeech := newTestEOS(func(_ context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- activityCompletion{packet: packet, at: time.Now()}
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": testCase.fallbackTimeout,
+				"microphone.eos.extended_timeout": 200.0,
+			}))
+			endOfSpeech.turnStopTimeout = time.Second
+			endOfSpeech.predictor = testPredictor{predictContext: func(ctx context.Context, _ []float32) (float64, error) {
+				deadline, _ := ctx.Deadline()
+				predictionStarted <- deadline
+				<-ctx.Done()
+				predictionCanceled <- struct {
+					at  time.Time
+					err error
+				}{at: time.Now(), err: ctx.Err()}
+				return 0, ctx.Err()
+			}}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer closeTestEndOfSpeech(endOfSpeech)
+			defer cancel()
+			require.NoError(t, endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(ctx, audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(ctx, sttInput("hello", true)))
+			go func() {
+				defer close(predictionDone)
+				predictionReturned <- endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+					Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+				})
+			}()
+			t.Cleanup(func() {
+				select {
+				case <-predictionDone:
+				case <-time.After(time.Second):
+					t.Error("canceled prediction did not return")
+				}
+			})
+
+			var predictionDeadline time.Time
+			select {
+			case predictionDeadline = <-predictionStarted:
+				require.False(t, predictionDeadline.IsZero(), "inference must have a fixed deadline")
+			case <-time.After(time.Second):
+				t.Fatal("prediction did not start")
+			}
+			endOfSpeech.mu.RLock()
+			expectedPredictionDeadline := endOfSpeech.state.turnStopDeadline
+			if endOfSpeech.state.transcriptDeadline.After(expectedPredictionDeadline) {
+				expectedPredictionDeadline = endOfSpeech.state.transcriptDeadline
+			}
+			endOfSpeech.mu.RUnlock()
+			assert.Equal(t, expectedPredictionDeadline, predictionDeadline)
+			select {
+			case result := <-completed:
+				t.Fatalf("blocked prediction completed before transcript activity: %+v", result.packet)
+			case <-time.After(time.Until(predictionDeadline.Add(-400 * time.Millisecond))):
+			}
+			require.NoError(t, endOfSpeech.Execute(ctx, sttInput("there", false)))
+			endOfSpeech.mu.RLock()
+			activityDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.True(t, activityDeadline.After(predictionDeadline))
+
+			select {
+			case result := <-predictionCanceled:
+				assert.ErrorIs(t, result.err, context.DeadlineExceeded)
+				assert.False(t, result.at.Before(predictionDeadline), "inference canceled before its initial deadline")
+				assert.True(t, result.at.Before(activityDeadline), "STT activity must not extend inference")
+			case <-time.After(time.Until(predictionDeadline.Add(300 * time.Millisecond))):
+				t.Fatal("prediction did not cancel at its original deadline")
+			}
+			select {
+			case err := <-predictionReturned:
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			case <-time.After(300 * time.Millisecond):
+				t.Fatal("prediction cancellation did not release Execute")
+			}
+			select {
+			case result := <-completed:
+				t.Fatalf("inference cancellation caused premature EOS: %+v", result.packet)
+			case <-time.After(100 * time.Millisecond):
+			}
+			require.NoError(t, endOfSpeech.Execute(ctx, sttInput("there friend", true)))
+			endOfSpeech.mu.RLock()
+			finalDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			assert.True(t, finalDeadline.After(activityDeadline))
+
+			select {
+			case result := <-completed:
+				assert.Equal(t, "hello there friend", result.packet.Speech)
+				assert.False(t, result.at.Before(finalDeadline), "late final must receive a full inactivity budget")
+			case <-time.After(time.Until(finalDeadline.Add(time.Second))):
+				t.Fatal("late final did not complete after transcript inactivity")
+			}
+		})
+	}
+}
+
+func TestEOS_InterimOnlyActivityNeverCompletesTurn(t *testing.T) {
+	for _, probability := range []float64{0.1, 0.9} {
+		name := "incomplete"
+		if probability > defaultPctThreshold {
+			name = "complete"
+		}
+		t.Run(name, func(t *testing.T) {
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(_ context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 80.0,
+				"microphone.eos.extended_timeout": 100.0,
+			}), func([]float32) (float64, error) { return probability, nil })
+			endOfSpeech.turnStopTimeout = 400 * time.Millisecond
+			defer closeTestEndOfSpeech(endOfSpeech)
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello", false)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			select {
+			case packet := <-completed:
+				t.Fatalf("interim-only text completed before later activity: %+v", packet)
+			case <-time.After(200 * time.Millisecond):
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello there", false)))
+			endOfSpeech.mu.RLock()
+			activityDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			select {
+			case packet := <-completed:
+				t.Fatalf("interim-only text completed after inactivity: %+v", packet)
+			case <-time.After(time.Until(activityDeadline.Add(150 * time.Millisecond))):
+			}
+		})
+	}
+}

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_bench_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_bench_test.go
@@ -259,6 +259,37 @@ func BenchmarkExecute_STTInput(b *testing.B) {
 	}
 }
 
+func BenchmarkIncompleteTurnTimer(b *testing.B) {
+	for _, benchmarkCase := range []struct {
+		name      string
+		turnState turnState
+	}{
+		{name: "prediction pending", turnState: turnStatePending},
+		{name: "prediction incomplete", turnState: turnStateIncomplete},
+	} {
+		b.Run(benchmarkCase.name, func(b *testing.B) {
+			endOfSpeech := newTestEOS(func(context.Context, ...internal_type.Packet) error { return nil }, nil)
+			defer closeTestEndOfSpeech(endOfSpeech)
+			endOfSpeech.mu.Lock()
+			endOfSpeech.state.vadState = vadStateEnded
+			endOfSpeech.state.turnState = benchmarkCase.turnState
+			endOfSpeech.state.transcript = transcriptStateFinalized
+			endOfSpeech.state.segment = speechSegment{Revision: 1, FinalText: "committed", Text: "committed"}
+			endOfSpeech.state.turnStopDeadline = time.Now().Add(time.Hour)
+			command := workerCommand{
+				ctx:      context.Background(),
+				segment:  endOfSpeech.state.segment,
+				deadline: time.Now().Add(time.Minute),
+			}
+			endOfSpeech.mu.Unlock()
+			b.ReportAllocs()
+			for b.Loop() {
+				endOfSpeech.enqueueCommand(command)
+			}
+		})
+	}
+}
+
 // BenchmarkExecute_AudioInput measures the audio accumulation path.
 func BenchmarkExecute_AudioInput(b *testing.B) {
 	callback := func(context.Context, ...internal_type.Packet) error { return nil }

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_integration_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_integration_test.go
@@ -42,6 +42,7 @@ func TestEOS_UIOptionDefaults(t *testing.T) {
 	require.Equal(t, defaultPctThreshold, configured.threshold)
 	require.Equal(t, time.Duration(defaultPctFallbackTimeout)*time.Millisecond, configured.fallbackTimeout)
 	require.Equal(t, time.Duration(defaultPctExtendedTimeout)*time.Millisecond, configured.extendedTimeout)
+	require.Equal(t, 5*time.Second, configured.turnStopTimeout)
 }
 
 func TestEOS_CanonicalConstructorOptions(t *testing.T) {
@@ -55,8 +56,8 @@ func TestEOS_CanonicalConstructorOptions(t *testing.T) {
 		{
 			name:            "missing canonical values use defaults",
 			threshold:       defaultPctThreshold,
-			fallbackTimeout: 500 * time.Millisecond,
-			extendedTimeout: 3000 * time.Millisecond,
+			fallbackTimeout: time.Duration(defaultPctFallbackTimeout) * time.Millisecond,
+			extendedTimeout: time.Duration(defaultPctExtendedTimeout) * time.Millisecond,
 		},
 		{
 			name: "custom canonical values",
@@ -88,8 +89,8 @@ func TestEOS_CanonicalConstructorOptions(t *testing.T) {
 				internal_options.MicrophoneEOSOptionExtendedTimeout: "invalid",
 			},
 			threshold:       defaultPctThreshold,
-			fallbackTimeout: 500 * time.Millisecond,
-			extendedTimeout: 3000 * time.Millisecond,
+			fallbackTimeout: time.Duration(defaultPctFallbackTimeout) * time.Millisecond,
+			extendedTimeout: time.Duration(defaultPctExtendedTimeout) * time.Millisecond,
 		},
 		{
 			name: "aliases ignored",
@@ -100,8 +101,8 @@ func TestEOS_CanonicalConstructorOptions(t *testing.T) {
 				internal_options.MicrophoneEOSOptionModel:        "ignored",
 			},
 			threshold:       defaultPctThreshold,
-			fallbackTimeout: 500 * time.Millisecond,
-			extendedTimeout: 3000 * time.Millisecond,
+			fallbackTimeout: time.Duration(defaultPctFallbackTimeout) * time.Millisecond,
+			extendedTimeout: time.Duration(defaultPctExtendedTimeout) * time.Millisecond,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -116,6 +117,7 @@ func TestEOS_CanonicalConstructorOptions(t *testing.T) {
 			require.Equal(t, test.threshold, configured.threshold)
 			require.Equal(t, test.fallbackTimeout, configured.fallbackTimeout)
 			require.Equal(t, test.extendedTimeout, configured.extendedTimeout)
+			require.Equal(t, 5*time.Second, configured.turnStopTimeout)
 		})
 	}
 }
@@ -126,7 +128,7 @@ func TestEOS_NativeSmartTurnAudioFlow(t *testing.T) {
 		WithContext(t.Context()),
 		WithOptions(utils.Option{
 			"microphone.eos.fallback_timeout": 50.0,
-			"microphone.eos.extended_timeout": 100.0,
+			"microphone.eos.extended_timeout": 1000.0,
 		}),
 		WithOnPacket(func(ctx context.Context, packets ...internal_type.Packet) error {
 			for _, packet := range packets {
@@ -141,8 +143,8 @@ func TestEOS_NativeSmartTurnAudioFlow(t *testing.T) {
 	nativeEndOfSpeech := endOfSpeech.(*pipecatEndOfSpeech)
 	nativePredictor := nativeEndOfSpeech.predictor
 	var predictionCount int
-	nativeEndOfSpeech.predictor = testPredictor{predict: func(audio []float32) (float64, error) {
-		probability, predictionError := nativePredictor.Predict(audio)
+	nativeEndOfSpeech.predictor = testPredictor{predictContext: func(ctx context.Context, audio []float32) (float64, error) {
+		probability, predictionError := nativePredictor.PredictContext(ctx, audio)
 		require.NoError(t, predictionError)
 		predictionCount++
 		return probability, predictionError
@@ -166,7 +168,7 @@ func TestEOS_NativeSmartTurnAudioFlow(t *testing.T) {
 			Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
 		}))
 		require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{
-			Audio: make([]byte, 3200),
+			Audio: make([]byte, 32000),
 		}))
 		select {
 		case packet := <-completed:

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_prediction_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_prediction_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package internal_pipecat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEOS_StoppedTurnCompletesWhilePredictionIsBlocked(t *testing.T) {
+	for _, finalBeforePrediction := range []bool{true, false} {
+		name := "final before prediction"
+		if !finalBeforePrediction {
+			name = "final during prediction"
+		}
+		t.Run(name, func(t *testing.T) {
+			predictionStarted := make(chan struct{})
+			finishPrediction := make(chan struct{})
+			predictionReturned := make(chan struct{})
+			var predictionErr error
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(ctx context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 100.0,
+				"microphone.eos.extended_timeout": 200.0,
+			}), func([]float32) (float64, error) {
+				close(predictionStarted)
+				<-finishPrediction
+				return 0.9, nil
+			})
+			endOfSpeech.turnStopTimeout = 200 * time.Millisecond
+			t.Cleanup(func() {
+				select {
+				case <-finishPrediction:
+				default:
+					close(finishPrediction)
+				}
+				select {
+				case <-predictionReturned:
+					assert.NoError(t, predictionErr)
+				case <-time.After(time.Second):
+					t.Error("prediction did not return after being released")
+				}
+				closeTestEndOfSpeech(endOfSpeech)
+			})
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			if finalBeforePrediction {
+				require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("committed transcript", true)))
+			}
+			stoppedAt := time.Now()
+			go func() {
+				predictionErr = endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+					Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+				})
+				close(predictionReturned)
+			}()
+			select {
+			case <-predictionStarted:
+			case <-time.After(time.Second):
+				t.Fatal("prediction did not start")
+			}
+			if !finalBeforePrediction {
+				require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("committed transcript", true)))
+			}
+			select {
+			case packet := <-completed:
+				assert.Equal(t, "committed transcript", packet.Speech)
+				assert.GreaterOrEqual(t, time.Since(stoppedAt), 200*time.Millisecond)
+				assert.Less(t, time.Since(stoppedAt), 600*time.Millisecond)
+			case <-time.After(600 * time.Millisecond):
+				t.Fatal("blocked prediction prevented stopped-turn completion")
+			}
+			select {
+			case <-predictionReturned:
+				t.Fatalf("test predictor returned before release: %v", predictionErr)
+			default:
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("next turn", true)))
+			close(finishPrediction)
+			select {
+			case <-predictionReturned:
+				require.NoError(t, predictionErr)
+			case <-time.After(time.Second):
+				t.Fatal("stale prediction did not return")
+			}
+			select {
+			case packet := <-completed:
+				assert.Equal(t, "next turn", packet.Speech)
+			case <-time.After(time.Second):
+				t.Fatal("stale prediction blocked the next turn")
+			}
+			select {
+			case packet := <-completed:
+				t.Fatalf("stale prediction completed an extra turn: %+v", packet)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestEOS_PredictionCancellation(t *testing.T) {
+	for _, action := range []string{"deadline", "audio completion", "speech resumed", "typed text", "close"} {
+		t.Run(action, func(t *testing.T) {
+			predictionStarted := make(chan struct{})
+			predictionCanceled := make(chan error, 1)
+			predictionReturned := make(chan struct{})
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			extendedTimeout := 200.0
+			if action == "audio completion" {
+				extendedTimeout = 1000.0
+			}
+			endOfSpeech := newTestEOS(func(ctx context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 50.0,
+				"microphone.eos.extended_timeout": extendedTimeout,
+			}))
+			endOfSpeech.turnStopTimeout = 200 * time.Millisecond
+			if action == "audio completion" {
+				endOfSpeech.turnStopTimeout = time.Second
+			}
+			endOfSpeech.predictor = testPredictor{predictContext: func(ctx context.Context, audio []float32) (float64, error) {
+				close(predictionStarted)
+				<-ctx.Done()
+				predictionCanceled <- ctx.Err()
+				return 0, ctx.Err()
+			}}
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(func() {
+				cancel()
+				select {
+				case <-predictionReturned:
+				case <-time.After(time.Second):
+					t.Error("canceled prediction did not return")
+				}
+				closeTestEndOfSpeech(endOfSpeech)
+			})
+			require.NoError(t, endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(ctx, audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(ctx, sttInput("committed transcript", true)))
+			go func() {
+				_ = endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+					Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+				})
+				close(predictionReturned)
+			}()
+			select {
+			case <-predictionStarted:
+			case <-time.After(time.Second):
+				t.Fatal("prediction did not start")
+			}
+			switch action {
+			case "audio completion":
+				require.NoError(t, endOfSpeech.Execute(ctx, internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 32000)}))
+			case "speech resumed":
+				require.NoError(t, endOfSpeech.Execute(ctx, internal_type.InterruptionDetectedPacket{
+					Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+				}))
+			case "typed text":
+				require.NoError(t, endOfSpeech.Execute(ctx, userInput("typed replacement")))
+			case "close":
+				closed := make(chan error, 1)
+				go func() { closed <- endOfSpeech.Close(ctx) }()
+				select {
+				case err := <-closed:
+					require.NoError(t, err)
+				case <-time.After(time.Second):
+					t.Fatal("close waited for the prediction deadline")
+				}
+			}
+			cancellationTimeout := time.Second
+			if action == "audio completion" {
+				cancellationTimeout = 200 * time.Millisecond
+			}
+			select {
+			case err := <-predictionCanceled:
+				if action == "deadline" {
+					assert.Error(t, err)
+				} else {
+					assert.ErrorIs(t, err, context.Canceled)
+				}
+			case <-time.After(cancellationTimeout):
+				t.Fatal("prediction was not canceled")
+			}
+			if action == "deadline" || action == "audio completion" || action == "typed text" {
+				select {
+				case packet := <-completed:
+					if action == "typed text" {
+						assert.Equal(t, "typed replacement", packet.Speech)
+					} else {
+						assert.Equal(t, "committed transcript", packet.Speech)
+					}
+				case <-time.After(cancellationTimeout):
+					t.Fatal("expected turn did not complete after prediction cancellation")
+				}
+			}
+			select {
+			case packet := <-completed:
+				t.Fatalf("canceled prediction completed an extra turn: %+v", packet)
+			case <-time.After(250 * time.Millisecond):
+			}
+		})
+	}
+}

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_test.go
@@ -56,11 +56,19 @@ func newTestOpts(m map[string]any) utils.Option {
 }
 
 type testPredictor struct {
-	predict func([]float32) (float64, error)
+	predict        func([]float32) (float64, error)
+	predictContext func(context.Context, []float32) (float64, error)
 }
 
 func (predictor testPredictor) Predict(audio []float32) (float64, error) {
 	return predictor.predict(audio)
+}
+
+func (predictor testPredictor) PredictContext(ctx context.Context, audio []float32) (float64, error) {
+	if predictor.predictContext != nil {
+		return predictor.predictContext(ctx, audio)
+	}
+	return predictor.Predict(audio)
 }
 
 func newTestEOS(onPacket func(context.Context, ...internal_type.Packet) error, opts utils.Option) *pipecatEndOfSpeech {
@@ -83,6 +91,7 @@ func newTestEOS(onPacket func(context.Context, ...internal_type.Packet) error, o
 		threshold:       threshold,
 		extendedTimeout: extendedTimeout,
 		fallbackTimeout: fallbackTimeout,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		audioBuffer:     make([]float32, 0, maxAudioSamples),
 		commandCh:       make(chan workerCommand, 32),
 		stopCh:          make(chan struct{}),
@@ -569,6 +578,8 @@ func TestExecuteVADEnd_SampleDurationBounds(t *testing.T) {
 			endOfSpeech := &pipecatEndOfSpeech{
 				threshold:       0.5,
 				fallbackTimeout: 500 * time.Millisecond,
+				extendedTimeout: time.Second,
+				turnStopTimeout: defaultPctTurnStopTimeout,
 				audioNextSample: testCase.elapsedSamples + pipecatAudioSampleRate,
 				state:           &endOfSpeechState{},
 			}
@@ -652,7 +663,7 @@ func TestAppendAudio_ConcurrentSafety(t *testing.T) {
 
 func TestPredictEOU_EmptyAudioBufferRemainsIncomplete(t *testing.T) {
 	eos := &pipecatEndOfSpeech{}
-	probability, err := eos.predictEOU()
+	probability, err := eos.predictEOU(t.Context())
 	require.NoError(t, err)
 	assert.Zero(t, probability)
 }
@@ -661,7 +672,7 @@ func TestPredictEOU_DetectorUnavailableReturnsError(t *testing.T) {
 	eos := &pipecatEndOfSpeech{
 		audioBuffer: []float32{0.1, -0.1, 0.05},
 	}
-	probability, err := eos.predictEOU()
+	probability, err := eos.predictEOU(t.Context())
 	require.ErrorIs(t, err, errPipecatDetectorNil)
 	assert.Zero(t, probability)
 }
@@ -673,7 +684,7 @@ func TestPredictEOU_SpeechOffsetBeyondBufferSkipsPrediction(t *testing.T) {
 			hasSpeechStart:    true,
 			speechStartSample: speechStartSample,
 		}
-		probability, err := endOfSpeech.predictEOU()
+		probability, err := endOfSpeech.predictEOU(t.Context())
 		require.NoError(t, err, "speech start: %d", speechStartSample)
 		require.Zero(t, probability)
 	}
@@ -694,7 +705,7 @@ func TestPredictEOU_ReusesCachedProbabilityForSameAudioGeneration(t *testing.T) 
 	require.NoError(t, eos.Execute(context.Background(), audioInput(1600)))
 
 	for range 2 {
-		probability, err := eos.predictEOU()
+		probability, err := eos.predictEOU(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, 0.75, probability)
 	}
@@ -714,13 +725,13 @@ func TestPredictEOU_InvalidatesCacheWhenAudioChanges(t *testing.T) {
 
 	require.NoError(t, eos.Execute(context.Background(), audioInput(1600)))
 	for range 2 {
-		probability, err := eos.predictEOU()
+		probability, err := eos.predictEOU(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, 1.0, probability)
 	}
 
 	require.NoError(t, eos.Execute(context.Background(), audioInput(1600)))
-	probability, err := eos.predictEOU()
+	probability, err := eos.predictEOU(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 2.0, probability)
 	assert.Equal(t, int32(2), atomic.LoadInt32(&predictorCalls))
@@ -750,7 +761,7 @@ func TestPredictEOU_UsesSpeechScopedAudio(t *testing.T) {
 	eos.audioGeneration = 1
 	eos.mu.Unlock()
 
-	probability, err := eos.predictEOU()
+	probability, err := eos.predictEOU(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 0.7, probability)
 
@@ -778,12 +789,12 @@ func TestPredictEOU_FailedPredictionIsNotCached(t *testing.T) {
 	)
 	defer closeTestEndOfSpeech(endOfSpeech)
 	require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
-	probability, err := endOfSpeech.predictEOU()
+	probability, err := endOfSpeech.predictEOU(t.Context())
 	require.ErrorIs(t, err, errPipecatDetectorRunInference)
 	require.ErrorIs(t, err, errPipecatDetectorCreateInputTensor)
 	assert.Zero(t, probability)
 	for range 2 {
-		probability, err = endOfSpeech.predictEOU()
+		probability, err = endOfSpeech.predictEOU(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, 0.9, probability)
 	}
@@ -816,6 +827,7 @@ func TestPipecatEndOfSpeech_IgnoresInterruptionForDifferentContext(t *testing.T)
 		commandCh:       make(chan workerCommand, 1),
 		stopCh:          make(chan struct{}),
 		extendedTimeout: 30 * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		state: &endOfSpeechState{segment: speechSegment{
 			Revision:  1,
 			ContextID: "ctx-new",
@@ -1043,6 +1055,7 @@ func TestEOS_FinalSTTDoesNotRunSmartTurnPrediction(t *testing.T) {
 		},
 		threshold:       0.5,
 		extendedTimeout: 260 * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		fallbackTimeout: 80 * time.Millisecond,
 		audioBuffer:     []float32{0.1, 0.2, 0.3},
 		audioGeneration: 1,
@@ -1276,7 +1289,7 @@ func TestEOS_FinalSTTWhileVADSpeakingWaitsForVADEnd(t *testing.T) {
 	}
 }
 
-func TestEOS_FinalSTTAfterIncompleteVADEndWaitsForSilentAudio(t *testing.T) {
+func TestEOS_FinalSTTAfterIncompleteVADEndSchedulesFallback(t *testing.T) {
 	var predictorCalls int32
 	eos := &pipecatEndOfSpeech{
 		onPacket: func(context.Context, ...internal_type.Packet) error { return nil },
@@ -1288,6 +1301,7 @@ func TestEOS_FinalSTTAfterIncompleteVADEndWaitsForSilentAudio(t *testing.T) {
 		},
 		threshold:       0.5,
 		extendedTimeout: 250 * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		fallbackTimeout: 60 * time.Millisecond,
 		audioBuffer:     []float32{0.1, 0.2, 0.3},
 		audioGeneration: 1,
@@ -1305,7 +1319,13 @@ func TestEOS_FinalSTTAfterIncompleteVADEndWaitsForSilentAudio(t *testing.T) {
 		Event:  internal_type.InterruptionEventEnd,
 	}))
 	require.NoError(t, eos.Execute(context.Background(), sttInput("not done yet", true)))
-	assert.Empty(t, eos.commandCh)
+	select {
+	case command := <-eos.commandCh:
+		assert.Equal(t, "not done yet", command.segment.Text)
+		assert.False(t, command.fireImmediately)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("incomplete turn did not schedule its fallback")
+	}
 	require.NoError(t, eos.Execute(context.Background(), audioInput(4000)))
 
 	select {
@@ -1332,6 +1352,7 @@ func TestEOS_FinalSTTAfterVADEndCompletePredictionWaitsForTranscriptDeadline(t *
 		},
 		threshold:       0.5,
 		extendedTimeout: 250 * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		fallbackTimeout: 60 * time.Millisecond,
 		audioBuffer:     []float32{0.1, 0.2, 0.3},
 		audioGeneration: 1,
@@ -1374,10 +1395,11 @@ func TestEOS_VADEndCompletePredictionWaitsForTranscriptDeadline(t *testing.T) {
 		},
 		threshold:       0.5,
 		extendedTimeout: 300 * time.Millisecond,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		fallbackTimeout: 60 * time.Millisecond,
 		audioBuffer:     []float32{0.1, 0.2, 0.3},
 		audioGeneration: 1,
-		commandCh:       make(chan workerCommand, 1),
+		commandCh:       make(chan workerCommand, 2),
 		stopCh:          make(chan struct{}),
 		state: &endOfSpeechState{
 			segment: speechSegment{
@@ -1397,6 +1419,13 @@ func TestEOS_VADEndCompletePredictionWaitsForTranscriptDeadline(t *testing.T) {
 		Event:     internal_type.InterruptionEventEnd,
 	}))
 
+	select {
+	case command := <-endOfSpeech.commandCh:
+		assert.Equal(t, 0.0, command.confidence)
+		assert.Equal(t, "I just wanted to talk with you and then", command.segment.Text)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("VAD end did not arm completion before inference")
+	}
 	select {
 	case command := <-endOfSpeech.commandCh:
 		assert.False(t, command.fireImmediately)
@@ -2656,7 +2685,7 @@ func TestEOS_FinalSTTInferenceFailure_DoesNotUseSilenceTimeout(t *testing.T) {
 // FACTORY TEST
 // ============================================================================
 
-func TestEOS_IncompleteTurnRequiresSilentAudio(t *testing.T) {
+func TestEOS_IncompleteTurnAudioCanCompleteBeforeWallDeadline(t *testing.T) {
 	for _, testCase := range []struct {
 		name              string
 		textBeforeSilence bool
@@ -2675,7 +2704,7 @@ func TestEOS_IncompleteTurnRequiresSilentAudio(t *testing.T) {
 				return nil
 			}, newTestOpts(map[string]any{
 				"microphone.eos.fallback_timeout": 10.0,
-				"microphone.eos.extended_timeout": 100.0,
+				"microphone.eos.extended_timeout": 1000.0,
 			}), func([]float32) (float64, error) { return 0.5, nil })
 			defer closeTestEndOfSpeech(endOfSpeech)
 			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
@@ -2694,7 +2723,7 @@ func TestEOS_IncompleteTurnRequiresSilentAudio(t *testing.T) {
 				t.Fatalf("incomplete turn released by transcript timeout: %+v", packet)
 			case <-time.After(120 * time.Millisecond):
 			}
-			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1599)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(15999)))
 			select {
 			case packet := <-completed:
 				t.Fatalf("turn released before silent audio limit: %+v", packet)
@@ -2707,7 +2736,7 @@ func TestEOS_IncompleteTurnRequiresSilentAudio(t *testing.T) {
 			select {
 			case packet := <-completed:
 				assert.Equal(t, "committed", packet.Speech)
-			case <-time.After(time.Second):
+			case <-time.After(200 * time.Millisecond):
 				t.Fatal("silence-complete turn did not release committed transcript")
 			}
 		})
@@ -2728,6 +2757,7 @@ func TestEOS_TranscriptDuringInferenceKeepsOriginalDeadline(t *testing.T) {
 		threshold:       0.5,
 		fallbackTimeout: 20 * time.Millisecond,
 		extendedTimeout: time.Second,
+		turnStopTimeout: defaultPctTurnStopTimeout,
 		commandCh:       make(chan workerCommand, 4),
 		stopCh:          make(chan struct{}),
 		state:           &endOfSpeechState{},
@@ -2747,7 +2777,16 @@ func TestEOS_TranscriptDuringInferenceKeepsOriginalDeadline(t *testing.T) {
 	endOfSpeech.mu.RUnlock()
 	require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("first", true)))
 	require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("second", true)))
-	assert.Empty(t, endOfSpeech.commandCh)
+	for _, transcript := range []string{"first", "first second"} {
+		select {
+		case command := <-endOfSpeech.commandCh:
+			assert.Equal(t, transcript, command.segment.Text)
+			assert.Equal(t, deadline, command.deadline)
+			assert.Equal(t, 0.0, command.confidence)
+		case <-time.After(time.Second):
+			t.Fatal("transcript did not arm completion during inference")
+		}
+	}
 	time.Sleep(30 * time.Millisecond)
 	close(finishPrediction)
 	require.NoError(t, <-vadStopped)
@@ -2882,7 +2921,8 @@ func TestEOS_VADDeadlineDiscountsBufferedStopSilence(t *testing.T) {
 				predictor:       testPredictor{predict: func([]float32) (float64, error) { return 0.9, nil }},
 				threshold:       0.5,
 				fallbackTimeout: 500 * time.Millisecond,
-				commandCh:       make(chan workerCommand, 1),
+				turnStopTimeout: defaultPctTurnStopTimeout,
+				commandCh:       make(chan workerCommand, 2),
 				stopCh:          make(chan struct{}),
 				state:           &endOfSpeechState{},
 			}
@@ -2896,17 +2936,19 @@ func TestEOS_VADDeadlineDiscountsBufferedStopSilence(t *testing.T) {
 				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
 				EndAt: testCase.endAt,
 			}))
-			select {
-			case command := <-endOfSpeech.commandCh:
-				assert.WithinDuration(t, stoppedAt.Add(testCase.remainingBudget), command.deadline, 20*time.Millisecond)
-			case <-time.After(time.Second):
-				t.Fatal("missing transcript safety deadline")
+			for commandIndex := 0; commandIndex < 2; commandIndex++ {
+				select {
+				case command := <-endOfSpeech.commandCh:
+					assert.WithinDuration(t, stoppedAt.Add(testCase.remainingBudget), command.deadline, 20*time.Millisecond)
+				case <-time.After(time.Second):
+					t.Fatal("missing transcript safety deadline")
+				}
 			}
 		})
 	}
 }
 
-func TestEOS_VADWithoutPredictionWaitsForSilentAudio(t *testing.T) {
+func TestEOS_VADWithoutPredictionAudioCanCompleteBeforeWallDeadline(t *testing.T) {
 	for _, testCase := range []struct {
 		name          string
 		audioSamples  int
@@ -2938,7 +2980,7 @@ func TestEOS_VADWithoutPredictionWaitsForSilentAudio(t *testing.T) {
 				return nil
 			}, newTestOpts(map[string]any{
 				"microphone.eos.fallback_timeout": 10.0,
-				"microphone.eos.extended_timeout": 60.0,
+				"microphone.eos.extended_timeout": 1000.0,
 			}))
 			endOfSpeech.predictor = testCase.predictor
 			defer closeTestEndOfSpeech(endOfSpeech)
@@ -2966,17 +3008,17 @@ func TestEOS_VADWithoutPredictionWaitsForSilentAudio(t *testing.T) {
 				t.Fatalf("missing prediction released text at the transcript deadline: %+v", packet)
 			case <-time.After(80 * time.Millisecond):
 			}
-			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 960)}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 16000)}))
 			select {
 			case packet := <-completed:
 				t.Fatalf("turn completed before the received-silence limit: %+v", packet)
 			case <-time.After(20 * time.Millisecond):
 			}
-			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 960)}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 16000)}))
 			select {
 			case packet := <-completed:
 				assert.Equal(t, "committed tail", packet.Speech)
-			case <-time.After(time.Second):
+			case <-time.After(200 * time.Millisecond):
 				t.Fatal("received-silence limit did not release committed text")
 			}
 			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.EndOfSpeechAudioPacket{Audio: make([]byte, 1920)}))
@@ -3060,6 +3102,7 @@ func TestEOS_QueuedUserTextPreservesNewerInput(t *testing.T) {
 					return nil
 				},
 				fallbackTimeout: 10 * time.Millisecond,
+				turnStopTimeout: defaultPctTurnStopTimeout,
 				commandCh:       make(chan workerCommand, 4),
 				stopCh:          make(chan struct{}),
 				state:           &endOfSpeechState{},

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_timeout_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/pipecat_end_of_speech_timeout_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2023-2025 RapidaAI
+// Author: Prashant Srivastav <prashant@rapida.ai>
+//
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+package internal_pipecat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rapidaai/api/assistant-api/internal/observability"
+	internal_type "github.com/rapidaai/api/assistant-api/internal/type"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEOS_IncompleteTurnCompletesWithoutMoreAudio(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		audioSamples  int
+		probability   float64
+		predictionErr error
+	}{
+		{name: "below threshold", audioSamples: 1600, probability: 0.1},
+		{name: "at threshold", audioSamples: 1600, probability: defaultPctThreshold},
+		{name: "inference failure", audioSamples: 1600, predictionErr: errPipecatDetectorRunInference},
+		{name: "empty audio"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			fallbackLogs := make(chan internal_type.ObservabilityLogRecordPacket, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(ctx context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+					if packet, ok := packet.(internal_type.ObservabilityLogRecordPacket); ok && packet.Record.Level == observability.LevelInfo {
+						fallbackLogs <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 300.0,
+				"microphone.eos.extended_timeout": 400.0,
+			}), func([]float32) (float64, error) {
+				return testCase.probability, testCase.predictionErr
+			})
+			endOfSpeech.turnStopTimeout = 400 * time.Millisecond
+			defer closeTestEndOfSpeech(endOfSpeech)
+
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(testCase.audioSamples)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("committed transcript", true)))
+			stoppedAt := time.Now()
+			require.ErrorIs(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}), testCase.predictionErr)
+
+			select {
+			case packet := <-completed:
+				assert.Equal(t, "committed transcript", packet.Speech)
+				assert.GreaterOrEqual(t, time.Since(stoppedAt), 400*time.Millisecond)
+				assert.Less(t, time.Since(stoppedAt), 600*time.Millisecond)
+			case <-time.After(600 * time.Millisecond):
+				t.Fatal("committed transcript remained blocked without additional audio")
+			}
+			select {
+			case packet := <-fallbackLogs:
+				assert.Contains(t, packet.Record.Message, "inactivity watchdog")
+			default:
+				t.Fatal("inactivity watchdog completion was not reported")
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(4800)))
+			select {
+			case packet := <-completed:
+				t.Fatalf("turn completed twice: %+v", packet)
+			case <-time.After(30 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestEOS_IncompleteTurnLateTranscriptResetsWatchdog(t *testing.T) {
+	for _, finalBeforeStop := range []bool{false, true} {
+		name := "interim only until after deadline"
+		if finalBeforeStop {
+			name = "committed prefix with later transcript"
+		}
+		t.Run(name, func(t *testing.T) {
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(ctx context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 20.0,
+				"microphone.eos.extended_timeout": 400.0,
+			}), func([]float32) (float64, error) { return 0.1, nil })
+			endOfSpeech.turnStopTimeout = 400 * time.Millisecond
+			defer closeTestEndOfSpeech(endOfSpeech)
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello", finalBeforeStop)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			endOfSpeech.mu.RLock()
+			turnStopDeadline := endOfSpeech.state.turnStopDeadline
+			endOfSpeech.mu.RUnlock()
+			if finalBeforeStop {
+				time.Sleep(250 * time.Millisecond)
+			} else {
+				select {
+				case packet := <-completed:
+					t.Fatalf("interim-only transcript completed: %+v", packet)
+				case <-time.After(450 * time.Millisecond):
+				}
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("pending suffix", false)))
+			endOfSpeech.mu.RLock()
+			assert.True(t, endOfSpeech.state.turnStopDeadline.After(turnStopDeadline))
+			endOfSpeech.mu.RUnlock()
+			transcribedAt := time.Now()
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("world", true)))
+			select {
+			case packet := <-completed:
+				if finalBeforeStop {
+					assert.Equal(t, "hello world", packet.Speech)
+				} else {
+					assert.Equal(t, "world", packet.Speech)
+				}
+				assert.GreaterOrEqual(t, time.Since(transcribedAt), 400*time.Millisecond)
+			case <-time.After(600 * time.Millisecond):
+				t.Fatal("late committed transcript remained blocked")
+			}
+		})
+	}
+}
+
+func TestEOS_IncompleteTurnWatchdogCanceledBySpeechOrClose(t *testing.T) {
+	for _, closeBeforeDeadline := range []bool{false, true} {
+		name := "speech resumed"
+		if closeBeforeDeadline {
+			name = "closed"
+		}
+		t.Run(name, func(t *testing.T) {
+			completed := make(chan internal_type.EndOfSpeechPacket, 4)
+			endOfSpeech := newTestEOSWithPredictor(func(ctx context.Context, packets ...internal_type.Packet) error {
+				for _, packet := range packets {
+					if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+						completed <- packet
+					}
+				}
+				return nil
+			}, newTestOpts(map[string]any{
+				"microphone.eos.fallback_timeout": 20.0,
+				"microphone.eos.extended_timeout": 80.0,
+			}), func([]float32) (float64, error) { return 0.1, nil })
+			endOfSpeech.turnStopTimeout = 80 * time.Millisecond
+			defer closeTestEndOfSpeech(endOfSpeech)
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+			}))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), audioInput(1600)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("hello", true)))
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			if closeBeforeDeadline {
+				require.NoError(t, endOfSpeech.Close(t.Context()))
+			} else {
+				require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+					Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart,
+				}))
+			}
+			select {
+			case packet := <-completed:
+				t.Fatalf("invalidated inactivity watchdog completed a turn: %+v", packet)
+			case <-time.After(120 * time.Millisecond):
+			}
+			if closeBeforeDeadline {
+				return
+			}
+			require.NoError(t, endOfSpeech.Execute(t.Context(), sttInput("world", true)))
+			stoppedAt := time.Now()
+			require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+				Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+			}))
+			select {
+			case packet := <-completed:
+				assert.Equal(t, "hello world", packet.Speech)
+				assert.GreaterOrEqual(t, time.Since(stoppedAt), 80*time.Millisecond)
+			case <-time.After(time.Second):
+				t.Fatal("resumed speech did not complete after its new inactivity deadline")
+			}
+		})
+	}
+}
+
+func TestEOS_IncompleteTurnHonorsLongerTranscriptDeadline(t *testing.T) {
+	completed := make(chan internal_type.EndOfSpeechPacket, 4)
+	endOfSpeech := newTestEOSWithPredictor(func(ctx context.Context, packets ...internal_type.Packet) error {
+		for _, packet := range packets {
+			if packet, ok := packet.(internal_type.EndOfSpeechPacket); ok {
+				completed <- packet
+			}
+		}
+		return nil
+	}, newTestOpts(map[string]any{
+		"microphone.eos.fallback_timeout": 400.0,
+		"microphone.eos.extended_timeout": 300.0,
+	}), func([]float32) (float64, error) { return 0.1, nil })
+	endOfSpeech.turnStopTimeout = 300 * time.Millisecond
+	defer closeTestEndOfSpeech(endOfSpeech)
+	for _, packet := range []internal_type.Packet{
+		internal_type.InterruptionDetectedPacket{Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventStart},
+		audioInput(1600), sttInput("committed", true),
+	} {
+		require.NoError(t, endOfSpeech.Execute(t.Context(), packet))
+	}
+	stoppedAt := time.Now()
+	require.NoError(t, endOfSpeech.Execute(t.Context(), internal_type.InterruptionDetectedPacket{
+		Source: internal_type.InterruptionSourceVad, Event: internal_type.InterruptionEventEnd,
+	}))
+	select {
+	case packet := <-completed:
+		assert.Equal(t, "committed", packet.Speech)
+		assert.GreaterOrEqual(t, time.Since(stoppedAt), 400*time.Millisecond)
+		assert.Less(t, time.Since(stoppedAt), 600*time.Millisecond)
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("turn did not complete after both deadlines elapsed")
+	}
+}

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector.go
@@ -11,6 +11,7 @@ package internal_pipecat
 import "C"
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,6 +120,15 @@ func NewPipecatDetector(cfg PipecatDetectorConfig) (*PipecatDetector, error) {
 //
 // audio must be float32 PCM samples at 16kHz.
 func (pd *PipecatDetector) Predict(audio []float32) (float64, error) {
+	return pd.PredictContext(context.Background(), audio)
+}
+
+// PredictContext computes mel features and synchronously runs cancellable native inference.
+// The caller must serialize prediction and Destroy, including cancellation cleanup.
+func (pd *PipecatDetector) PredictContext(ctx context.Context, audio []float32) (float64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	if pd == nil {
 		return 0, errPipecatDetectorNil
 	}
@@ -129,13 +139,47 @@ func (pd *PipecatDetector) Predict(audio []float32) (float64, error) {
 	// Extract mel spectrogram features [80 * 800]
 	features := pd.features.extractInto(audio, pd.scratch.output[:], pd.scratch)
 
-	// Run ONNX inference
-	prob, err := pd.infer(features)
-	if err != nil {
+	return pd.inferContext(ctx, features)
+}
+
+// infer retains the feature-only entry point used by parity tests and benchmarks.
+func (pd *PipecatDetector) infer(features []float32) (float64, error) {
+	return pd.inferContext(context.Background(), features)
+}
+
+func (pd *PipecatDetector) inferContext(ctx context.Context, features []float32) (prob float64, err error) {
+	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
 
-	return prob, nil
+	var runOptions *C.OrtRunOptions
+	status := C.PctOrtApiCreateRunOptions(pd.api, &runOptions)
+	defer C.PctOrtApiReleaseStatus(pd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("%w: %s", errPipecatDetectorCreateRunOptions, C.GoString(C.PctOrtApiGetErrorMessage(pd.api, status)))
+	}
+	defer C.PctOrtApiReleaseRunOptions(pd.api, runOptions)
+
+	terminated := make(chan struct{})
+	stop := context.AfterFunc(ctx, func() {
+		defer close(terminated)
+		status := C.PctOrtApiRunOptionsSetTerminate(pd.api, runOptions)
+		C.PctOrtApiReleaseStatus(pd.api, status)
+	})
+	defer func() {
+		// Join a started callback before releasing the per-run options.
+		if !stop() {
+			<-terminated
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			prob, err = 0, ctxErr
+		}
+	}()
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	return pd.inferWithRunOptions(features, runOptions)
 }
 
 // Destroy releases all ONNX Runtime resources.

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector_cancellation_test.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector_cancellation_test.go
@@ -1,0 +1,103 @@
+//go:build integration && cgo
+
+// Copyright (c) 2023-2025 RapidaAI
+// Licensed under GPL-2.0 with Rapida Additional Terms.
+// See LICENSE.md or contact sales@rapida.ai for commercial usage.
+
+package internal_pipecat
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipecatDetectorCancellation(t *testing.T) {
+	// ONNX IR 8/opset 13: Loop carries 0.75 for max(0, max(input_features))*1e9 iterations.
+	// Silence or zero features finish immediately; a positive feature exercises native cancellation.
+	model, err := base64.StdEncoding.DecodeString(
+		"CAg69QMKMgoOaW5wdXRfZmVhdHVyZXMSBHBlYWsiCVJlZHVjZU1heCoPCghrZWVwZGltcxgAoAECChYKBHBlYWsSCHBvc2l0aXZlIgRSZWx1Ch0KCHBvc2l0aXZlCgVzY2FsZRIFY291bnQiA011bAofCgVjb3VudBIFdHJpcHMiBENhc3QqCQoCdG8YB6ABAgrjAQoFdHJpcHMKCWNvbmRpdGlvbgoHaW5pdGlhbBIGbG9naXRzIgRMb29wKrcBCgRib2R5MqsBCh0KB2NvbmRfaW4SCGNvbmRfb3V0IghJZGVudGl0eQofCgh2YWx1ZV9pbhIJdmFsdWVfb3V0IghJZGVudGl0eRIEYm9keVoLCgFpEgYKBAgHEgBaEQoHY29uZF9pbhIGCgQICRIAWhYKCHZhbHVlX2luEgoKCAgBEgQKAggBYhIKCGNvbmRfb3V0EgYKBAgJEgBiFwoJdmFsdWVfb3V0EgoKCAgBEgQKAggBoAEFEgxjYW5jZWxsYXRpb24qDxABIgQoa25OQgVzY2FsZSoQEAkqAQFCCWNvbmRpdGlvbioTCAEQASIEAABAP0IHaW5pdGlhbFolCg5pbnB1dF9mZWF0dXJlcxITChEIARINCgIIAQoCCFAKAwigBmIUCgZsb2dpdHMSCgoICAESBAoCCAFCBAoAEA0=")
+	require.NoError(t, err)
+	modelPath := filepath.Join(t.TempDir(), "loop.onnx")
+	require.NoError(t, os.WriteFile(modelPath, model, 0o600))
+	pd, err := NewPipecatDetector(PipecatDetectorConfig{ModelPath: modelPath})
+	require.NoError(t, err)
+	t.Cleanup(pd.Destroy)
+	audio := make([]float32, 16000)
+
+	t.Run("before_start", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		prob, err := pd.PredictContext(ctx, audio)
+		require.Zero(t, prob)
+		require.ErrorIs(t, err, context.Canceled)
+
+		ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		prob, err = pd.PredictContext(ctx, audio)
+		require.Zero(t, prob)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+		prob, err = pd.Predict(audio)
+		require.NoError(t, err)
+		require.Equal(t, 0.75, prob)
+	})
+
+	for _, deadline := range []bool{false, true} {
+		name := "during_run_cancel"
+		if deadline {
+			name = "during_run_deadline"
+		}
+		t.Run(name, func(t *testing.T) {
+			features := make([]float32, whisperNMels*whisperMaxFrames)
+			features[0] = 1
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wantErr := context.Canceled
+			if deadline {
+				ctx, cancel = context.WithTimeout(ctx, 25*time.Millisecond)
+				defer cancel()
+				wantErr = context.DeadlineExceeded
+			} else {
+				timer := time.AfterFunc(25*time.Millisecond, cancel)
+				defer timer.Stop()
+			}
+			started := time.Now()
+			prob, err := pd.inferContext(ctx, features)
+			require.Zero(t, prob)
+			require.ErrorIs(t, err, wantErr)
+			require.Less(t, time.Since(started), time.Second)
+
+			features[0] = 0
+			prob, err = pd.infer(features)
+			require.NoError(t, err)
+			require.Equal(t, 0.75, prob)
+			prob, err = pd.PredictContext(context.Background(), audio)
+			require.NoError(t, err)
+			require.Equal(t, 0.75, prob)
+		})
+	}
+
+	t.Run("prediction_error", func(t *testing.T) {
+		prob, err := pd.PredictContext(context.Background(), nil)
+		require.Zero(t, prob)
+		require.ErrorIs(t, err, errPipecatDetectorEmptyAudio)
+
+		prob, err = (*PipecatDetector)(nil).PredictContext(context.Background(), audio)
+		require.Zero(t, prob)
+		require.ErrorIs(t, err, errPipecatDetectorNil)
+
+		prob, err = pd.infer(make([]float32, 1))
+		require.Zero(t, prob)
+		require.ErrorIs(t, err, errPipecatDetectorCreateInputTensor)
+
+		prob, err = pd.Predict(audio)
+		require.NoError(t, err)
+		require.Equal(t, 0.75, prob)
+	})
+}

--- a/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector_nocgo.go
+++ b/api/assistant-api/internal/end_of_speech/internal/pipecat/turn_detector_nocgo.go
@@ -9,6 +9,7 @@
 package internal_pipecat
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,7 +25,14 @@ func NewPipecatDetector(PipecatDetectorConfig) (*PipecatDetector, error) {
 	return nil, errPipecatDetectorRuntimeAPIUnavailable
 }
 
-func (pd *PipecatDetector) Predict([]float32) (float64, error) {
+func (pd *PipecatDetector) Predict(audio []float32) (float64, error) {
+	return pd.PredictContext(context.Background(), audio)
+}
+
+func (pd *PipecatDetector) PredictContext(ctx context.Context, _ []float32) (float64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	return 0, errPipecatDetectorRuntimeAPIUnavailable
 }
 


### PR DESCRIPTION
## Summary

- Recover stopped Pipecat turns with a separate five-second inactivity watchdog, reset by nonblank interim and final transcripts.
- Keep model/audio completion on the existing transcript safety deadline, without waiting for the watchdog.
- Bound and cancel native ONNX inference independently of subsequent transcription activity; discard stale results after turn changes.
- Cover delayed finals, interim-only input, blank updates, blocked inference, resumed speech, shutdown, and duplicate completion.

## Branch And Scope

- Base: `chore/sip-input-audio-improvement` at `c20ad28f`.
- Cherry-picks `4b819b5f` from the already-merged EOS branch into a fresh follow-up branch.
- Preserves the SIP branch's newer Pipecat defaults: threshold `0.85`, extended timeout `4000ms`, fallback timeout `1000ms`.
- Only the Pipecat EOS provider and its tests change. No dispatch, packet, public-option, UI, or migration changes.

## Verification

- Full scoped `just agent-finalize` passed on the new SIP base with `GOFLAGS='-race -tags=integration'`, the native model configured, and the Pipecat reference fixture supplied: `40.522s`.
- The finalizer ran `go test ./api/assistant-api/internal/end_of_speech/internal/pipecat` with those flags.
- Activity regressions passed three race-enabled repetitions before cherry-picking.
- Commit checks passed, including formatting, security scanning, dependency checks, and commit-message validation.
- Independent review of the implementation and cherry-pick adaptation completed with no remaining findings.

## Risks And Rollback

- Continuing transcript activity postpones watchdog recovery intentionally; interim-only input is not promoted to committed speech.
- Existing packet contracts do not expose Pipecat's explicit transcript-finalization acknowledgment or STT P99 metadata, so this is not a claim of complete upstream parity.
- Live-call E2E and Linux-native execution have not been tested.
- Rollback: revert this fix commit. No schema or data migration is involved.
